### PR TITLE
xtest: fix compiler warning (redux)

### DIFF
--- a/host/xtest/xtest_6000.c
+++ b/host/xtest/xtest_6000.c
@@ -1546,7 +1546,7 @@ static void xtest_tee_test_6016_loop(ADBG_Case_t *c, uint32_t storage_id)
 	for (n = 0; n < num_threads; n++) {
 		arg[n].case_t = c;
 		arg[n].storage_id = storage_id;
-		snprintf(&arg[n].file_name, sizeof(arg[n].file_name),
+		snprintf(arg[n].file_name, sizeof(arg[n].file_name),
 			"file_%d", n);
 		if (!ADBG_EXPECT(c, 0, pthread_create(thr + n, NULL,
 						test_6016_thread, arg + n)))


### PR DESCRIPTION
Fixing parent commit. Sometimes two pairs of eyes are not even enough
to fix a single line of code ;O (and the fact that my local compiler is
not the same as the one used by Travis does not help).

/home/travis/optee_repo/optee_test/host/xtest/xtest_6000.c:1549:12: error: passing argument 1 of 'snprintf' from incompatible pointer type [-Werror=incompatible-pointer-types]
   snprintf(&arg[n].file_name, sizeof(arg[n].file_name),
            ^
In file included from /home/travis/optee_repo/optee_test/host/xtest/xtest_6000.c:15:0:
/home/travis/build/OP-TEE/optee_os/gcc-linaro-5.3-2016.02-x86_64_arm-linux-gnueabihf/arm-linux-gnueabihf/libc/usr/include/stdio.h:386:12: note: expected 'char * restrict' but argument is of type 'char (*)[8]'
 extern int snprintf (char *__restrict __s, size_t __maxlen,
            ^

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>