### PR TITLE
Format UUID strings correctly

### DIFF
--- a/host/xtest/xtest_1000.c
+++ b/host/xtest/xtest_1000.c
@@ -529,7 +529,7 @@ static void uuid_to_full_name(char *buf, size_t blen, const TEEC_UUID *uuid,
 			bool for_write)
 {
 	snprintf(buf, blen,
-		"%s/%08x-%04x-%04x-%02x%02x%02x%02x%02x%02x%02x%02x.ta",
+		"%s/%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x.ta",
 		for_write ? TA_TEST_DIR : TA_DIR,
 		uuid->timeLow, uuid->timeMid, uuid->timeHiAndVersion,
 		uuid->clockSeqAndNode[0], uuid->clockSeqAndNode[1],

--- a/ta/aes_perf/Android.mk
+++ b/ta/aes_perf/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module := e626662e-c0e2-485c-b8c809fbce6edf3d.ta
+local_module := e626662e-c0e2-485c-b8c8-09fbce6edf3d.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/aes_perf/Makefile
+++ b/ta/aes_perf/Makefile
@@ -1,3 +1,3 @@
-BINARY = e626662e-c0e2-485c-b8c809fbce6edf3d
+BINARY = e626662e-c0e2-485c-b8c8-09fbce6edf3d
 include ../ta_common.mk
 

--- a/ta/concurrent/Android.mk
+++ b/ta/concurrent/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module :=  e13010e0-2ae1-11e5-896a0002a5d5c51b.ta
+local_module :=  e13010e0-2ae1-11e5-896a-0002a5d5c51b.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/concurrent/Makefile
+++ b/ta/concurrent/Makefile
@@ -1,2 +1,2 @@
-BINARY =  e13010e0-2ae1-11e5-896a0002a5d5c51b
+BINARY =  e13010e0-2ae1-11e5-896a-0002a5d5c51b
 include ../ta_common.mk

--- a/ta/concurrent_large/Android.mk
+++ b/ta/concurrent_large/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module :=  5ce0c432-0ab0-40e5-a056782ca0e6aba2.ta
+local_module :=  5ce0c432-0ab0-40e5-a056-782ca0e6aba2.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/concurrent_large/Makefile
+++ b/ta/concurrent_large/Makefile
@@ -1,2 +1,2 @@
-BINARY =  5ce0c432-0ab0-40e5-a056782ca0e6aba2
+BINARY =  5ce0c432-0ab0-40e5-a056-782ca0e6aba2
 include ../ta_common.mk

--- a/ta/create_fail_test/Android.mk
+++ b/ta/create_fail_test/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module := c3f6e2c0-3548-11e1-b86c0800200c9a66.ta
+local_module := c3f6e2c0-3548-11e1-b86c-0800200c9a66.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/create_fail_test/Makefile
+++ b/ta/create_fail_test/Makefile
@@ -1,2 +1,2 @@
-BINARY = c3f6e2c0-3548-11e1-b86c0800200c9a66
+BINARY = c3f6e2c0-3548-11e1-b86c-0800200c9a66
 include ../ta_common.mk

--- a/ta/crypt/Android.mk
+++ b/ta/crypt/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module := cb3e5ba0-adf1-11e0-998b0002a5d5c51b.ta
+local_module := cb3e5ba0-adf1-11e0-998b-0002a5d5c51b.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/crypt/Makefile
+++ b/ta/crypt/Makefile
@@ -1,2 +1,2 @@
-BINARY =  cb3e5ba0-adf1-11e0-998b0002a5d5c51b
+BINARY =  cb3e5ba0-adf1-11e0-998b-0002a5d5c51b
 include ../ta_common.mk

--- a/ta/os_test/Android.mk
+++ b/ta/os_test/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module := 5b9e0e40-2636-11e1-ad9e0002a5d5c51b.ta
+local_module := 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/os_test/Makefile
+++ b/ta/os_test/Makefile
@@ -1,2 +1,2 @@
-BINARY = 5b9e0e40-2636-11e1-ad9e0002a5d5c51b
+BINARY = 5b9e0e40-2636-11e1-ad9e-0002a5d5c51b
 include ../ta_common.mk

--- a/ta/rpc_test/Android.mk
+++ b/ta/rpc_test/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module :=  d17f73a0-36ef-11e1-984a0002a5d5c51b.ta
+local_module :=  d17f73a0-36ef-11e1-984a-0002a5d5c51b.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/rpc_test/Makefile
+++ b/ta/rpc_test/Makefile
@@ -1,2 +1,2 @@
-BINARY = d17f73a0-36ef-11e1-984a0002a5d5c51b
+BINARY = d17f73a0-36ef-11e1-984a-0002a5d5c51b
 include ../ta_common.mk

--- a/ta/sha_perf/Android.mk
+++ b/ta/sha_perf/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module := 614789f2-39c0-4ebf-b23592b32ac107ed.ta
+local_module := 614789f2-39c0-4ebf-b235-92b32ac107ed.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/sha_perf/Makefile
+++ b/ta/sha_perf/Makefile
@@ -1,3 +1,3 @@
-BINARY = 614789f2-39c0-4ebf-b23592b32ac107ed
+BINARY = 614789f2-39c0-4ebf-b235-92b32ac107ed
 include ../ta_common.mk
 

--- a/ta/sims/Android.mk
+++ b/ta/sims/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module := e6a33ed4-562b-463a-bb7eff5e15a493c8.ta
+local_module := e6a33ed4-562b-463a-bb7e-ff5e15a493c8.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/sims/Makefile
+++ b/ta/sims/Makefile
@@ -1,2 +1,2 @@
-BINARY = e6a33ed4-562b-463a-bb7eff5e15a493c8
+BINARY = e6a33ed4-562b-463a-bb7e-ff5e15a493c8
 include ../ta_common.mk

--- a/ta/storage/Android.mk
+++ b/ta/storage/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module := b689f2a7-8adf-477a-9f9932e90c0ad0a2.ta
+local_module := b689f2a7-8adf-477a-9f99-32e90c0ad0a2.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/storage/Makefile
+++ b/ta/storage/Makefile
@@ -1,2 +1,2 @@
-BINARY = b689f2a7-8adf-477a-9f9932e90c0ad0a2
+BINARY = b689f2a7-8adf-477a-9f99-32e90c0ad0a2
 include ../ta_common.mk

--- a/ta/storage2/Android.mk
+++ b/ta/storage2/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module := 731e279e-aafb-4575-a77138caa6f0cca6.ta
+local_module := 731e279e-aafb-4575-a771-38caa6f0cca6.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/storage2/Makefile
+++ b/ta/storage2/Makefile
@@ -1,2 +1,2 @@
-BINARY = 731e279e-aafb-4575-a77138caa6f0cca6
+BINARY = 731e279e-aafb-4575-a771-38caa6f0cca6
 include ../ta_common.mk

--- a/ta/storage_benchmark/Android.mk
+++ b/ta/storage_benchmark/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module := f157cda0-550c-11e5-a6fa0002a5d5c51b.ta
+local_module := f157cda0-550c-11e5-a6fa-0002a5d5c51b.ta
 include $(BUILD_OPTEE_MK)

--- a/ta/storage_benchmark/Makefile
+++ b/ta/storage_benchmark/Makefile
@@ -1,2 +1,2 @@
-BINARY = f157cda0-550c-11e5-a6fa0002a5d5c51b
+BINARY = f157cda0-550c-11e5-a6fa-0002a5d5c51b
 include ../ta_common.mk


### PR DESCRIPTION
Prior to this patch although GlobalPlatform specifies that TAs and such
are identified with UUIDs, we don't format them quite right when turning
them into strings. Per https://www.ietf.org/rfc/rfc4122.txt, there
should be another hyphen after the first two bytes of clockSeqAndNode.

Unfortunately, fixing this breaks compatibility between how TAs are
built, and when the OS loads them.

With this patch UUID string are formated with the additional hyphen as
for instance: f81d4fae-7dec-11d0-a765-00a0c91e6bf6

Fixes: https://github.com/OP-TEE/optee_os/issues/857
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>


Depends on https://github.com/OP-TEE/optee_os/pull/1227 and https://github.com/OP-TEE/optee_client/pull/71