### PR TITLE
concurrent_ta: set type for assembly functions

### DIFF
--- a/ta/concurrent/atomic_a32.S
+++ b/ta/concurrent/atomic_a32.S
@@ -28,6 +28,7 @@
 /* uint32_t atomic_inc(uint32_t *v); */
 .global atomic_inc
 .func atomic_inc
+.type atomic_inc %function
 atomic_inc:
 	ldrex	r1, [r0]
 	add	r1, r1, #1
@@ -41,6 +42,7 @@ atomic_inc:
 /* uint32_t atomic_dec(uint32_t *v); */
 .global atomic_dec
 .func atomic_dec
+.type atomic_dec %function
 atomic_dec:
 	ldrex	r1, [r0]
 	sub	r1, r1, #1

--- a/ta/concurrent/atomic_a64.S
+++ b/ta/concurrent/atomic_a64.S
@@ -28,6 +28,7 @@
 /* uint32_t atomic_inc(uint32_t *v); */
 .global atomic_inc
 .func atomic_inc
+.type atomic_inc %function
 atomic_inc:
 	ldaxr	w1, [x0]
 	add	w1, w1, #1
@@ -41,6 +42,7 @@ atomic_inc:
 /* uint32_t atomic_dec(uint32_t *v); */
 .global atomic_dec
 .func atomic_dec
+.type atomic_dec %function
 atomic_dec:
 	ldaxr	w1, [x0]
 	sub	w1, w1, #1


### PR DESCRIPTION
Sets type for assembly functions.

Tested-by: Jens Wiklander <jens.wiklander@linaro.org> (QEMU)
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>