### PR TITLE
bugfix test case 4005

### DIFF
--- a/host/xtest/xtest_4000.c
+++ b/host/xtest/xtest_4000.c
@@ -541,7 +541,7 @@ static TEEC_Result ta_crypt_cmd_ae_init(ADBG_Case_t *c, TEEC_Session *s,
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT,
 					 TEEC_MEMREF_TEMP_INPUT,
-					 TEEC_VALUE_OUTPUT, TEEC_NONE);
+					 TEEC_VALUE_INPUT, TEEC_NONE);
 
 	res = TEEC_InvokeCommand(s, TA_CRYPT_CMD_AE_INIT, &op, &ret_orig);
 

--- a/ta/crypt/cryp_taf.c
+++ b/ta/crypt/cryp_taf.c
@@ -551,7 +551,7 @@ TEE_Result ta_entry_ae_init(uint32_t param_type, TEE_Param params[4])
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,
 			   TEE_PARAM_TYPE_MEMREF_INPUT,
-			   TEE_PARAM_TYPE_VALUE_OUTPUT, TEE_PARAM_TYPE_NONE));
+			   TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE));
 	return TEE_AEInit((TEE_OperationHandle) params[0].value.a,
 			  params[1].memref.buffer, params[1].memref.size,
 			  params[0].value.b * 8, /* tag_len in bits */


### PR DESCRIPTION
ta_crypt_cmd_ae_init() passed some value parameters as output instead of
input.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)