### PR TITLE
update xtest on new "TA private memory definition"

### DIFF
--- a/ta/os_test/include/os_test.h
+++ b/ta/os_test/include/os_test.h
@@ -35,7 +35,7 @@ TEE_Result ta_entry_client_with_timeout(uint32_t param_types,
 					TEE_Param params[4]);
 TEE_Result ta_entry_panic(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_client(uint32_t param_types, TEE_Param params[4]);
-TEE_Result ta_entry_private_params(uint32_t param_types, TEE_Param params[4]);
+TEE_Result ta_entry_params_access_rights(uint32_t p_types, TEE_Param params[4]);
 TEE_Result ta_entry_wait(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_bad_mem_access(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_mfw_apply_ddr_rules(uint32_t param_types,

--- a/ta/os_test/include/ta_os_test.h
+++ b/ta/os_test/include/ta_os_test.h
@@ -38,7 +38,7 @@
 #define TA_OS_TEST_CMD_BASIC                5
 #define TA_OS_TEST_CMD_PANIC                6
 #define TA_OS_TEST_CMD_CLIENT               7
-#define TA_OS_TEST_CMD_PRIVATE_PARAMS       8
+#define TA_OS_TEST_CMD_PARAMS_ACCESS        8
 #define TA_OS_TEST_CMD_WAIT                 9
 #define TA_OS_TEST_CMD_BAD_MEM_ACCESS       10
 

--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -91,8 +91,8 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_OS_TEST_CMD_CLIENT:
 		return ta_entry_client(nParamTypes, pParams);
 
-	case TA_OS_TEST_CMD_PRIVATE_PARAMS:
-		return ta_entry_private_params(nParamTypes, pParams);
+	case TA_OS_TEST_CMD_PARAMS_ACCESS:
+		return ta_entry_params_access_rights(nParamTypes, pParams);
 
 	case TA_OS_TEST_CMD_WAIT:
 		return ta_entry_wait(nParamTypes, pParams);


### PR DESCRIPTION
Related to [optee_os/pull#119](https://github.com/OP-TEE/optee_os/pull/1119).

TA private memory definition has changed. Memory reference received
as parameters by an TA when invoked are never "private TA memory",
they are at least shared with the client(s) in some way.

As a side effect, when a TA invokes a TA relaying a memref parameter,
the invoked TA sees memory as ANY_OWNER: it is non secure shared memory.
When a TA invoke a TA with its private memory (stack, heap, code/data)
as memref parameter, the invoked TA sees ANY_OWNER memory, mapped secure,
inside TEE reserved memory (TA RAM).

Since this change, xtest 1006 is broken.
Rename PRIVATE_PARAMS into PARAM_ACCESS tests.
Run TEE_CheckMemoryAccessRights() on several areas of the memory space.
Fix TA that see memref parameters as ANY_OWNER only memory.