### PR TITLE
Android support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ host/xtest/xtest_9000.c
 host/xtest/adbg_case_declare.h
 host/xtest/adbg_entry_declare.h
 package/testsuite/global_platform/api_1.0/TEE*
+/libs
+/obj

--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,62 @@
+LOCAL_PATH := $(call my-dir)
+
+VERSION = $(shell git describe --always --dirty=-dev 2>/dev/null || echo Unknown)
+OPTEE_CLIENT_PATH ?= $(LOCAL_PATH)/../optee_client
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := teec
+LOCAL_SRC_FILES := $(OPTEE_CLIENT_PATH)/libs/$(TARGET_ARCH_ABI)/libteec.so
+LOCAL_EXPORT_C_INCLUDES := $(OPTEE_CLIENT_PATH)/public
+include $(PREBUILT_SHARED_LIBRARY)
+
+-include $(TA_DEV_KIT_DIR)/host_include/conf.mk
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := xtest
+LOCAL_SHARED_LIBRARIES := teec
+
+srcs := xtest_1000.c \
+	xtest_4000.c \
+	xtest_5000.c \
+	xtest_6000.c \
+	xtest_7000.c \
+	xtest_10000.c \
+	xtest_20000.c \
+	xtest_helpers.c \
+	xtest_main.c \
+	xtest_test.c \
+	adbg/src/adbg_case.c \
+	adbg/src/adbg_enum.c \
+	adbg/src/adbg_expect.c \
+	adbg/src/adbg_log.c \
+	adbg/src/adbg_mts.c \
+	adbg/src/adbg_run.c \
+	adbg/src/adbg_util.c \
+	adbg/src/r_list_genutil.c \
+	adbg/src/security_utils_hex.c \
+	adbg/src/security_utils_mem.c
+
+LOCAL_SRC_FILES := $(patsubst %,host/xtest/%,$(srcs))
+
+LOCAL_C_INCLUDES += host/xtest
+LOCAL_C_INCLUDES += host/xtest/adbg/include
+LOCAL_C_INCLUDES += host/xtest/xml/include
+LOCAL_C_INCLUDES += $(TA_DEV_KIT_DIR)/host_include
+
+LOCAL_C_INCLUDES += ta/create_fail_test/include
+LOCAL_C_INCLUDES += ta/crypt/include
+LOCAL_C_INCLUDES += ta/enc_fs/include
+LOCAL_C_INCLUDES += ta/os_test/include
+LOCAL_C_INCLUDES += ta/rpc_test/include
+LOCAL_C_INCLUDES += ta/sims/include
+LOCAL_C_INCLUDES += ta/storage/include
+
+ifeq ($(CFG_ENC_FS),y)
+LOCAL_CFLAGS += -DCFG_ENC_FS
+endif
+
+LOCAL_CFLAGS += -DUSER_SPACE
+LOCAL_CFLAGS += -DTA_DIR=\"/system/lib/optee_armtz\"
+LOCAL_CFLAGS += -pthread
+
+include $(BUILD_EXECUTABLE)

--- a/host/xtest/xtest_1000.c
+++ b/host/xtest/xtest_1000.c
@@ -523,10 +523,14 @@ static void xtest_tee_test_1007(ADBG_Case_t *c)
 	TEEC_CloseSession(&session);
 }
 
+#ifndef TA_DIR
+#define TA_DIR "/lib/optee_armtz"
+#endif
+
 static void uuid_to_full_name(char *buf, size_t blen, const TEEC_UUID *uuid,
 			const char *extra_suffix)
 {
-	static const char ta_dir[] = "/lib/optee_armtz";
+	static const char ta_dir[] = TA_DIR;
 
 	snprintf(buf, blen,
 		"%s/%08x-%04x-%04x-%02x%02x%02x%02x%02x%02x%02x%02x.ta%s",


### PR DESCRIPTION
- Add Android.mk which can be used to build the client side (xtest
  binary) using the Android NDK.
- xtest_1000.c: make the path to TA files configurable via a macro

Note: the additional GlobalPlatform tests (see CFG_GP_PACKAGE_PATH in
the regular Linux Makefile) are not supported.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>