### PR TITLE
xtest_20000: Fix printf conversions

### DIFF
--- a/host/xtest/xtest_20000.c
+++ b/host/xtest/xtest_20000.c
@@ -346,7 +346,7 @@ static TEEC_Result obj_corrupt(TEEC_UUID *p_uuid, void *file_id,
 		dump_file(fd);
 
 		if (0 != fseek(fd, real_offset, SEEK_SET)) {
-			fprintf(stderr, "fseek(%d): %s",
+			fprintf(stderr, "fseek(%zu): %s",
 					real_offset, strerror(errno));
 			tee_res = TEEC_ERROR_BAD_PARAMETERS;
 			goto exit;
@@ -361,7 +361,7 @@ static TEEC_Result obj_corrupt(TEEC_UUID *p_uuid, void *file_id,
 		}
 
 		printf("o Corrupt %s\n", name);
-		printf("o Byte offset: %u (0x%04X)\n", real_offset, real_offset);
+		printf("o Byte offset: %zu (0x%04zX)\n", real_offset, real_offset);
 		printf("Old value:");
 		for (i = 0; i < num_corrupt_bytes; i++) {
 			printf(" 0x%02x", bytes[i]);
@@ -375,7 +375,7 @@ static TEEC_Result obj_corrupt(TEEC_UUID *p_uuid, void *file_id,
 		printf("\n");
 
 		if (0 != fseek(fd, real_offset, SEEK_SET)) {
-			fprintf(stderr, "fseek(%d): %s",
+			fprintf(stderr, "fseek(%zu): %s",
 					real_offset, strerror(errno));
 			tee_res = TEEC_ERROR_BAD_PARAMETERS;
 			goto exit;


### PR DESCRIPTION
Fix the compilation errors shown below by specifying correct printf
conversions.

optee_test/host/xtest/xtest_20000.c: In function 'obj_corrupt':
optee_test/host/xtest/xtest_20000.c:349:20: error: format '%d' expects argument of type 'int', but argument 3 has type 'size_t {aka long unsigned int}' [-Werror=format=]
    fprintf(stderr, "fseek(%d): %s",
                    ^
optee_test/host/xtest/xtest_20000.c:364:10: error: format '%u' expects argument of type 'unsigned int', but argument 2 has type 'size_t {aka long unsigned int}' [-Werror=format=]
   printf("o Byte offset: %u (0x%04X)\n", real_offset, real_offset);
          ^
optee_test/host/xtest/xtest_20000.c:364:10: error: format '%X' expects argument of type 'unsigned int', but argument 3 has type 'size_t {aka long unsigned int}' [-Werror=format=]
optee_test/host/xtest/xtest_20000.c:378:20: error: format '%d' expects argument of type 'int', but argument 3 has type 'size_t {aka long unsigned int}' [-Werror=format=]
    fprintf(stderr, "fseek(%d): %s",
                    ^

Signed-off-by: Soren Brinkmann <soren.brinkmann@xilinx.com>