### PR TITLE
ta/Makefile: include host_include/conf.mk

### DIFF
--- a/ta/Makefile
+++ b/ta/Makefile
@@ -8,6 +8,8 @@ ifeq ($(out-dir),)
 $(error invalid output directory (O=$(O)))
 endif
 
+include $(TA_DEV_KIT_DIR)/host_include/conf.mk
+
 # Prevent use of LDFLAGS from the environment. For example, yocto exports
 # LDFLAGS that are suitable for the client applications, not for TAs
 LDFLAGS=


### PR DESCRIPTION
The compile-time options of OP-TEE OS (CFG_*) are currently not
available from the main TA makefile. Fix this, since we already
have a need (the sdp_basic TA should automatically be selected
when OP-TEE supports the Secure Data Path).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>