### PR TITLE
Added info about available benchmarks within xtest tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,32 @@ Then the tests must be compiled with `CFG_GP_PACKAGE_PATH=<path>`.
 	$ tee-supplicant &
 	$ xtest _<family> (i.e.: xtest _1)
 
+	# running all benchmarks (secured storage, aes/sha)
+	boot and execute on your target
+	$ modprobe optee_armtz
+	$ tee-supplicant &
+	$ xtest -t benchmark
+
+	# running single benchmark
+	boot and execute on your target
+	$ modprobe optee_armtz
+	$ tee-supplicant &
+	$ xtest -t benchmark <benchmark_number> (i.e. xtest 2001)
+
+### HOWTO use SHA/AES benchmarking modules
+It's also possible to run SHA/AES benchmarks by using sha-perf/aes-perf modules
+within xtest. These modules allow to run custom benchmarks with user-defined 
+params.
+
+	# running sha-perf with default params
+	boot and execute on your target
+	$ modprobe optee_armtz
+	$ tee-supplicant &
+	$ xtest --sha-perf
+
+	# getting usage details and list of possible options for sha-perf
+	$ xtest --sha-perf -h
+
 #### Compiler flags
 To be able to see the full command when building you could build using following
 flag:


### PR DESCRIPTION
What additional info it will be good to add about benchmarks?


FYI, I've used the term "modules" to describe aes-perf/sha-perf test tools, that are included into xtest. We can use them by running: 
$ xterm --sha-perf
If it's OK, I will also change "applets" to "modules" in the usage output for xtest utility