### PR TITLE
xtest 6xxx: test multiple storage IDs as supported by OP-TEE

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -60,6 +60,9 @@ endif
 ifeq ($(CFG_REE_FS),y)
 LOCAL_CFLAGS += -DCFG_REE_FS
 endif
+ifeq ($(CFG_RPMB_FS),y)
+LOCAL_CFLAGS += -DCFG_RPMB_FS
+endif
 
 LOCAL_CFLAGS += -DUSER_SPACE
 LOCAL_CFLAGS += -DTA_DIR=\"/system/lib/optee_armtz\"

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -117,6 +117,9 @@ endif
 ifeq ($(CFG_REE_FS),y)
 CFLAGS += -DCFG_REE_FS
 endif
+ifeq ($(CFG_RPMB_FS),y)
+CFLAGS += -DCFG_RPMB_FS
+endif
 
 ifndef CFG_GP_PACKAGE_PATH
 CFLAGS += -Wall -Wcast-align -Werror \

--- a/host/xtest/xtest_20000.c
+++ b/host/xtest/xtest_20000.c
@@ -135,9 +135,11 @@ static TEEC_Result obj_open(TEEC_Session *sess, void *id, uint32_t id_size,
 	op.params[0].tmpref.size = id_size;
 	op.params[1].value.a = flags;
 	op.params[1].value.b = 0;
+	op.params[2].value.a = TEE_STORAGE_PRIVATE;
 
 	op.paramTypes = TEEC_PARAM_TYPES(
-		TEEC_MEMREF_TEMP_INPUT, TEEC_VALUE_INOUT, TEEC_NONE, TEEC_NONE);
+		TEEC_MEMREF_TEMP_INPUT, TEEC_VALUE_INOUT, TEEC_VALUE_INPUT,
+		TEEC_NONE);
 
 	res = TEEC_InvokeCommand(sess, TA_STORAGE_CMD_OPEN, &op, &org);
 
@@ -161,7 +163,7 @@ static TEEC_Result obj_create(TEEC_Session *sess, void *id, uint32_t id_size,
 	op.params[1].value.a = flags;
 	op.params[1].value.b = 0;
 	op.params[2].value.a = attr;
-	op.params[2].value.b = 0;
+	op.params[2].value.b = TEE_STORAGE_PRIVATE;
 	op.params[3].tmpref.buffer = data;
 	op.params[3].tmpref.size = data_size;
 

--- a/ta/storage/storage.c
+++ b/ta/storage/storage.c
@@ -45,10 +45,11 @@ TEE_Result ta_storage_cmd_open(uint32_t param_types, TEE_Param params[4])
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_MEMREF_INPUT,
-			   TEE_PARAM_TYPE_VALUE_INOUT, TEE_PARAM_TYPE_NONE,
+			   TEE_PARAM_TYPE_VALUE_INOUT,
+			   TEE_PARAM_TYPE_VALUE_INPUT,
 			   TEE_PARAM_TYPE_NONE));
 
-	res = TEE_OpenPersistentObject(TEE_STORAGE_PRIVATE,
+	res = TEE_OpenPersistentObject(params[2].value.a,
 					params[0].memref.buffer,
 					params[0].memref.size,
 					params[1].value.a, &o);
@@ -68,7 +69,7 @@ TEE_Result ta_storage_cmd_create(uint32_t param_types, TEE_Param params[4])
 			   TEE_PARAM_TYPE_VALUE_INPUT,
 			   TEE_PARAM_TYPE_MEMREF_INPUT));
 
