### PR TITLE
GP: do not expect to find non-standard macros in tee_internal_api.h

### DIFF
--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Arithmetical/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Arithmetical/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_Arithmetical.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerErrorTo_Invoke/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerErrorTo_Invoke/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_answerErrorTo_Invoke.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerErrorTo_OpenSession/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerErrorTo_OpenSession/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_answerErrorTo_OpenSession.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerSuccessTo_OpenSession_Invoke/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerSuccessTo_OpenSession_Invoke/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_answerSuccessTo_OpenSession_Invoke.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_check_OpenSession_with_4_parameters/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_check_OpenSession_with_4_parameters/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_check_OpenSession_with_4_parameters.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_testingClientAPI/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_testingClientAPI/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_testingClientAPI.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Crypto/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Crypto/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_Crypto.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_DS/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_DS/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_DS.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_TCF.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_ICA/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_ICA/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_TCF_ICA.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_ICA2/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_ICA2/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_TCF_ICA2.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_MultipleInstanceTA/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_MultipleInstanceTA/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_TCF_MultipleInstanceTA.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_SingleInstanceTA/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_SingleInstanceTA/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y += TTA_TCF_SingleInstanceTA.c
+cflags-y := -include ../include/GP_defs.h

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Time/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Time/code_files/sub.mk
@@ -1,2 +1,3 @@
 global-incdirs-y += include
 srcs-y +=TTA_Time.c
+cflags-y := -include ../include/GP_defs.h

--- a/ta/include/GP_defs.h
+++ b/ta/include/GP_defs.h
@@ -1,0 +1,4 @@
+#define SLogTrace(...)
+#define SLogError(...)
+#define SLogWarning(...)
+#define S_VAR_NOT_USED(x) do { (void)(x); } while (0)


### PR DESCRIPTION
With [1], SLogTrace(), SLogError(), SLogWarning() and S_VAR_NOT_USED()
are not defined in tee_internal_api.h anymore. Define them locally.

[1] https://github.com/OP-TEE/optee_os/pull/1449

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>