### PR TITLE
xtest 6009: TEE_GetNextPersistentObject with objectInfo==NULL

### DIFF
--- a/host/xtest/xtest_6000.c
+++ b/host/xtest/xtest_6000.c
@@ -299,9 +299,10 @@ static TEEC_Result fs_next_enum(TEEC_Session *sess, uint32_t e, void *obj_info,
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t org;
 
-	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT,
-					 TEEC_MEMREF_TEMP_OUTPUT,
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE,
 					 TEEC_MEMREF_TEMP_OUTPUT, TEEC_NONE);
+	if (obj_info && info_size)
+		op.paramTypes |= (TEEC_MEMREF_TEMP_OUTPUT << 4);
 
 	op.params[0].value.a = e;
 	op.params[1].tmpref.buffer = obj_info;
@@ -993,7 +994,7 @@ static void xtest_tee_test_6009(ADBG_Case_t *c)
 
 	/* get 01 */
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
-		fs_next_enum(&sess, e, info, sizeof(info), id, sizeof(id))))
+		fs_next_enum(&sess, e, NULL, 0, id, sizeof(id))))
 		goto exit;
 
 	/* get 02 */

--- a/ta/storage/storage.c
+++ b/ta/storage/storage.c
@@ -241,21 +241,32 @@ TEE_Result ta_storage_cmd_start_enum(uint32_t param_types, TEE_Param params[4])
 TEE_Result ta_storage_cmd_next_enum(uint32_t param_types, TEE_Param params[4])
 {
 	TEE_ObjectEnumHandle oe = VAL2HANDLE(params[0].value.a);
+	TEE_ObjectInfo *obj;
 
-	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
-			  (TEE_PARAM_TYPE_VALUE_INPUT,
-			   TEE_PARAM_TYPE_MEMREF_OUTPUT,
-			   TEE_PARAM_TYPE_MEMREF_OUTPUT, TEE_PARAM_TYPE_NONE));
+	if (TEE_PARAM_TYPE_GET(param_types, 0) != TEE_PARAM_TYPE_VALUE_INPUT)
+		return TEE_ERROR_BAD_PARAMETERS;
+	if (TEE_PARAM_TYPE_GET(param_types, 2) != TEE_PARAM_TYPE_MEMREF_OUTPUT)
+		return TEE_ERROR_BAD_PARAMETERS;
+	if (TEE_PARAM_TYPE_GET(param_types, 3) != TEE_PARAM_TYPE_NONE)
+		return TEE_ERROR_BAD_PARAMETERS;
 
-	if (params[1].memref.size < sizeof(TEE_ObjectInfo))
-		return TEE_ERROR_SHORT_BUFFER;
+	if (TEE_PARAM_TYPE_GET(param_types, 1) == TEE_PARAM_TYPE_NONE)
+		obj = NULL;
+	else if (TEE_PARAM_TYPE_GET(param_types, 1) ==
+		 TEE_PARAM_TYPE_MEMREF_OUTPUT) {
+		if (params[1].memref.size < sizeof(TEE_ObjectInfo)) {
+			params[1].memref.size = sizeof(TEE_ObjectInfo);
+			return TEE_ERROR_SHORT_BUFFER;
+		}
+		params[1].memref.size = sizeof(TEE_ObjectInfo);
+		obj = (TEE_ObjectInfo *)params[1].memref.buffer;
+	} else
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	if (params[2].memref.size < TEE_OBJECT_ID_MAX_LEN)
 		return TEE_ERROR_SHORT_BUFFER;
 
-	params[1].memref.size = sizeof(TEE_ObjectInfo);
-
-	return TEE_GetNextPersistentObject(oe,
-			(TEE_ObjectInfo *)params[1].memref.buffer,
-			params[2].memref.buffer, &params[2].memref.size);
+	return TEE_GetNextPersistentObject(oe, obj,
+					   params[2].memref.buffer,
+					   &params[2].memref.size);
 }


### PR DESCRIPTION
Signed-off-by: Pascal Brand <pascal.brand@st.com>

Depends on https://github.com/OP-TEE/optee_os/pull/759
