### PR TITLE
xtest: add a SDP test in the non-regression suite

### DIFF
--- a/host/xtest/sdp_basic.h
+++ b/host/xtest/sdp_basic.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, Linaro Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef XTEST_SDP_BASIC_H
+#define XTEST_SDP_BASIC_H
+
+#include "include/uapi/linux/ion.h"
+#include "ta_sdp_basic.h"
+
+#define DEFAULT_ION_HEAP_TYPE	ION_HEAP_TYPE_UNMAPPED
+
+enum test_target_ta {
+	TEST_NS_TO_TA,
+	TEST_NS_TO_PTA,
+	TEST_TA_TO_TA,
+	TEST_TA_TO_PTA,
+};
+
+int allocate_ion_buffer(size_t size, int heap_id);
+int sdp_basic_test(enum test_target_ta ta,
+			  size_t size, size_t loop, int ion_heap,
+			  int rnd_offset);
+
+#endif /* XTEST_SDP_BASIC_H */

--- a/host/xtest/xtest_test.c
+++ b/host/xtest/xtest_test.c
@@ -29,6 +29,7 @@
 #include <__tee_isocket_defines.h>
 #include <__tee_tcpsocket_defines.h>
 #include <__tee_udpsocket_defines.h>
+#include <ta_sdp_basic.h>
 #ifdef WITH_GP_TESTS
 #include <tee_api_types.h>
 #include <TTA_DS_protocol.h>
@@ -100,6 +101,7 @@ const TEEC_UUID concurrent_ta_uuid = TA_CONCURRENT_UUID;
 const TEEC_UUID concurrent_large_ta_uuid = TA_CONCURRENT_LARGE_UUID;
 const TEEC_UUID storage_benchmark_ta_uuid = TA_STORAGE_BENCHMARK_UUID;
 const TEEC_UUID socket_ta_uuid = TA_SOCKET_UUID;
+const TEEC_UUID sdp_basic_ta_uuid = TA_SDP_BASIC_UUID;
 #ifdef WITH_GP_TESTS
 const TEEC_UUID gp_tta_ds_uuid = TA_TTA_DS_UUID;
 #endif

--- a/host/xtest/xtest_test.h
+++ b/host/xtest/xtest_test.h
@@ -127,6 +127,7 @@ extern const TEEC_UUID concurrent_ta_uuid;
 extern const TEEC_UUID concurrent_large_ta_uuid;
 extern const TEEC_UUID storage_benchmark_ta_uuid;
 extern const TEEC_UUID socket_ta_uuid;
+extern const TEEC_UUID sdp_basic_ta_uuid;
 extern char *_device;
 
 #endif /*XTEST_TEST_H*/


### PR DESCRIPTION
xtest regression test #1014 is dedicated to secure data path.
It is enable only upon CFG_SECURE_DATA_PATH=y.
