### PR TITLE
Fix the invalid free in xtest 9089

### DIFF
--- a/host/xtest/xml/include/xml_crypto_api.h
+++ b/host/xtest/xml/include/xml_crypto_api.h
@@ -2046,8 +2046,8 @@ static TEEC_Result Invoke_Crypto_MACCompareFinal(
 
 	res = TEEC_InvokeCommand(s, cmd_id, &op, &ret_orig);
 
-exit:
 	CRYPTO_FREE(mac);
+exit:
 	TEEC_ReleaseSharedMemory(SHARE_MEM01);
 	TEEC_ReleaseSharedMemory(SHARE_MEM02);
 	return res;


### PR DESCRIPTION
when the ALLOCATE_SHARED_MEMORY get failed, it will directly go to the
exit, and do an invalid free in CRYPTO_FREE(mac)

Signed-off-by: Zeng Tao <prime.zeng@hisilicon.com>