### PR TITLE
Add __maybe_unused to variable used only in assert()

### DIFF
--- a/ta/os_test/tb_gcd.c
+++ b/ta/os_test/tb_gcd.c
@@ -26,6 +26,7 @@
  */
 #include "testframework.h"
 #include <assert.h>
+#include <compiler.h>
 
 #define TEST_GCD(stra, strb)                  \
 do {                                          \
@@ -119,7 +120,7 @@ static void test_extended_gcd_special(void)
 
 static void test_relative_prime(void)
 {
-	bool res;
+	bool res __maybe_unused;
 
 	DEF_BIGINT(x, 2048);
 	DEF_BIGINT(y, 2048);


### PR DESCRIPTION
Fixes a compilation warning/error when tests are build with NDEBUG
defined (make CPPFLAGS=-DNDEBUG) if OP-TEE pull request #910 [1] is
merged.

[1] https://github.com/OP-TEE/optee_os/pull/910

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>