### PR TITLE
aes-perf, sha-perf: display more statistics

### DIFF
--- a/host/xtest/aes_perf.c
+++ b/host/xtest/aes_perf.c
@@ -311,6 +311,7 @@ void aes_perf_run_test(int mode, int keysize, int decrypt, size_t size,
 	struct timespec ts;
 	TEEC_Operation op;
 	int n0 = n;
+	double sd;
 
 	vverbose("aes-perf version %s\n", TO_STR(VERSION));
 	if (clock_getres(CLOCK_MONOTONIC, &ts) < 0) {
@@ -359,9 +360,14 @@ void aes_perf_run_test(int mode, int keysize, int decrypt, size_t size,
 			vverbose("#");
 	}
 	vverbose("\n");
-	printf("min=%gμs max=%gμs mean=%gμs stddev=%gμs (%gMiB/s)\n",
+	sd = stddev(&stats);
+	printf("min=%gμs max=%gμs mean=%gμs stddev=%gμs (cv %g%%) (%gMiB/s)\n",
 	       stats.min/1000, stats.max/1000, stats.m/1000,
-	       stddev(&stats)/1000, mb_per_sec(size, stats.m));
+	       sd/1000, 100*sd/stats.m, mb_per_sec(size, stats.m));
+	verbose("2-sigma interval: %g..%gμs (%g..%gMiB/s)\n",
+		(stats.m-2*sd)/1000, (stats.m+2*sd)/1000,
+		mb_per_sec(size, stats.m+2*sd),
+		mb_per_sec(size, stats.m-2*sd));
 	free_shm();
 }
 

--- a/host/xtest/sha_perf.c
+++ b/host/xtest/sha_perf.c
@@ -306,6 +306,7 @@ extern void sha_perf_run_test(int algo, size_t size, unsigned int n,
 	TEEC_Operation op;
 	int n0 = n;
 	struct timespec ts;
+	double sd;
 
 	vverbose("sha-perf version %s\n", TO_STR(VERSION));
 	if (clock_getres(CLOCK_MONOTONIC, &ts) < 0) {
@@ -354,9 +355,14 @@ extern void sha_perf_run_test(int algo, size_t size, unsigned int n,
 			vverbose("#");
 	}
 	vverbose("\n");
-	printf("min=%gμs max=%gμs mean=%gμs stddev=%gμs (%gMiB/s)\n",
+	sd = stddev(&stats);
+	printf("min=%gμs max=%gμs mean=%gμs stddev=%gμs (cv %g%%) (%gMiB/s)\n",
 	       stats.min/1000, stats.max/1000, stats.m/1000,
-	       stddev(&stats)/1000, mb_per_sec(size, stats.m));
+	       sd/1000, 100*sd/stats.m, mb_per_sec(size, stats.m));
+	verbose("2-sigma interval: %g..%gμs (%g..%gMiB/s)\n",
+		(stats.m-2*sd)/1000, (stats.m+2*sd)/1000,
+		mb_per_sec(size, stats.m+2*sd),
+		mb_per_sec(size, stats.m-2*sd));
 	free_shm();
 }
 


### PR DESCRIPTION
Show more statistics to help assess the test repeatability and compare
test runs:
- Print the coefficient of variation (cv = stddev/mean)
- When the -v option is given: also show the 2-sigma interval

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>