### PR TITLE
xtest_4000 fix build errors

### DIFF
--- a/host/xtest/xtest_4000.c
+++ b/host/xtest/xtest_4000.c
@@ -4260,7 +4260,7 @@ static void xtest_tee_test_4009(ADBG_Case_t *c)
 	uint8_t out[2048];
 	size_t out_size;
 	uint32_t size_bytes;
-	int i;
+	uint32_t i;
 	struct derive_key_ecdh_t *pt;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,


### PR DESCRIPTION
Log:
xtest_4000.c: In function ‘xtest_tee_test_4009’:
xtest_4000.c:4271:16: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
for (i = 0; i < ARRAY_SIZE(derive_key_ecdh); i++) {
              ^
cc1: all warnings being treated as errors

Signed-off-by: Peng <van.freenix@gmail.com>