### PR TITLE
xtest: fix compiler warning

### DIFF
--- a/host/xtest/xtest_6000.c
+++ b/host/xtest/xtest_6000.c
@@ -1467,7 +1467,7 @@ DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6015)
 struct test_6016_thread_arg {
 	ADBG_Case_t *case_t;
 	uint32_t storage_id;
-	uint8_t file_name[8];
+	char file_name[8];
 	TEEC_Session session;
 };
 


### PR DESCRIPTION
Fix compiler warning introduced by commit 29d7c7a486e4 ("xtest: add
6016 to test concurency storage"):

/home/travis/optee_repo/optee_test/host/xtest/xtest_6000.c: In function 'xtest_tee_test_6016_loop':
/home/travis/optee_repo/optee_test/host/xtest/xtest_6000.c:1549:12: error: passing argument 1 of 'snprintf' from incompatible pointer type [-Werror=incompatible-pointer-types]
   snprintf(&arg[n].file_name, sizeof(arg[n].file_name),
            ^
In file included from /home/travis/optee_repo/optee_test/host/xtest/xtest_6000.c:15:0:
/home/travis/build/jforissier/optee_os/gcc-linaro-5.3-2016.02-x86_64_arm-linux-gnueabihf/arm-linux-gnueabihf/libc/usr/include/stdio.h:386:12: note: expected 'char * restrict' but argument is of type 'uint8_t (*)[8] {aka unsigned char (*)[8]}'
 extern int snprintf (char *__restrict __s, size_t __maxlen,
            ^

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>