### PR TITLE
xtest: fix dependency to initstate_r() and friends

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -53,8 +53,6 @@ srcs += xtest_4000.c \
 	adbg/src/adbg_run.c \
 	adbg/src/security_utils_hex.c
 
-CFLAGS += -D_GNU_SOURCE
-
 ifdef CFG_GP_PACKAGE_PATH
 CFLAGS += -DWITH_GP_TESTS
 


### PR DESCRIPTION
initstate_r() and friends are glibc extensions which are not available
in all libc. This patch removes this dependency and implements its own
portable implementation.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>