### PR TITLE
benchmark: initialize local var.

### DIFF
--- a/host/xtest/xtest_benchmark_1000.c
+++ b/host/xtest/xtest_benchmark_1000.c
@@ -85,7 +85,7 @@ static TEEC_Result run_chunk_access_test(enum storage_benchmark_cmd cmd,
 		uint32_t data_size, uint32_t chunk_size, struct test_record *rec)
 {
 	TEE_Result res;
-	uint32_t spent_time;
+	uint32_t spent_time = 0;
 
 	res = run_test_with_args(cmd, data_size, chunk_size, DO_VERIFY, 0,
 				&spent_time, NULL);


### PR DESCRIPTION
Resolve maybe-uninitialized compiler warning.

Moving patch from meta-los to upstream:

https://github.com/kuscsik/meta-los/blob/5c5a2e33bcda865ec581bc581eccf12f9fea1ada/recipes-security/optee/optee-test/0001-Silence-may-be-unset-CLang-warning.patch

Signed-off-by: Zoltan Kuscsik <zoltan.kuscsik@linaro.org>