### PR TITLE
xtest 6xxx: add TEE_STORAGE_PRIVATE_SQL

### DIFF
--- a/host/xtest/xtest_6000.c
+++ b/host/xtest/xtest_6000.c
@@ -36,6 +36,9 @@ static uint32_t storage_ids[] = {
 #ifdef CFG_RPMB_FS
 	TEE_STORAGE_PRIVATE_RPMB,
 #endif
+#ifdef CFG_SQL_FS
+	TEE_STORAGE_PRIVATE_SQL,
+#endif
 };
 
 static uint8_t file_00[] = {


### PR DESCRIPTION
If OP-TEE was compiled with SQL FS support (CFG_SQL_FS=y), test the
specific storage ID.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>