### PR TITLE
case 6018: reduce the number of blocks written

### DIFF
--- a/host/xtest/xtest_6000.c
+++ b/host/xtest/xtest_6000.c
@@ -1763,7 +1763,7 @@ static void xtest_tee_test_6018_single(ADBG_Case_t *c, uint32_t storage_id)
 		num_blocks = 20;
 		block_size = 1024;
 	} else {
-		num_blocks = 50;
+		num_blocks = 40;
 		block_size = sizeof(block);
 	}
 


### PR DESCRIPTION
Reduces the number of blocks written to avoid out of memory errors on some
platforms.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>