### PR TITLE
API change for mpa_get_str()

### DIFF
--- a/ta/os_test/include/tb_asserts.h
+++ b/ta/os_test/include/tb_asserts.h
@@ -97,11 +97,11 @@ do {                                                            \
 /*
  * TB_ASSERT_HEX_VALUE checks that a prints to the string v in hex.
  */
-#define TB_ASSERT_HEX_PRINT_VALUE(a, v, grpsize)       \
+#define TB_ASSERT_HEX_PRINT_VALUE(a, v)                \
 do {                                                   \
 	char *_str_;                                   \
 	_str_ = TEE_BigIntConvertToString(NULL,        \
-		TEE_STRING_MODE_HEX_UC, grpsize, (a)); \
+		TEE_STRING_MODE_HEX_UC, (a));          \
 	TB_ASSERT_STR_EQ(_str_, (v));                  \
 	TEE_Free(_str_);                               \
 } while (0)

--- a/ta/os_test/include/testframework.h
+++ b/ta/os_test/include/testframework.h
@@ -65,7 +65,6 @@ void tb_prime(void);
 extern mpa_scratch_mem mempool;
 
 int TEE_BigIntConvertFromString(TEE_BigInt *dest, const char *src);
-char *TEE_BigIntConvertToString(char *dest, int mode, int groupsize,
-				const TEE_BigInt *src);
+char *TEE_BigIntConvertToString(char *dest, int mode, const TEE_BigInt *src);
 
 #endif /* include guard */

--- a/ta/os_test/tb_addsub.c
+++ b/ta/os_test/tb_addsub.c
@@ -32,19 +32,19 @@ do {                                          \
 	TEE_BigIntConvertFromString(a, (s));  \
 	TEE_BigIntConvertFromString(b, (t));  \
 	TEE_BigIntAdd(c, a, b);               \
-	TB_ASSERT_HEX_PRINT_VALUE(c, (r), 0); \
+	TB_ASSERT_HEX_PRINT_VALUE(c, (r));    \
 	TEE_BigIntAdd(a, a, b);               \
-	TB_ASSERT_HEX_PRINT_VALUE(a, (r), 0); \
+	TB_ASSERT_HEX_PRINT_VALUE(a, (r));    \
 	TEE_BigIntSub(a, a, b);               \
 	TEE_BigIntAdd(b, a, b);               \
-	TB_ASSERT_HEX_PRINT_VALUE(b, (r), 0); \
+	TB_ASSERT_HEX_PRINT_VALUE(b, (r));    \
 } while (0)
 
 #define ADDWORD(s, t, r)                                \
 do {                                                    \
 	TEE_BigIntConvertFromString(a, (s));            \
 	mpa_add_word((mpanum)b, (mpanum)a, t, mempool); \
-	TB_ASSERT_HEX_PRINT_VALUE(b, (r), 0);           \
+	TB_ASSERT_HEX_PRINT_VALUE(b, (r));              \
 } while (0)
 
 #define SUB(r, t, s)                          \
@@ -52,29 +52,29 @@ do {                                          \
 	TEE_BigIntConvertFromString(a, (s));  \
 	TEE_BigIntConvertFromString(b, (t));  \
 	TEE_BigIntSub(c, a, b);               \
-	TB_ASSERT_HEX_PRINT_VALUE(c, (r), 0); \
+	TB_ASSERT_HEX_PRINT_VALUE(c, (r));    \
 	TEE_BigIntSub(a, a, b);               \
-	TB_ASSERT_HEX_PRINT_VALUE(a, (r), 0); \
+	TB_ASSERT_HEX_PRINT_VALUE(a, (r));    \
 	TEE_BigIntAdd(a, a, b);               \
 	TEE_BigIntSub(b, a, b);               \
-	TB_ASSERT_HEX_PRINT_VALUE(b, (r), 0); \
+	TB_ASSERT_HEX_PRINT_VALUE(b, (r));    \
 } while (0)
 
 #define SUBWORD(r, t, s)                                \
 do {                                                    \
 	TEE_BigIntConvertFromString(a, (s));            \
 	mpa_sub_word((mpanum)b, (mpanum)a, t, mempool); \
-	TB_ASSERT_HEX_PRINT_VALUE(b, (r), 0);           \
+	TB_ASSERT_HEX_PRINT_VALUE(b, (r));              \
 } while (0)
 
 #define NEG(s, r)                              \
 do {                                           \
 	TEE_BigIntConvertFromString(a, (s));   \
 	TEE_BigIntNeg(b, a);                   \
-	TB_ASSERT_HEX_PRINT_VALUE(b, (r), 0);  \
+	TB_ASSERT_HEX_PRINT_VALUE(b, (r));     \
 	TEE_BigIntConvertFromString(c, (r));   \
 	TEE_BigIntNeg(c, c);                   \
-	TB_ASSERT_HEX_PRINT_VALUE(c, (s), 0);  \
+	TB_ASSERT_HEX_PRINT_VALUE(c, (s));     \
 } while (0)
 
 void tb_addsub(void)

