### PR TITLE
xtest 1008: fix out of memory problem

### DIFF
--- a/host/xtest/xtest_1000.c
+++ b/host/xtest/xtest_1000.c
@@ -689,11 +689,6 @@ static void xtest_tee_test_1008(ADBG_Case_t *c)
 	Do_ADBG_BeginSubCase(c, "Invoke command");
 	{
 		(void)ADBG_EXPECT_TEEC_SUCCESS(c,
-			xtest_teec_open_session(&session_crypt,
-						&crypt_user_ta_uuid, NULL,
-						&ret_orig));
-
-		(void)ADBG_EXPECT_TEEC_SUCCESS(c,
 			xtest_teec_open_session(&session, &os_test_ta_uuid,
 						NULL, &ret_orig));
 
@@ -702,7 +697,6 @@ static void xtest_tee_test_1008(ADBG_Case_t *c)
 					   NULL, &ret_orig));
 
 		TEEC_CloseSession(&session);
-		TEEC_CloseSession(&session_crypt);
 	}
 	Do_ADBG_EndSubCase(c, "Invoke command");
 


### PR DESCRIPTION
Fixes out of secure memory problem with running this test case with LPAE.

The out of memory problem was introduced by
38a66f9 Make crypt ta multi-instance

Previously the crypt ta was signle-instance, multi-session allowing
several open sessions share the same context (and saving some memory).
When the crypt ta is instead multi-instance test case 1008 indirectly
loads two instances of crypt TA which is too here.

This patch skips the first session to crypt TA which was opened first in
the test case due to legacy reasons.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (Juno)