### PR TITLE
Make cross compile variables configurable via the environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ endif
 .PHONY: xtest
 xtest:
 	$(q)$(MAKE) -C host/xtest CROSS_COMPILE="$(CROSS_COMPILE_HOST)" \
+			     --no-builtin-variables \
 			     q=$(q) \
 			     O=$(out-dir)/xtest \
 			     $@

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -12,14 +12,14 @@ include $(TA_DEV_KIT_DIR)/host_include/conf.mk
 # be used instead.
 OPTEE_CLIENT_EXPORT ?= ../../../optee_client/out/export
 
-CC		:= $(CROSS_COMPILE)gcc
-CPP		:= $(CROSS_COMPILE)cpp
-LD		:= $(CROSS_COMPILE)ld
-AR		:= $(CROSS_COMPILE)ar
-NM		:= $(CROSS_COMPILE)nm
-OBJCOPY		:= $(CROSS_COMPILE)objcopy
-OBJDUMP		:= $(CROSS_COMPILE)objdump
-READELF		:= $(CROSS_COMPILE)readelf
+CC		?= $(CROSS_COMPILE)gcc
+CPP		?= $(CROSS_COMPILE)cpp
+LD		?= $(CROSS_COMPILE)ld
+AR		?= $(CROSS_COMPILE)ar
+NM		?= $(CROSS_COMPILE)nm
+OBJCOPY		?= $(CROSS_COMPILE)objcopy
+OBJDUMP		?= $(CROSS_COMPILE)objdump
+READELF		?= $(CROSS_COMPILE)readelf
 
 ifdef CFG_GP_PACKAGE_PATH
 GP := _gp

--- a/ta/Makefile
+++ b/ta/Makefile
@@ -5,6 +5,10 @@ ifeq ($O,)
 $(error output path should be specified when calling this makefile)
 endif
 
+# Prevent use of LDFLAGS from the environment. For example, yocto exports
+# LDFLAGS that are suitable for the client applications, not for TAs
+LDFLAGS=
+
 TA_DIRS := create_fail_test \
 	   crypt \
 	   os_test \


### PR DESCRIPTION
Required to override cross compile variables with cross compile
variables set by yocto environment.
Also LDFLAGS should be empty to properly compile trusted application
with yocto.

Signed-off-by: Sumit Garg <b49020@freescale.com>