--- a/ta/os_test/tb_div.c
+++ b/ta/os_test/tb_div.c
@@ -32,7 +32,7 @@ do {                                                 \
 	TEE_BigIntConvertFromString(n, (s));         \
 	TEE_BigIntConvertFromString(d, (t));         \
 	TEE_BigIntDiv(q, r, n, d);                   \
-	TB_ASSERT_HEX_PRINT_VALUE(q, (out), 0);      \
+	TB_ASSERT_HEX_PRINT_VALUE(q, (out));         \
 	if (TEE_BigIntCmpS32(d, 0) > 0)              \
 			TB_ASSERT_BIGINT_LESS(r, d); \
 } while (0)

--- a/ta/os_test/tb_fmm.c
+++ b/ta/os_test/tb_fmm.c
@@ -35,7 +35,7 @@ do {                                                                \
 	TEE_BigIntInitFMMContext(context, nLen, n);                 \
 	TEE_BigIntConvertFromString(x, xstr);                       \
 	TEE_BigIntConvertFromString(e, estr);                       \
-	TB_ASSERT_HEX_PRINT_VALUE(dest, resstr, 0);                 \
+	TB_ASSERT_HEX_PRINT_VALUE(dest, resstr);                    \
 	TEE_Free(context);                                          \
 } while (0)
 

--- a/ta/os_test/tb_modulus.c
+++ b/ta/os_test/tb_modulus.c
@@ -31,7 +31,7 @@ do {                                             \
 	TEE_BigIntConvertFromString(op, opstr);  \
 	TEE_BigIntConvertFromString(n, nstr);    \
 	TEE_BigIntMod(r, op, n);                 \
-	TB_ASSERT_HEX_PRINT_VALUE(r, resstr, 0); \
+	TB_ASSERT_HEX_PRINT_VALUE(r, resstr);    \
 } while (0)
 
 static void test_modular_reduction(void)
@@ -197,7 +197,7 @@ static void test_modular_reduction(void)
 		TEE_BigIntConvertFromString(op2, op2str); \
 		TEE_BigIntConvertFromString(n, nstr);     \
 		TEE_BigIntAddMod(r, op1, op2, n);         \
-		TB_ASSERT_HEX_PRINT_VALUE(r, result, 0);  \
+		TB_ASSERT_HEX_PRINT_VALUE(r, result);     \
 		 TEE_BigIntSubMod(tmp1, r, op2, n);       \
 		TB_ASSERT_BIGINT_EQ(tmp1, op1);           \
 	} while (0)
@@ -318,7 +318,7 @@ do {                                              \
 	TEE_BigIntConvertFromString(op2, op2str); \
 	TEE_BigIntConvertFromString(n, nstr);     \
 	TEE_BigIntMulMod(r, op1, op2, n);         \
-	TB_ASSERT_HEX_PRINT_VALUE(r, result, 0);  \
+	TB_ASSERT_HEX_PRINT_VALUE(r, result);     \
 } while (0)
 
 static void test_modular_mul(void)
@@ -399,11 +399,11 @@ do {                                                \
 	TEE_BigIntConvertFromString(op1, op1str);   \
 	TEE_BigIntConvertFromString(n, nstr);       \
 	TEE_BigIntInvMod(r, op1, n);                \
-	TB_ASSERT_HEX_PRINT_VALUE(r, result, 0);    \
+	TB_ASSERT_HEX_PRINT_VALUE(r, result);       \
 	TEE_BigIntMulMod(tmp1, r, op1, n);          \
-	TB_ASSERT_HEX_PRINT_VALUE(tmp1, "1", 0);    \
+	TB_ASSERT_HEX_PRINT_VALUE(tmp1, "1");       \
 	TEE_BigIntInvMod(tmp1, r, n);               \
-	TB_ASSERT_HEX_PRINT_VALUE(tmp1, op1str, 0); \
+	TB_ASSERT_HEX_PRINT_VALUE(tmp1, op1str);    \
 } while (0)
 
 static void test_modular_inv(void)

