### PR TITLE
ta os_test: increase size beyond 1 MB

### DIFF
--- a/ta/os_test/include/user_ta_header_defines.h
+++ b/ta/os_test/include/user_ta_header_defines.h
@@ -38,7 +38,7 @@
 		  TA_FLAG_UNSAFE_NW_PARAMS | \
 		  TA_FLAG_MULTI_SESSION)
 #define TA_STACK_SIZE (2 * 1024)
-#define TA_DATA_SIZE (32 * 1024)
+#define TA_DATA_SIZE (900 * 1024)
 
 #define TA_CURRENT_TA_EXT_PROPERTIES \
 	{ "myprop.true", USER_TA_PROP_TYPE_BOOL, &(const bool){ true } }, \


### PR DESCRIPTION
Increase size of os_test TA beyond 1 MB of code and data.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Tests that the fix for a large va space for TAs still works.