### PR TITLE
Create an explicit LICENSE file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,5 @@
+The client applications (`optee_test/host/*`) are provided under the
+[GPL-2.0](http://opensource.org/licenses/GPL-2.0) license.
+
+The user TAs (`optee_test/ta/*`) are provided under the
+[BSD 2-Clause](http://opensource.org/licenses/BSD-2-Clause) license.


### PR DESCRIPTION
Various projects (including OpenEmbedded and Github) expect an
explicit license file.  Extract the license information from the
README.md into a separate file.

Signed-off-by: David Brown <david.brown@linaro.org>