### PR TITLE
.gitignore: add name of GlobalPlatform test suite package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ host/xtest/adbg_entry_declare.h
 package/testsuite/global_platform/api_1.0/TEE*
 /libs
 /obj
+/TEE_Initial_Configuration-Test_Suite*


### PR DESCRIPTION
Tells Git to ignore any file or folder named like the GlobalPlatform
test suite package (TEE_Initial_Configuration-Test_Suite*), so that Git
won't complain about modified content when the test suite is extracted
in the main directory.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>