### PR TITLE
#146 Wrong name for OPTEE-Client Export

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -7,7 +7,7 @@ include $(BUILD_OPTEE_MK)
 INCLUDE_FOR_BUILD_TA :=
 
 VERSION = $(shell git describe --always --dirty=-dev 2>/dev/null || echo Unknown)
-OPTEE_CLIENT_PATH ?= $(LOCAL_PATH)/../optee_client
+OPTEE_CLIENT_EXPORT ?= $(LOCAL_PATH)/../optee_client
 
 # TA_DEV_KIT_DIR must be set to non-empty value to
 # avoid the Android build scripts complaining about

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ By default `optee_test` expects that `optee_client` is located at the same
 folder level. However if you build optee_client in another location, then you
 also would need to use (or export) the following flag:
 
-`$ make OPTEE_CLIENT_PATH=$HOME/my_new_location`
+`$ make OPTEE_CLIENT_EXPORT=$HOME/my_new_location`
 
 ## Coding standards
 In this project we are trying to adhere to the same coding convention as used in


### PR DESCRIPTION
This is closing #146 by changing OPTEE_CLIENT_PATH into OPTEE_CLIENT_EXPORT in README.md