### PR TITLE
Check if TEEC_OPERATION_INITIALIZER has been defined

### DIFF
--- a/host/xtest/xtest_helpers.h
+++ b/host/xtest/xtest_helpers.h
@@ -39,7 +39,7 @@ TEEC_Result xtest_teec_open_static_session(TEEC_Session *session,
 					   TEEC_Operation *op,
 					   uint32_t *ret_orig);
 
-#define TEEC_OPERATION_INITIALIZER { 0, 0, { { { 0 } } } }
+#define TEEC_OPERATION_INITIALIZER { 0 }
 
 /* IO access macro */
 #define  IO(addr)  (*((volatile unsigned long *)(addr)))


### PR DESCRIPTION
If the struct TEEC_TempMemoryReference in TEE client API is changed
with union members added, the macro TEEC_OPERATION_INITIALIZER
need be changed also for union member initialization.
The alternative macro is defined in the TEE client API header file.

Signed-off-by: Aijun Sun <aijun.sun@linaro.org>
Tested-by: Aijun Sun <aijun.sun@linaro.org> (FVP and Qemu)