### PR TITLE
xtest client: compilation mode (32bits / 64bits) fix

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -93,8 +93,14 @@ CFLAGS += -I../../ta/GP_TTA_testingClientAPI
 # need more include: openssl
 CFLAGS += -Ifor_gp/include
 
-# need more libraries: openssl
+# by default, the client application is compiled as the kernel of optee-os
 ifeq ($(CFG_ARM32),y)
+COMPILE_NS_USER ?= 32
+else
+COMPILE_NS_USER ?= 64
+endif
+
+ifeq ($(COMPILE_NS_USER),32)
 LDFLAGS += ../lib/armv7/libcrypto.a
 else
 LDFLAGS += ../lib/armv8/libcrypto.a


### PR DESCRIPTION
Compilation of xtest requires linking to the precompiled library
libcrypto.a. Hence it needs to know in which mode (32bits / 64bits) xtest
is compiled.

Before this patch, it was believed that the compilation mode of the client
part is the same as the optee_os core part. This is not true and fixed
using optional environment variable COMPILE_NS_USER, which is defined
by default the same as the optee_os core compilation mode

Signed-off-by: Pascal Brand <pascal.brand@st.com>