### PR TITLE
Enable xtest 6016 (storage concurrency) for all backends

### DIFF
--- a/host/xtest/xtest_6000.c
+++ b/host/xtest/xtest_6000.c
@@ -1543,7 +1543,6 @@ exit2:
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6015)
 
 
-#ifdef CFG_RPMB_FS
 struct test_6016_thread_arg {
 	ADBG_Case_t *case_t;
 	uint32_t storage_id;
@@ -1651,26 +1650,7 @@ static void xtest_tee_test_6016_single(ADBG_Case_t *c, uint32_t storage_id)
 		xtest_tee_test_6016_loop(c, storage_id);
 }
 
-/*
- * To be replaced with: DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6016)
- * when all filesystems support concurrency
- */
-static void xtest_tee_test_6016(ADBG_Case_t *c)
-{
-	Do_ADBG_BeginSubCase(c, "Storage id: %08x", TEE_STORAGE_PRIVATE_RPMB);
-	xtest_tee_test_6016_single(c, TEE_STORAGE_PRIVATE_RPMB);
-	Do_ADBG_EndSubCase(c, "Storage id: %08x", TEE_STORAGE_PRIVATE_RPMB);
-}
-
-#else
-
-static void xtest_tee_test_6016(ADBG_Case_t *c)
-{
-	(void)c;
-	Do_ADBG_Log("    Only RPMB supports concurrency. Test disabled.");
-}
-
-#endif /* CFG_RPMB_FS */
+DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6016)
 
 
 ADBG_CASE_DEFINE(


### PR DESCRIPTION
Depends on https://github.com/OP-TEE/optee_os/pull/1047.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>