### PR TITLE
Always build xtest with -g3

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -67,6 +67,7 @@ endif
 LOCAL_CFLAGS += -DUSER_SPACE
 LOCAL_CFLAGS += -DTA_DIR=\"/system/lib/optee_armtz\"
 LOCAL_CFLAGS += -pthread
+LOCAL_CFLAGS += -g3
 
 ## target BUILD_OPTEE_OS is defined in the common ta build
 ## mk file included before, and this BUILD_OPTEE_OS will

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -133,6 +133,8 @@ CFLAGS += -Wall -Wcast-align -Werror \
 	  -Wno-missing-field-initializers -Wno-format-zero-length
 endif
 
+CFLAGS += -g3
+
 LDFLAGS += -L$(OPTEE_CLIENT_EXPORT)/lib -lteec
 LDFLAGS += -lpthread
 


### PR DESCRIPTION
Helps debugging (gdb, valgrind).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>