### PR TITLE
update to use common mk file for ta compiling and variant importing 

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,5 +1,11 @@
 LOCAL_PATH := $(call my-dir)
 
+## include variants like TA_DEV_KIT_DIR
+## and target of BUILD_OPTEE_OS
+INCLUDE_FOR_BUILD_TA := false
+include $(BUILD_OPTEE_MK)
+INCLUDE_FOR_BUILD_TA :=
+
 VERSION = $(shell git describe --always --dirty=-dev 2>/dev/null || echo Unknown)
 OPTEE_CLIENT_PATH ?= $(LOCAL_PATH)/../optee_client
 
@@ -58,6 +64,11 @@ endif
 LOCAL_CFLAGS += -DUSER_SPACE
 LOCAL_CFLAGS += -DTA_DIR=\"/system/lib/optee_armtz\"
 LOCAL_CFLAGS += -pthread
+
+## target BUILD_OPTEE_OS is defined in the common ta build
+## mk file included before, and this BUILD_OPTEE_OS will
+## help to generate the header files under $(TA_DEV_KIT_DIR)/host_include
+LOCAL_ADDITIONAL_DEPENDENCIES := BUILD_OPTEE_OS
 
 include $(BUILD_EXECUTABLE)
 

--- a/ta/concurrent/Android.mk
+++ b/ta/concurrent/Android.mk
@@ -1,7 +1,4 @@
-include $(CLEAR_VARS)
-LOCAL_MODULE :=  e13010e0-2ae1-11e5-896a0002a5d5c51b.ta
-LOCAL_SRC_FILES := concurrent/e13010e0-2ae1-11e5-896a0002a5d5c51b.ta
-LOCAL_MODULE_PATH := $(TARGET_OUT)/lib/optee_armtz
-LOCAL_MODULE_CLASS := EXECUTABLES
-LOCAL_MODULE_TAGS := optional
-include $(BUILD_PREBUILT)
+LOCAL_PATH := $(call my-dir)
+
+local_module :=  e13010e0-2ae1-11e5-896a0002a5d5c51b.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/concurrent_large/Android.mk
+++ b/ta/concurrent_large/Android.mk
@@ -1,7 +1,4 @@
-include $(CLEAR_VARS)
-LOCAL_MODULE :=  5ce0c432-0ab0-40e5-a056782ca0e6aba2.ta
-LOCAL_SRC_FILES := concurrent_large/5ce0c432-0ab0-40e5-a056782ca0e6aba2.ta
-LOCAL_MODULE_PATH := $(TARGET_OUT)/lib/optee_armtz
-LOCAL_MODULE_CLASS := EXECUTABLES
-LOCAL_MODULE_TAGS := optional
-include $(BUILD_PREBUILT)
+LOCAL_PATH := $(call my-dir)
+
+local_module :=  5ce0c432-0ab0-40e5-a056782ca0e6aba2.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/create_fail_test/Android.mk
+++ b/ta/create_fail_test/Android.mk
@@ -1,7 +1,4 @@
-include $(CLEAR_VARS)
-LOCAL_MODULE := c3f6e2c0-3548-11e1-b86c0800200c9a66.ta
-LOCAL_SRC_FILES := create_fail_test/c3f6e2c0-3548-11e1-b86c0800200c9a66.ta
-LOCAL_MODULE_PATH := $(TARGET_OUT)/lib/optee_armtz
-LOCAL_MODULE_CLASS := EXECUTABLES
-LOCAL_MODULE_TAGS := optional
-include $(BUILD_PREBUILT)
+LOCAL_PATH := $(call my-dir)
+
+local_module := c3f6e2c0-3548-11e1-b86c0800200c9a66.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/crypt/Android.mk
+++ b/ta/crypt/Android.mk
@@ -1,7 +1,4 @@
-include $(CLEAR_VARS)
-LOCAL_MODULE := cb3e5ba0-adf1-11e0-998b0002a5d5c51b.ta
-LOCAL_SRC_FILES := ./crypt/cb3e5ba0-adf1-11e0-998b0002a5d5c51b.ta
-LOCAL_MODULE_PATH := $(TARGET_OUT)/lib/optee_armtz
-LOCAL_MODULE_CLASS := EXECUTABLES
-LOCAL_MODULE_TAGS := optional
-include $(BUILD_PREBUILT)
+LOCAL_PATH := $(call my-dir)
+
+local_module := cb3e5ba0-adf1-11e0-998b0002a5d5c51b.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/os_test/Android.mk
+++ b/ta/os_test/Android.mk
@@ -1,7 +1,4 @@
-include $(CLEAR_VARS)
-LOCAL_MODULE := 5b9e0e40-2636-11e1-ad9e0002a5d5c51b.ta
-LOCAL_SRC_FILES := ./os_test/5b9e0e40-2636-11e1-ad9e0002a5d5c51b.ta
-LOCAL_MODULE_PATH := $(TARGET_OUT)/lib/optee_armtz
-LOCAL_MODULE_CLASS := EXECUTABLES
-LOCAL_MODULE_TAGS := optional
-include $(BUILD_PREBUILT)
+LOCAL_PATH := $(call my-dir)
+
+local_module := 5b9e0e40-2636-11e1-ad9e0002a5d5c51b.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/rpc_test/Android.mk
+++ b/ta/rpc_test/Android.mk
@@ -1,7 +1,4 @@
-include $(CLEAR_VARS)
-LOCAL_MODULE :=  d17f73a0-36ef-11e1-984a0002a5d5c51b.ta
-LOCAL_SRC_FILES := ./rpc_test/d17f73a0-36ef-11e1-984a0002a5d5c51b.ta
-LOCAL_MODULE_PATH := $(TARGET_OUT)/lib/optee_armtz
-LOCAL_MODULE_CLASS := EXECUTABLES
-LOCAL_MODULE_TAGS := optional
-include $(BUILD_PREBUILT)
+LOCAL_PATH := $(call my-dir)
+
+local_module :=  d17f73a0-36ef-11e1-984a0002a5d5c51b.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/sims/Android.mk
+++ b/ta/sims/Android.mk
@@ -1,7 +1,4 @@
-include $(CLEAR_VARS)
-LOCAL_MODULE := e6a33ed4-562b-463a-bb7eff5e15a493c8.ta
-LOCAL_SRC_FILES := ./sims/e6a33ed4-562b-463a-bb7eff5e15a493c8.ta
-LOCAL_MODULE_PATH := $(TARGET_OUT)/lib/optee_armtz
-LOCAL_MODULE_CLASS := EXECUTABLES
-LOCAL_MODULE_TAGS := optional
-include $(BUILD_PREBUILT)
+LOCAL_PATH := $(call my-dir)
+
+local_module := e6a33ed4-562b-463a-bb7eff5e15a493c8.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/storage/Android.mk
+++ b/ta/storage/Android.mk
@@ -1,7 +1,4 @@
-include $(CLEAR_VARS)
-LOCAL_MODULE := b689f2a7-8adf-477a-9f9932e90c0ad0a2.ta
-LOCAL_SRC_FILES :=  storage/b689f2a7-8adf-477a-9f9932e90c0ad0a2.ta
-LOCAL_MODULE_PATH := $(TARGET_OUT)/lib/optee_armtz
-LOCAL_MODULE_CLASS := EXECUTABLES
-LOCAL_MODULE_TAGS := optional
-include $(BUILD_PREBUILT)
+LOCAL_PATH := $(call my-dir)
+
+local_module := b689f2a7-8adf-477a-9f9932e90c0ad0a2.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/storage_benchmark/Android.mk
+++ b/ta/storage_benchmark/Android.mk
@@ -1,7 +1,4 @@
-include $(CLEAR_VARS)
-LOCAL_MODULE :=  f157cda0-550c-11e5-a6fa0002a5d5c51b.ta
-LOCAL_SRC_FILES := storage_benchmark/f157cda0-550c-11e5-a6fa0002a5d5c51b.ta
-LOCAL_MODULE_PATH := $(TARGET_OUT)/lib/optee_armtz
-LOCAL_MODULE_CLASS := EXECUTABLES
-LOCAL_MODULE_TAGS := optional
-include $(BUILD_PREBUILT)
+LOCAL_PATH := $(call my-dir)
+
+local_module := f157cda0-550c-11e5-a6fa0002a5d5c51b.ta
+include $(BUILD_OPTEE_MK)


### PR DESCRIPTION
import necessary variants and definition of BUILD_OPTEE_OS for xtest,
and update to include common mk file to generate TA files

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>