-	res = TEE_CreatePersistentObject(TEE_STORAGE_PRIVATE,
+	res = TEE_CreatePersistentObject(params[2].value.b,
 		 params[0].memref.buffer, params[0].memref.size,
 		 params[1].value.a,
 		 (TEE_ObjectHandle)(uintptr_t)params[2].value.a,
@@ -84,11 +85,11 @@ TEE_Result ta_storage_cmd_create_overwrite(uint32_t param_types,
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_MEMREF_INPUT,
-			   TEE_PARAM_TYPE_NONE,
+			   TEE_PARAM_TYPE_VALUE_INPUT,
 			   TEE_PARAM_TYPE_NONE,
 			   TEE_PARAM_TYPE_NONE));
 
-	res = TEE_CreatePersistentObject(TEE_STORAGE_PRIVATE,
+	res = TEE_CreatePersistentObject(params[1].value.a,
 		 params[0].memref.buffer, params[0].memref.size,
 		 TEE_DATA_FLAG_OVERWRITE,
 		 NULL, NULL, 0, NULL);
@@ -236,7 +237,7 @@ TEE_Result ta_storage_cmd_start_enum(uint32_t param_types, TEE_Param params[4])
 			  (TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE,
 			   TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE));
 
-	return TEE_StartPersistentObjectEnumerator(oe, TEE_STORAGE_PRIVATE);
+	return TEE_StartPersistentObjectEnumerator(oe, params[0].value.b);
 }
 
 TEE_Result ta_storage_cmd_next_enum(uint32_t param_types, TEE_Param params[4])
@@ -304,8 +305,9 @@ TEE_Result ta_storage_cmd_key_in_persistent(uint32_t param_types,
 			 TEE_DATA_FLAG_SHARE_READ |
 			 TEE_DATA_FLAG_SHARE_WRITE;
 
-	(void)param_types;
-	(void)params;
+	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
+			  (TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE,
+			   TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE));
 
 	result = TEE_AllocateTransientObject(TEE_TYPE_AES, key_size,
 					     &transient_key);
@@ -322,7 +324,7 @@ TEE_Result ta_storage_cmd_key_in_persistent(uint32_t param_types,
 	}
 
 	TEE_GetObjectInfo1(transient_key, &keyInfo);
-	result = TEE_CreatePersistentObject(TEE_STORAGE_PRIVATE,
+	result = TEE_CreatePersistentObject(params[0].value.a,
 					    &objectID, sizeof(objectID),
 					    flags, transient_key, NULL, 0,
 					    &persistent_key);
@@ -340,7 +342,7 @@ TEE_Result ta_storage_cmd_key_in_persistent(uint32_t param_types,
 
 	TEE_CloseObject(persistent_key);
 
-	result = TEE_OpenPersistentObject(TEE_STORAGE_PRIVATE,
+	result = TEE_OpenPersistentObject(params[0].value.a,
 					  &objectID, sizeof(objectID),
 					  flags, &key);
 	if (result != TEE_SUCCESS) {
@@ -397,14 +399,16 @@ TEE_Result ta_storage_cmd_loop(uint32_t param_types, TEE_Param params[4])
 			  TEE_DATA_FLAG_ACCESS_WRITE_META;
 	int i = 0;
 
-	(void)param_types;
 	(void)params;
+	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
+			  (TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE,
+			   TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE));
 
 	for (i = 0; i < 20; i++) {
 		DMSG("\n\nLOOP : %d", i);
 		object = TEE_HANDLE_NULL;
 		object_id = i;
-		res = TEE_CreatePersistentObject(TEE_STORAGE_PRIVATE,
+		res = TEE_CreatePersistentObject(params[0].value.a,
 						 &object_id, sizeof(int), flags,
 						 TEE_HANDLE_NULL, NULL, 0,
 						 &object);


### PR DESCRIPTION
Update xtest 6xxx to test the OP-TEE specific storage IDs
(TEE_STORAGE_PRIVATE_REE, TEE_STORAGE_PRIVATE_RPMB) in addition to the
default, GP-defined value: TEE_STORAGE_PRIVATE. Which values are
enabled is determined at compile time based on whether CFG_REE_FS and
CFG_RPMB_FS are 'y' or 'n' (these values are exported by optee_os and
may be overriden).

Among all the tests in the 6xxx series, 6009 and 6010 are not updated
(i.e., they test only TEE_STORAGE_PRIVATE) because they are GP tests.

xtest_20000.c is updated accordingly, due to the change in the
interface between xtest and the secure storage TA.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>