--- a/ta/os_test/tb_mul.c
+++ b/ta/os_test/tb_mul.c
@@ -32,18 +32,18 @@ do {                                          \
 	TEE_BigIntConvertFromString(a, (s));  \
 	TEE_BigIntConvertFromString(b, (t));  \
 	TEE_BigIntMul(c, a, b);               \
-	TB_ASSERT_HEX_PRINT_VALUE(c, (r), 0); \
+	TB_ASSERT_HEX_PRINT_VALUE(c, (r));    \
 	TEE_BigIntMul(a, a, b);               \
-	TB_ASSERT_HEX_PRINT_VALUE(a, (r), 0); \
+	TB_ASSERT_HEX_PRINT_VALUE(a, (r));    \
 } while (0)
 
 #define MULWORD(s, t, r)                                \
 do {                                                    \
 	TEE_BigIntConvertFromString(a, (s));            \
 	mpa_mul_word((mpanum)b, (mpanum)a, t, mempool); \
-	TB_ASSERT_HEX_PRINT_VALUE(b, (r), 0);           \
+	TB_ASSERT_HEX_PRINT_VALUE(b, (r));              \
 	mpa_mul_word((mpanum)a, (mpanum)a, t, mempool); \
-	TB_ASSERT_HEX_PRINT_VALUE(a, (r), 0);           \
+	TB_ASSERT_HEX_PRINT_VALUE(a, (r));              \
 } while (0)
 
 void tb_mul(void)

--- a/ta/os_test/tb_shift.c
+++ b/ta/os_test/tb_shift.c
@@ -32,7 +32,7 @@
 {                                                       \
 	{                                               \
 		TEE_BigIntConvertFromString(a, (in));   \
-		TB_ASSERT_HEX_PRINT_VALUE(b, (out), 0); \
+		TB_ASSERT_HEX_PRINT_VALUE(b, (out));    \
 	} while (0);                                    \
 }
 
@@ -132,7 +132,7 @@ static void tb_shift_left(void)
 	{                                               \
 		TEE_BigIntConvertFromString(a, (in));   \
 		TEE_BigIntShiftRight(b, a, (s));        \
-		TB_ASSERT_HEX_PRINT_VALUE(b, (out), 0); \
+		TB_ASSERT_HEX_PRINT_VALUE(b, (out));    \
 	} while (0);                                    \
 }
 

--- a/ta/os_test/testframework.c
+++ b/ta/os_test/testframework.c
@@ -55,16 +55,14 @@ int TEE_BigIntConvertFromString(TEE_BigInt *dest, const char *src)
  *
  * Prints a zero-terminated string representation of src into dest. The need
  * length of dest is the space needed to print src plus additional chars for the
- * minus sign and the terminating '\0' char. If grouping is used (!= 0), we pad
- * the number string with zeros to the left, up to the current group size.  A
- * pointer to str is returned. If something went wrong, we return 0.
+ * minus sign and the terminating '\0' char.  A pointer to str is returned.
+ * If something went wrong, we return 0.
  *
  * mode is one of the following:
  *     TEE_MATHAPI_PRINT_MODE_HEX_LC   : output in lower case hex
  *     TEE_MATHAPI_PRINT_MODE_DEC      : output in decimal
  */
-char *TEE_BigIntConvertToString(char *dest, int mode, int groupsize,
-				const TEE_BigInt *src)
+char *TEE_BigIntConvertToString(char *dest, int mode, const TEE_BigInt *src)
 {
 	mpanum mpa_src = (mpa_num_base *) src;
 
@@ -73,7 +71,7 @@ char *TEE_BigIntConvertToString(char *dest, int mode, int groupsize,
 		if (dest == 0)
 			return 0;
 	}
-	return mpa_get_str(dest, mode, groupsize, mpa_src);
+	return mpa_get_str(dest, mode, mpa_src);
 }
 
 static uint8_t myrand(void)


### PR DESCRIPTION
Dropping the groupsize parameter for mpa_get_str().

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)

need to be merged in sync with https://github.com/OP-TEE/optee_os/pull/409