### PR TITLE
xtest 1013: disable second half with paged TAs

### DIFF
--- a/host/xtest/xtest_1000.c
+++ b/host/xtest/xtest_1000.c
@@ -443,7 +443,8 @@ static void xtest_tee_test_1005(ADBG_Case_t *c)
 
 	for (i = 0; i < MAX_SESSIONS; i++) {
 		if (!ADBG_EXPECT_TEEC_SUCCESS(c,
-			xtest_teec_open_session(&sessions[i], &os_test_ta_uuid,
+			xtest_teec_open_session(&sessions[i],
+						&concurrent_ta_uuid,
 						NULL, &ret_orig)))
 			break;
 	}

--- a/host/xtest/xtest_1000.c
+++ b/host/xtest/xtest_1000.c
@@ -1185,6 +1185,7 @@ static void xtest_tee_test_1013(ADBG_Case_t *c)
 	Do_ADBG_Log("    Mean concurrency: %g", mean_concurrency);
 	Do_ADBG_EndSubCase(c, "Using small concurrency TA");
 
+#ifndef CFG_PAGED_USER_TA
 	Do_ADBG_BeginSubCase(c, "Using large concurrency TA");
 	mean_concurrency = 0;
 	for (i = 0; i < nb_loops; i++) {
@@ -1197,4 +1198,5 @@ static void xtest_tee_test_1013(ADBG_Case_t *c)
 	Do_ADBG_Log("    Number of parallel threads: %d", NUM_THREADS);
 	Do_ADBG_Log("    Mean concurrency: %g", mean_concurrency);
 	Do_ADBG_EndSubCase(c, "Using large concurrency TA");
+#endif
 }


### PR DESCRIPTION
Disabled the large TA part of 1013 when paging of user TAs is enabled
since it uses too much secure heap.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>