### PR TITLE
Flush standard output each time a message is displayed

### DIFF
--- a/host/xtest/adbg/src/adbg_log.c
+++ b/host/xtest/adbg/src/adbg_log.c
@@ -50,6 +50,7 @@ void Do_ADBG_Log(const char *const Format, ...)
 	vsnprintf(buf, sizeof(buf), Format, ap);
 	va_end(ap);
 	printf("%s\n", buf);
+	fflush(stdout);
 }
 
 void Do_ADBG_LogHeading(unsigned Level, const char *const Format, ...)


### PR DESCRIPTION
This makes debugging easier by keeping messages in sync with the ones
logged by OP-TEE (assuming OP-TEE also flushes its output
synchronously).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>