### PR TITLE
GP tests: don't patch xtest_7000.c, create xtest_7000_gp.c instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ GTAGS
 out/*
 ta/GP_*
 host/xtest/global_platform/
+host/xtest/xtest_7000_gp.c
 host/xtest/xtest_7500.c
 host/xtest/xtest_8000.c
 host/xtest/xtest_8500.c

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ patch-generate-host: patch-package
 	$(q)find ${CFG_GP_XSL_PACKAGE_PATH}/packages -type f -name "*.xsl" -exec cp -p {} ${GP_XTEST_IN_DIR} \;
 	$(call patch-xalan,TEE.xml,adbg_case_declare.xsl,adbg_case_declare.h)
 	$(call patch-xalan,TEE.xml,adbg_entry_declare.xsl,adbg_entry_declare.h)
-	$(call patch-xalan,TEE.xml,TEE.xsl,xtest_7000.c)
+	$(call patch-xalan,TEE.xml,TEE.xsl,xtest_7000_gp.c)
 	$(call patch-xalan,TEE_DataStorage_API.xml,TEE_DataStorage_API.xsl,xtest_7500.c)
 	$(call patch-xalan,TEE_Internal_API.xml,TEE_Internal_API.xsl,xtest_8000.c)
 	$(call patch-xalan,TEE_TimeArithm_API.xml,TEE_TimeArithm_API.xsl,xtest_8500.c)

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -19,11 +19,15 @@ OBJCOPY		:= $(CROSS_COMPILE)objcopy
 OBJDUMP		:= $(CROSS_COMPILE)objdump
 READELF		:= $(CROSS_COMPILE)readelf
 
+ifdef CFG_GP_PACKAGE_PATH
+GP := _gp
+endif
+
 srcs := xtest_1000.c \
 	xtest_4000.c \
 	xtest_5000.c \
 	xtest_6000.c \
-	xtest_7000.c \
+	xtest_7000$(GP).c \
 	xtest_10000.c \
 	xtest_helpers.c \
 	xtest_main.c \


### PR DESCRIPTION
xtest_7000.c contains a subset of the GP tests in TEE.xml (the 29-*
series). When GP tests are enabled, instead of patching xtest_7000.c
we can just generate a new file called xtest_7000_gp.c with all the
tests from TEE.xml. This avoids modifying a source file that is managed
by Git.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>