### PR TITLE
Fix 64-bit compile error in case xtest_6000.c

### DIFF
--- a/host/xtest/xtest_6000.c
+++ b/host/xtest/xtest_6000.c
@@ -1626,7 +1626,7 @@ static void xtest_tee_test_6016_loop(ADBG_Case_t *c, uint32_t storage_id)
 		arg[n].case_t = c;
 		arg[n].storage_id = storage_id;
 		snprintf(arg[n].file_name, sizeof(arg[n].file_name),
-			"file_%d", n);
+			"file_%zu", n);
 		if (!ADBG_EXPECT(c, 0, pthread_create(thr + n, NULL,
 						test_6016_thread, arg + n)))
 			goto out;


### PR DESCRIPTION
host/xtest/xtest_6000.c: In function ‘xtest_tee_test_6016_loop’:
host/xtest/xtest_6000.c:1629:4: error: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘size_t’ [-Werror=format=]
    "file_%d", n);
    ^
host/xtest/xtest_6000.c:1629:4: error: format ‘%d’ expects argument of type ‘int’, but argument 4 has type ‘size_t’ [-Werror=format=]
cc1: all warnings being treated as errors

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>