### PR TITLE
GP: clean up the compilation messages

### DIFF
--- a/host/xtest/xml/include/xml_common_api.h
+++ b/host/xtest/xml/include/xml_common_api.h
@@ -14,6 +14,8 @@
 #ifndef XML_COMMON_API_H_
 #define XML_COMMON_API_H_
 
+#include <assert.h>
+
 /*Helper functions/macros*/
 #define IDENTIFIER_NOT_USED(x) { if (sizeof(&x)) {} }
 
@@ -49,5 +51,15 @@
 	op.params[parameterNumber].memref.offset = sharedMemoryOffset; \
 	op.params[parameterNumber].memref.size = sharedMemorySize; \
 	op.params[parameterNumber].memref.parent = sharedMemory;
+
+static uint32_t _handle_to_u32(unsigned long h)
+{
+#ifdef __LP64__
+        assert(!(h >> 32));
+#endif
+        return (uint32_t)(h & 0xFFFFFFFF);
+}
+
+#define handle_to_u32(h) _handle_to_u32((unsigned long)h)
 
 #endif /* XML_COMMON_API_H_ */

--- a/host/xtest/xml/include/xml_crypto_api.h
+++ b/host/xtest/xml/include/xml_crypto_api.h
@@ -682,7 +682,7 @@ static TEEC_Result Invoke_Crypto_AllocateOperation(
 	op.params[0].value.a = algo;
 	op.params[0].value.b = mode;
 	op.params[1].value.a = obj_size1 + obj_size2;
-	op.params[3].value.a = (uint32_t)*oph;
+	op.params[3].value.a = handle_to_u32(*oph);
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_VALUE_INPUT,
 					 TEEC_NONE, TEEC_VALUE_INPUT);
@@ -716,7 +716,7 @@ static TEEC_Result Invoke_Crypto_GetOperationInfo(
 	uint32_t ret_orig;
 	uint32_t mask_handle_state = 0;
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INOUT, TEEC_VALUE_OUTPUT,
 					 TEEC_VALUE_OUTPUT, TEEC_VALUE_OUTPUT);
 
@@ -776,8 +776,8 @@ static TEEC_Result Invoke_Crypto_GetOperationInfoMultiple(
 	obuf_size = ((key_exp * 2) + 2) * 4;
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM01, obuf_size,
 			       TEEC_MEM_OUTPUT, mem01_exit)
+	op.params[0].value.a = handle_to_u32(*oph);
 
-	op.params[0].value.a = (uint32_t)*oph;
 
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(3, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
@@ -833,7 +833,7 @@ static TEEC_Result Invoke_Crypto_ResetOperation(
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t ret_orig;
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
 
@@ -853,7 +853,7 @@ static TEEC_Result Invoke_Crypto_FreeAllKeysAndOperations(
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t ret_orig;
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
 
@@ -974,7 +974,7 @@ static TEEC_Result Invoke_Crypto_InitObjectWithKeys(
 	 */
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01, 60)
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(2, 0, SHARE_MEM02, tmp_offset)
-	op.params[3].value.a = (uint32_t)*obh;
+	op.params[3].value.a = handle_to_u32(*obh);
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT,
 					 TEEC_MEMREF_PARTIAL_INPUT,
@@ -1014,8 +1014,8 @@ static TEEC_Result Invoke_Crypto_SetOperationKey(
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t ret_orig;
 
-	op.params[0].value.a = (uint32_t)*oph;
-	op.params[0].value.b = (uint32_t)*obh;
+	op.params[0].value.a = handle_to_u32(*oph);
+	op.params[0].value.b = handle_to_u32(*obh);
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
@@ -1045,9 +1045,9 @@ static TEEC_Result Invoke_Crypto_SetOperationKey2(
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t ret_orig;
 
-	op.params[0].value.a = (uint32_t)*oph;
-	op.params[0].value.b = (uint32_t)*obh1;
-	op.params[1].value.a = (uint32_t)*obh2;
+	op.params[0].value.a = handle_to_u32(*oph);
+	op.params[0].value.b = handle_to_u32(*obh1);
+	op.params[1].value.a = handle_to_u32(*obh2);
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_VALUE_INPUT,
 					 TEEC_NONE, TEEC_NONE);
 
@@ -1075,8 +1075,8 @@ static TEEC_Result Invoke_Crypto_DeriveKey(
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t ret_orig;
 
-	op.params[0].value.a = (uint32_t)*oph;
-	op.params[0].value.b = (uint32_t)*obh;
+	op.params[0].value.a = handle_to_u32(*oph);
+	op.params[0].value.b = handle_to_u32(*obh);
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
@@ -1110,7 +1110,7 @@ static TEEC_Result Invoke_Crypto_AEInit(
 					TEEC_MEM_INPUT, nonce_length,
 					nonce_val, mem01_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	op.params[0].value.b = in_tag_len;
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
@@ -1154,7 +1154,7 @@ static TEEC_Result Invoke_Crypto_AEUpdate_for_encryption(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM02, DS_BIG_SIZE,
 			       TEEC_MEM_OUTPUT, mem02_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 	/*if $IN_caseBuffer$ = OUTPUT_BUFFER_TOO_SHORT(2)
@@ -1218,7 +1218,7 @@ static TEEC_Result Invoke_Crypto_AEUpdate_for_decryption(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM02, partd_length,
 			       TEEC_MEM_OUTPUT, mem02_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01, partd_length)
 	/*if $IN_caseBuffer$ = OUTPUT_BUFFER_TOO_SHORT(2)
 		then Param[3].memref.size=1*/
@@ -1272,7 +1272,7 @@ static TEEC_Result Invoke_Crypto_AEUpdateAAD(
 					TEEC_MEM_INPUT, aad_length,
 					aad_data, mem01_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 
@@ -1316,7 +1316,7 @@ static TEEC_Result Invoke_Crypto_AEEncryptFinal(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM03, partd_length,
 			       TEEC_MEM_OUTPUT, mem03_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 	switch (case_buf) {
@@ -1424,7 +1424,7 @@ static TEEC_Result Invoke_Crypto_AEDecryptFinal(
 			BIT_CHANGE(*(uint32_t *)SHARE_MEM03->buffer, 4);
 	}
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(2, 0, SHARE_MEM03,
@@ -1551,7 +1551,7 @@ static TEEC_Result Invoke_Crypto_DigestUpdate(
 					TEEC_MEM_INPUT, partd_length,
 					part_data, mem01_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 
@@ -1585,7 +1585,7 @@ static TEEC_Result Invoke_Crypto_DigestDoFinal(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM02, fdata_length,
 			       TEEC_MEM_OUTPUT, mem02_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 	if (case_buf == OUTPUT_BUFFER_TOO_SHORT) {
@@ -1656,7 +1656,7 @@ static TEEC_Result Invoke_Crypto_AsymmetricSignDigest(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM02, 512,
 			       TEEC_MEM_OUTPUT, mem02_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      saved_digest.size)
 	/*if $IN_caseBuffer$ = OUTPUT_BUFFER_TOO_SHORT(2)
@@ -1732,7 +1732,7 @@ static TEEC_Result Invoke_Crypto_AsymmetricVerifyDigest(
 		}
 	}
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      saved_digest.size)
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(3, 0, SHARE_MEM02,
@@ -1771,7 +1771,7 @@ static TEEC_Result Invoke_Crypto_AsymmetricEncrypt(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM02, 512,
 			       TEEC_MEM_OUTPUT, mem02_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 	/*if $IN_caseBuffer$ = OUTPUT_BUFFER_TOO_SHORT(2)
@@ -1827,7 +1827,7 @@ static TEEC_Result Invoke_Crypto_AsymmetricDecrypt(
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t ret_orig;
 	size_t initial_size;
-	char *expected_res;
+	const char *expected_res;
 	size_t expected_size;
 
 	/* Fill SharedMem1 with buffer_asym_encrypted */
@@ -1839,7 +1839,7 @@ static TEEC_Result Invoke_Crypto_AsymmetricDecrypt(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM02, 512,
 			       TEEC_MEM_OUTPUT, mem02_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      buffer_asym_encrypted.size)
 	/*if $IN_caseBuffer$ = OUTPUT_BUFFER_TOO_SHORT(2)
@@ -1905,8 +1905,8 @@ static TEEC_Result Invoke_Crypto_CopyOperation(
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t ret_orig;
 
-	op.params[0].value.a = (uint32_t)*dst_oph;
-	op.params[0].value.b = (uint32_t)*src_oph;
+	op.params[0].value.a = handle_to_u32(*dst_oph);
+	op.params[0].value.b = handle_to_u32(*src_oph);
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
@@ -1928,7 +1928,7 @@ static TEEC_Result Invoke_Crypto_MACInit(
 	ALLOCATE_AND_FILL_SHARED_MEMORY(CONTEXT01, SHARE_MEM06, iv_len,
 					TEEC_MEM_INPUT, iv_len, iv, mem06_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM06, iv_len)
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT,
@@ -1966,7 +1966,7 @@ static TEEC_Result Invoke_Crypto_MACUpdate(
 					TEEC_MEM_INPUT, partd_length,
 					part_data, mem01_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 
@@ -2015,7 +2015,7 @@ static TEEC_Result Invoke_Crypto_MACCompareFinal(
 		}
 	}
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(2, 0, SHARE_MEM02, mac.size)
@@ -2054,7 +2054,7 @@ static TEEC_Result Invoke_Crypto_MACComputeFinal(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM02, fdata_length,
 			       TEEC_MEM_OUTPUT, mem02_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 	if (case_buf == OUTPUT_BUFFER_TOO_SHORT) {
@@ -2116,7 +2116,7 @@ static TEEC_Result Invoke_Crypto_CipherInit(
 	ALLOCATE_AND_FILL_SHARED_MEMORY(CONTEXT01, SHARE_MEM01, iv_len,
 					TEEC_MEM_INPUT, iv_len, iv, mem01_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 
@@ -2161,7 +2161,7 @@ static TEEC_Result Invoke_Crypto_CipherUpdate(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM02, partd_length,
 			       TEEC_MEM_OUTPUT, mem02_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 	/*if $IN_caseBuffer$ = OUTPUT_BUFFER_TOO_SHORT(2)
@@ -2228,7 +2228,7 @@ static TEEC_Result Invoke_Crypto_CipherDoFinal(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM02, fulld_length,
 			       TEEC_MEM_OUTPUT, mem02_exit)
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01,
 					      SHARE_MEM01->size)
 	/*if $IN_caseBuffer$ = OUTPUT_BUFFER_TOO_SHORT(2)
@@ -2307,7 +2307,7 @@ static TEEC_Result Invoke_Crypto_FreeOperation(
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t ret_orig;
 
-	op.params[0].value.a = (uint32_t)*oph;
+	op.params[0].value.a = handle_to_u32(*oph);
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
 	res = TEEC_InvokeCommand(s, cmd_id, &op, &ret_orig);
@@ -2339,7 +2339,7 @@ static TEEC_Result calculate_digest(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM05, data_length,
 			       TEEC_MEM_OUTPUT, mem05_exit)
 
-	op.params[0].value.a = (uint32_t)op1;
+	op.params[0].value.a = handle_to_u32(op1);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM04,
 					      SHARE_MEM04->size)
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(3, 0, SHARE_MEM05,
@@ -2409,7 +2409,7 @@ static TEEC_Result sign_digest(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM05, 512,
 			       TEEC_MEM_OUTPUT, mem05_exit)
 
-	op.params[0].value.a = (uint32_t)op1;
+	op.params[0].value.a = handle_to_u32(op1);
 	if (in_dgst->size != 0) {
 		SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM04,
 						      in_dgst->size)
@@ -2484,7 +2484,7 @@ static bool verify_digest(
 					TEEC_MEM_INPUT,
 					in_sdgst->size, in_sdgst->buffer, mem05_exit)
 
-	op.params[0].value.a = (uint32_t)op1;
+	op.params[0].value.a = handle_to_u32(op1);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM04,
 					      saved_digest.size)
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(3, 0, SHARE_MEM05, in_sdgst->size)
@@ -2554,7 +2554,7 @@ static TEEC_Result mac_compute_final(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM05, fdata_length,
 			       TEEC_MEM_OUTPUT, mem05_exit)
 
-	op.params[0].value.a = (uint32_t)op1;
+	op.params[0].value.a = handle_to_u32(op1);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM04,
 					      SHARE_MEM04->size)
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(3, 0, SHARE_MEM05,
@@ -2622,7 +2622,7 @@ static TEEC_Result cipher_do_final(
 					saved_cipher_iv.buffer,
 					mem04_exit)
 
-	op.params[0].value.a = (uint32_t)op1;
+	op.params[0].value.a = handle_to_u32(op1);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM04,
 					      saved_cipher_iv.size)
 
@@ -2646,7 +2646,7 @@ static TEEC_Result cipher_do_final(
 	ALLOCATE_SHARED_MEMORY(CONTEXT01, SHARE_MEM05, fdata_length,
 			       TEEC_MEM_OUTPUT, mem05_exit)
 
-	op.params[0].value.a = (uint32_t)op1;
+	op.params[0].value.a = handle_to_u32(op1);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM04,
 					      SHARE_MEM04->size)
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(3, 0, SHARE_MEM05,

--- a/host/xtest/xml/include/xml_datastorage_api.h
+++ b/host/xtest/xml/include/xml_datastorage_api.h
@@ -675,7 +675,7 @@ static TEEC_UUID UUID_TTA_testingInternalAPI_dataStorage = {
 					    connectionMethod, connectionData, \
 					    operation, &ret_orig)); \
 		if ((returnOrigin != 0) && \
-		    ((int)returnOrigin != TEEC_ORIGIN_ANY_NOT_TRUSTED_APP)) \
+		    (returnOrigin != TEEC_ORIGIN_ANY_NOT_TRUSTED_APP)) \
 			ADBG_EXPECT(c, (int)returnOrigin, ret_orig); \
 		else \
 			ADBG_EXPECT_NOT(c, (int)returnOrigin, ret_orig); \

--- a/host/xtest/xml/include/xml_internal_api.h
+++ b/host/xtest/xml/include/xml_internal_api.h
@@ -327,7 +327,7 @@ static TEEC_Result Invoke_GetPropertyAsXXX_withoutEnum(
 				       TEEC_MEM_OUTPUT, mem02_exit)
 	}
 
-	op.params[0].value.a = (uint32_t)propSet;
+	op.params[0].value.a = handle_to_u32(propSet);
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(1, 0, SHARE_MEM01, nameLen)
 	SET_SHARED_MEMORY_OPERATION_PARAMETER(2, 0, SHARE_MEM02,
 					      SHARE_MEM02->size)
@@ -592,7 +592,7 @@ static TEEC_Result Invoke_StartPropertyEnumerator(
 	uint32_t org;
 
 	op.params[0].value.a = enumerator;
-	op.params[1].value.a = (uint32_t)propSet;
+	op.params[1].value.a = handle_to_u32(propSet);
 
 	op.paramTypes = TEEC_PARAM_TYPES(
 		TEEC_VALUE_INPUT, TEEC_VALUE_INPUT, TEEC_NONE, TEEC_NONE);

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Arithmetical/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Arithmetical/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_Arithmetical.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerErrorTo_Invoke/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerErrorTo_Invoke/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_answerErrorTo_Invoke.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerErrorTo_OpenSession/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerErrorTo_OpenSession/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_answerErrorTo_OpenSession.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerSuccessTo_OpenSession_Invoke/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_answerSuccessTo_OpenSession_Invoke/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_answerSuccessTo_OpenSession_Invoke.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_check_OpenSession_with_4_parameters/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_check_OpenSession_with_4_parameters/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_check_OpenSession_with_4_parameters.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_testingClientAPI/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_testingClientAPI/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_testingClientAPI.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_testingClientAPI/code_patches/v1_1_0_4-2014_11_07/TTA_testingClientAPI.c.patch
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_ClientAPI/TTA_testingClientAPI/code_patches/v1_1_0_4-2014_11_07/TTA_testingClientAPI.c.patch
@@ -1,0 +1,11 @@
+--- TTA_testingClientAPI.c.orig	2017-03-30 08:39:33.427602417 +0200
++++ TTA_testingClientAPI.c	2017-03-30 08:40:06.979413695 +0200
+@@ -66,7 +66,7 @@
+    SLogTrace("TA_DestroyEntryPoint");
+    
+    // release the memory allocated to the invoke structure
+-   TEE_Free(TEE_GetInstanceData());
++   TEE_Free((void *)TEE_GetInstanceData());
+ }
+ 
+ /**

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Crypto/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Crypto/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_Crypto.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Crypto/code_patches/v1_1_0_4-2014_11_07/TTA_Crypto.c.patch
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Crypto/code_patches/v1_1_0_4-2014_11_07/TTA_Crypto.c.patch
@@ -1,23 +1,83 @@
 --- TTA_Crypto.c.orig	2012-10-23 16:25:21.000000000 +0200
-+++ TTA_Crypto.c	2015-07-22 11:12:01.458463753 +0200
-@@ -154,7 +154,7 @@
++++ TTA_Crypto.c	2017-03-30 14:39:05.936589767 +0200
+@@ -123,7 +123,7 @@
+    SLogTrace("TA_CloseSessionEntryPoint");
+ 
+    /* Free the instance data - if not already freed via a call to CmdFreeAllKeysAndOperations */
+-   pCryptoData = TEE_GetInstanceData();
++   pCryptoData = (TEE_CryptoData *)TEE_GetInstanceData();
+ 
+    if(pCryptoData != NULL){
+       if(pCryptoData->Operation1 != TEE_HANDLE_NULL)
+@@ -154,9 +154,9 @@
  TEE_OperationHandle getOperation(uint32_t lopId)
  {
     TEE_CryptoData *pCryptoData;
 -   TEE_OperationHandle operation;
 +   TEE_OperationHandle operation = TEE_HANDLE_NULL;
     
-    pCryptoData = TEE_GetInstanceData();
+-   pCryptoData = TEE_GetInstanceData();
++   pCryptoData = (TEE_CryptoData *)TEE_GetInstanceData();
     if(lopId == 1)
-@@ -204,7 +204,7 @@
+       operation = (pCryptoData->Operation1);
+    else if(lopId == 2)
+@@ -173,7 +173,7 @@
+ {
+    TEE_CryptoData *pCryptoData;
+ 
+-   pCryptoData = TEE_GetInstanceData();
++   pCryptoData = (TEE_CryptoData *)TEE_GetInstanceData();
+ 
+    return pCryptoData->Attribute;
+ }
+@@ -182,7 +182,7 @@
+ {
+    TEE_CryptoData *pCryptoData;
+ 
+-   pCryptoData = TEE_GetInstanceData();
++   pCryptoData = (TEE_CryptoData *)TEE_GetInstanceData();
+ 
+    return pCryptoData->AttributeCount;
+ }
+@@ -191,7 +191,7 @@
+ {
+    TEE_CryptoData *pCryptoData;
+    
+-   pCryptoData = TEE_GetInstanceData();
++   pCryptoData = (TEE_CryptoData *)TEE_GetInstanceData();
+ 
+    if(lopId == 1)
+       (pCryptoData->Operation1) = TEE_HANDLE_NULL;
+@@ -204,9 +204,9 @@
  TEE_ObjectHandle getKey(uint32_t lkeyId)
  {
     TEE_CryptoData *pCryptoData;
 -   TEE_ObjectHandle key;
 +   TEE_ObjectHandle key = TEE_HANDLE_NULL;
     
-    pCryptoData = TEE_GetInstanceData();
+-   pCryptoData = TEE_GetInstanceData();
++   pCryptoData = (TEE_CryptoData *)TEE_GetInstanceData();
     if(lkeyId == 1)
+       key = (pCryptoData->Key1);
+    else if(lkeyId == 2)
+@@ -310,7 +310,7 @@
+    nObjectType = pParams[0].value.a;
+    nMaxObjectSize = pParams[0].value.b;
+    /* Retrieve the pointer to the structure */
+-   pCryptoData = TEE_GetInstanceData();
++   pCryptoData = (TEE_CryptoData *)TEE_GetInstanceData();
+    
+    SLogTrace("CmdInitObjectWithKeys: Before TEE_AllocateTransientObject object1");
+    if(pParams[3].value.a == 1)
+@@ -371,7 +371,7 @@
+    }
+    else
+    {  
+-      pCryptoData = TEE_GetInstanceData();
++      pCryptoData = (TEE_CryptoData *)TEE_GetInstanceData();
+       
+       if(pCryptoData->Operation1 != TEE_HANDLE_NULL){
+          TEE_FreeOperation((pCryptoData->Operation1));
 @@ -415,7 +415,7 @@
  {
     /* VARIABLES */
@@ -27,16 +87,18 @@
     
     /* CODE */
     if((TEE_PARAM_TYPE_GET(nParamTypes, 0) != TEE_PARAM_TYPE_VALUE_INPUT) &&         /* .a &.b : [in] algorithm & mode */
-@@ -430,7 +430,7 @@
+@@ -430,8 +430,8 @@
        SLogError("CmdAllocateOperation: operation id not correct");
        return TRUSTED_APP_ERROR_BAD_PARAMETERS;
     }
 -   
+-   pCryptoData = TEE_GetInstanceData();
 +
-    pCryptoData = TEE_GetInstanceData();
++   pCryptoData = (TEE_CryptoData *)TEE_GetInstanceData();
     if(pParams[3].value.a == 1)
        nTempResult = TEE_AllocateOperation(&pCryptoData->Operation1, pParams[0].value.a, pParams[0].value.b, pParams[1].value.a);
-@@ -699,6 +699,84 @@
+    else if(pParams[3].value.a == 2)
+@@ -699,6 +699,83 @@
  }
  
  /**
@@ -57,7 +119,6 @@
 +{
 +   /* VARIABLES */
 +   TEE_OperationHandle operation;
-+   TEE_OperationInfo operationInfo;
 +   TEE_OperationInfoMultiple *operationInfoMultiple;
 +   TEE_Result res;
 +   uint32_t key_num;
@@ -121,7 +182,25 @@
   *  Function CmdDigestUpdate:
   *  Description:
   *    The function is called with:
-@@ -1570,6 +1648,8 @@
+@@ -1422,7 +1499,7 @@
+    pAttribBufferFromClient = (uint8_t*)pParams[2].memref.buffer;
+    
+    /* Retrieve the pointer to the structure */
+-   pCryptoData = TEE_GetInstanceData();
++   pCryptoData = (TEE_CryptoData *)TEE_GetInstanceData();
+ 
+    /*****************************************************
+    *
+@@ -1486,7 +1563,7 @@
+    TEE_Attribute nAttribute;
+    TEE_OperationInfo nOperInfo;
+    unsigned char pDerivedKey[128];  /* 1024 bytes */
+-   size_t nDerivedKeyLen = sizeof(pDerivedKey);
++   uint32_t nDerivedKeyLen = sizeof(pDerivedKey);
+    TEE_Result nTempResult;
+ 
+    /* CODE */
+@@ -1570,6 +1647,8 @@
           return CmdSetOperationKey2(pSessionContext, nParamTypes, pParams);
        case CMD_CopyOperation:
           return CmdCopyOperation(pSessionContext, nParamTypes, pParams);

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_DS/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_DS/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_DS.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_DS/code_patches/v1_1_0_4-2014_11_07/TTA_DS.c.patch
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_DS/code_patches/v1_1_0_4-2014_11_07/TTA_DS.c.patch
@@ -1,5 +1,5 @@
---- TTA_DS.c.ori	2012-10-24 08:33:24.000000000 +0200
-+++ TTA_DS.c	2015-04-22 23:06:41.520077876 +0200
+--- TTA_DS.c.orig	2012-10-24 08:33:24.000000000 +0200
++++ TTA_DS.c	2017-03-30 14:45:57.674128382 +0200
 @@ -22,7 +22,7 @@
   *       - updated persistent object management when using TEE_DATA_FLAG_ACCESS_WRITE_META (exclusive access)
   *    18/09/2012 : v1.1
@@ -9,7 +9,25 @@
   *    24/09/2012 : v1.2
   *       - some persistent objects are not cleared after panics so they are now wipped clean during the open session.
   *    24/09/2012 : v1.3
-@@ -249,6 +249,8 @@
+@@ -153,7 +153,7 @@
+    SLogTrace("TA_CloseSessionEntryPoint");
+ }
+ 
+-bool isObjectInTable(char pObjectIDBuffer[], uint32_t nObjectIDBufferLen, char pObjectIDTable[MAX_NUMBER_OF_OBJECTS][TEE_OBJECT_ID_MAX_LEN], size_t pObjectIDLenTable[], uint32_t nObjectCount )
++bool isObjectInTable(char pObjectIDBuffer[], uint32_t nObjectIDBufferLen, char pObjectIDTable[MAX_NUMBER_OF_OBJECTS][TEE_OBJECT_ID_MAX_LEN], uint32_t pObjectIDLenTable[], uint32_t nObjectCount )
+ {
+    uint32_t i;
+ 
+@@ -181,7 +181,7 @@
+ {
+    /* VARIABLES */
+    uint8_t* pInitialData;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    TEE_ObjectHandle  nObject1 = (TEE_ObjectHandle)0xFFFFDEAD;
+    TEE_Result nTempResult;
+    uint32_t i;
+@@ -249,12 +249,14 @@
              init = INITIAL_DATA_BUFFER_SIZE;    /* to check that 00 are inserted in the stream */
           length = offset2 + buff_len;           /* to include the 00 in the out buffer */
           break;
@@ -18,6 +36,13 @@
     }
     *start = init;
     *len = length;
+ }
+ 
+-void objectWipeOut(char *pObjectID, size_t nObjectIDLen)
++void objectWipeOut(char *pObjectID, uint32_t nObjectIDLen)
+ {
+    TEE_Result nTempResult;
+    TEE_ObjectHandle  nObject1 = (TEE_ObjectHandle)0xFFFFDEAD;
 @@ -266,7 +268,7 @@
           &nObject1);
  
@@ -290,7 +315,7 @@
   *    - Param#1   : buffer of uint32_t that contains successively attributeID|buffer offset|length)
   *    - Param#2   : buffer containing all the key values one after the other
   *    - Param#3.a : option in the test for coverage
-@@ -686,8 +688,8 @@
+@@ -686,15 +688,15 @@
                       nobject_invalid = (TEE_ObjectHandle)0xFFFFDEAD,
                       nTargetObject = (TEE_ObjectHandle)0xFFFFDEAD;
     TEE_Result nTempResult;
@@ -300,7 +325,25 @@
 +   uint32_t *pAttrVector = NULL;
     uint32_t nAttribID, nAttribIDTemp;
     uint32_t nOffset;
-    size_t nLength;
+-   size_t nLength;
++   uint32_t nLength;
+    uint32_t i;
+    uint32_t nTestOption = 0;
+    void *pAttribBuffer;
+-   size_t nAttribBufferSize = 0;
++   uint32_t nAttribBufferSize = 0;
+    uint8_t *pAttribBufferFromClient;
+ 
+    char pObjectID[] = "objectPersistent";                /* for persistent object */
+@@ -752,7 +754,7 @@
+          {
+             nAttribID = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3));                /* retrieve all the data relevant for the attribute */
+             nOffset = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 1));
+-            nLength = (size_t)retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 2));
++            nLength = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 2));
+ 
+             if(nTestOption == CASE_INIT_ATTRIBUTE_PANIC)
+                nAttribID = nAttribID | 0x20000000;             /* creates an error in attributeID, describes a value --> panic */
 @@ -774,13 +776,13 @@
  
     /* Allocate a fresh transient object */
@@ -327,7 +370,15 @@
           return nTempResult;
        }
     }
-@@ -870,7 +872,7 @@
+@@ -863,14 +865,14 @@
+    {
+       nAttribIDTemp = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3));                /* retrieve all the data relevant for the attribute */
+       nOffset = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 1));
+-      nLength = (size_t)retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 2));
++      nLength = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 2));
+       nAttribBufferSize = BIG_ATTRIBUTE_BUFFER_SIZE;
+ 
+       switch(nTestOption)
        {
           case CASE_GET_OBJECT_BUFFER_ATTRIB_BIT28:
              /* force the object to protect its protected attributes */
@@ -372,6 +423,15 @@
           break;
     }
  
+@@ -986,7 +988,7 @@
+    {
+       nAttribIDTemp = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3));                /* retrieve all the data relevant for the attribute */
+       nOffset = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 1));
+-      nLength = (size_t)retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 2));
++      nLength = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 2));
+       nAttribBufferSize = BIG_ATTRIBUTE_BUFFER_SIZE;                                         /* set the buffer length to its max size */
+ 
+       nTargetObject = nobject2;
 @@ -1022,7 +1024,7 @@
   *  Function CmdGenerateKey:
   *  Description:
@@ -381,7 +441,7 @@
   *    - Param#1   : buffer of uint32_t that contains successively attributeID|buffer offset|length)
   *    - Param#2   : buffer containing all the key values one after the other
   *    - Param#3.a & .b : option in the test for coverage and GenerateKey keysize parameter
-@@ -1038,7 +1040,7 @@
+@@ -1038,11 +1040,11 @@
                       nobject2 = (TEE_ObjectHandle)0xFFFFDEAD,
                       nTargetObject = (TEE_ObjectHandle)0xFFFFDEAD;
     TEE_Result nTempResult;
@@ -390,6 +450,20 @@
     uint32_t *pAttrVector;
     uint32_t nAttribID;
     uint32_t nOffset;
+-   size_t nLength;
++   uint32_t nLength;
+    uint32_t i;
+    uint32_t nTestOption = 0, nKeySize = 0;
+    uint8_t *pAttribBufferFromClient;
+@@ -1097,7 +1099,7 @@
+          {
+             nAttribID = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3));                /* retrieve all the data relevant for the attribute */
+             nOffset = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 1));
+-            nLength = (size_t)retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 2));
++            nLength = retrieveUint32FromBuffer((char*)(pAttrVector + i * 3 + 2));
+ 
+             SLogTrace("CmdGenerateKey: Before TEE_InitRefAttribute");
+             TEE_InitRefAttribute(&pattrib[i], nAttribID, (void*)(pAttribBufferFromClient + nOffset), nLength);      /* initialize the attribute */
 @@ -1106,9 +1108,9 @@
     }
     /* Allocate a fresh transient object */
@@ -411,6 +485,15 @@
  
     TEE_FreeTransientObject(nobject1);
     return nTempResult;
+@@ -1173,7 +1175,7 @@
+    uint32_t nObjectID1Size = 7;
+    uint32_t nTargetObjectIDSize;
+    uint32_t i;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    TEE_ObjectHandle  nObject1 = (TEE_ObjectHandle)0xFFFFDEAD,
+                      nObjectAttribute = (TEE_ObjectHandle)0xFFFFDEAD;
+    TEE_Result nTempResult;
 @@ -1228,7 +1230,7 @@
                             &nObject1);
  
@@ -420,6 +503,15 @@
  
     TEE_Free(pInitialData);
     return nTempResult;
+@@ -1250,7 +1252,7 @@
+    char pObjectID[] = "object1";
+    uint32_t nObjectIDSize = 7;
+    uint8_t* pInitialData;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    TEE_ObjectHandle nObject1 = (TEE_ObjectHandle)0xFFFFDEAD;
+    TEE_Result nTempResult;
+    uint32_t i;
 @@ -1273,7 +1275,7 @@
           &nObject1);
  
@@ -429,6 +521,15 @@
  
     TEE_Free(pInitialData);
  
+@@ -1291,7 +1293,7 @@
+    uint8_t* pInitialData;
+    uint32_t nObjectIDSize = 7;
+    uint32_t i;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    TEE_ObjectHandle  nObject1 = (TEE_ObjectHandle)0xFFFFDEAD,
+                      nObject2 = (TEE_ObjectHandle)0xFFFFDEAD;
+    TEE_Result nTempResult;
 @@ -1304,8 +1306,8 @@
     /* CODE */
     for(i = 0; i < INITIAL_DATA_BUFFER_SIZE; i++)
@@ -452,6 +553,15 @@
  
     TEE_Free(pInitialData);
  
+@@ -1344,7 +1346,7 @@
+    char pObjectID[] = "object1";
+    uint32_t nObjectIDSize = 7;
+    uint8_t* pInitialData;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    TEE_ObjectHandle  nObject1 = (TEE_ObjectHandle)0xFFFFDEAD,
+                      nObject2 = (TEE_ObjectHandle)0xFFFFDEAD;
+    TEE_Result nTempResult, nTempResult2;
 @@ -1400,7 +1402,7 @@
        if(nTempResult2 != TEE_SUCCESS)
              return nTempResult;                 /* if there was an error when opening the object */
@@ -461,6 +571,15 @@
     }
  
     pInitialData = TEE_Malloc(INITIAL_DATA_BUFFER_SIZE, 0);
+@@ -1450,7 +1452,7 @@
+    uint32_t nObjectID2Size = 7;
+    uint32_t i;
+    uint8_t* pInitialData;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    TEE_ObjectHandle  nObject1 = (TEE_ObjectHandle)0xFFFFDEAD,
+                      nObject2 = (TEE_ObjectHandle)0xFFFFDEAD;
+    TEE_Result nTempResult;
 @@ -1501,7 +1503,7 @@
           return TEE_ERROR_GENERIC;
     }
@@ -470,6 +589,15 @@
  
     TEE_Free(pInitialData);
  
+@@ -1518,7 +1520,7 @@
+    char pObjectID1[] = "object1";
+    uint32_t nObjectID1Size = 7;
+    uint8_t* pInitialData;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    TEE_ObjectHandle  nObject1 = (TEE_ObjectHandle)0xFFFFDEAD,
+                      nObject2 = (TEE_ObjectHandle)0xFFFFDEAD;
+    TEE_Result nTempResult, nTempResult2;
 @@ -1599,7 +1601,7 @@
           &nObject1);
     if(nTempResult2 != TEE_SUCCESS)
@@ -479,6 +607,15 @@
  
     TEE_Free(pInitialData);
  
+@@ -1622,7 +1624,7 @@
+    uint32_t nObjectID3Size = 16;
+    uint32_t nTargetObjectIDSize;
+    uint8_t* pInitialData;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    TEE_ObjectHandle  nObject1 = (TEE_ObjectHandle)0xFFFFDEAD,
+                      nObject2 = (TEE_ObjectHandle)0xFFFFDEAD,
+                      nTargetObject = (TEE_ObjectHandle)0xFFFFDEAD;
 @@ -1681,7 +1683,7 @@
                                (void*) pObjectID1, nObjectID1Size,
                                TEE_DATA_FLAG_ACCESS_WRITE_META,
@@ -488,6 +625,15 @@
  
     TEE_Free(pInitialData);
  
+@@ -1700,7 +1702,7 @@
+    char pObjectID2[] = "object2";
+    uint32_t nObjectID2Size = 7;
+    uint8_t* pInitialData;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    TEE_ObjectHandle  nObject1 = (TEE_ObjectHandle)0xFFFFDEAD,
+                      nObject2 = (TEE_ObjectHandle)0xFFFFDEAD;
+    TEE_Result nTempResult;
 @@ -1740,15 +1742,15 @@
  
     if(nTempResult != TEE_SUCCESS)
@@ -507,6 +653,15 @@
  
     TEE_Free(pInitialData);
  
+@@ -1767,7 +1769,7 @@
+    uint32_t nObjectID1Size = 7;
+    uint32_t nObjectID2Size = 16;
+    uint8_t* pInitialData;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    TEE_ObjectHandle nObject1 = (TEE_ObjectHandle)0xFFFFDEAD;
+    TEE_Result nTempResult;
+    uint32_t i;
 @@ -1799,7 +1801,7 @@
     /* rename the object */
     nTempResult = TEE_RenamePersistentObject(nObject1, (void*)pObjectID2, nObjectID2Size);
@@ -516,6 +671,21 @@
  
     TEE_Free(pInitialData);
  
+@@ -1820,11 +1822,11 @@
+    uint32_t nObjectID2Size = 16;
+    uint32_t nObjectID3Size = 8;
+    uint8_t* pInitialData;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    char pObjectIDTable[MAX_NUMBER_OF_OBJECTS][TEE_OBJECT_ID_MAX_LEN];
+-   size_t nObjectIDLenTable[MAX_NUMBER_OF_OBJECTS];
++   uint32_t nObjectIDLenTable[MAX_NUMBER_OF_OBJECTS];
+    char pObjectIDBuffer[TEE_OBJECT_ID_MAX_LEN];
+-   size_t nObjectIDBufferLen = TEE_OBJECT_ID_MAX_LEN;
++   uint32_t nObjectIDBufferLen = TEE_OBJECT_ID_MAX_LEN;
+    TEE_ObjectHandle  nObject1 = (TEE_ObjectHandle)0xFFFFDEAD,
+                      nObject2 = (TEE_ObjectHandle)0xFFFFDEAD,
+                      nObject3 = (TEE_ObjectHandle)0xFFFFDEAD;
 @@ -1902,7 +1904,7 @@
  
     if(nTempResult != TEE_SUCCESS)
@@ -549,6 +719,15 @@
  
    TEE_Free(pInitialData);
  
+@@ -1970,7 +1972,7 @@
+    char pObjectID1[] = "object1";
+    uint32_t nObjectID1Size = 7, i;
+    uint8_t* pInitialData;
+-   size_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
++   uint32_t nInitialDataLen = INITIAL_DATA_BUFFER_SIZE;
+    /* if we leave nObject1 unitialized, a compiler may zero-initialize it in which case the TEE will (correctly) not panic as it equal to a TEE_HANDLE_NULL */
+    TEE_ObjectHandle nObject1 = (TEE_ObjectHandle)0xFFFFDEAD;
+    TEE_Result nTempResult;
 @@ -1988,7 +1990,7 @@
     }
  
@@ -576,15 +755,36 @@
  
     return TEE_SUCCESS;
  }
-@@ -2166,7 +2168,7 @@
+@@ -2084,7 +2086,7 @@
+    TEE_ObjectEnumHandle nObjectEnumerator = (TEE_ObjectEnumHandle)0xFFFFDEAD;
+    TEE_ObjectInfo nObjectInfo;
+    char pObjectID1[TEE_OBJECT_ID_MAX_LEN];
+-   size_t nObjectID1Size = 0;
++   uint32_t nObjectID1Size = 0;
+ 
+    /* CODE */
+    TEE_GetNextPersistentObject(nObjectEnumerator, &nObjectInfo, pObjectID1, &nObjectID1Size);
+@@ -2101,7 +2103,7 @@
+    TEE_ObjectEnumHandle nObjectEnumerator;
+    TEE_ObjectInfo nObjectInfo;
+    char pObjectID1[TEE_OBJECT_ID_MAX_LEN];
+-   size_t nObjectID1Size = 0;
++   uint32_t nObjectID1Size = 0;
+    TEE_Result nTempResult;
+ 
+    /* CODE */
+@@ -2166,9 +2168,9 @@
  {
     /* VARIABLES */
     TEE_ObjectHandle pobject = (TEE_ObjectHandle)0xFFFFDEAD;
 -   uint32_t nObjectType, nMaxObjectSize;
 +   uint32_t nObjectType, nMaxKeySize;
     void* pBuffer;
-    size_t nBufferSize = BIG_ATTRIBUTE_BUFFER_SIZE;
+-   size_t nBufferSize = BIG_ATTRIBUTE_BUFFER_SIZE;
++   uint32_t nBufferSize = BIG_ATTRIBUTE_BUFFER_SIZE;
     TEE_Result nTempResult;
+ 
+    pBuffer = TEE_Malloc(BIG_ATTRIBUTE_BUFFER_SIZE, 0);
 @@ -2176,16 +2178,16 @@
  	return TRUSTED_APP_ERROR_MALLOC_FAILED;
  

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_DS/code_patches/v1_1_0_4-2014_11_07/TTA_DS_protocol.h.patch
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_DS/code_patches/v1_1_0_4-2014_11_07/TTA_DS_protocol.h.patch
@@ -1,5 +1,5 @@
---- TTA_DS_protocol.h.ori	2015-02-02 14:09:02.722617469 +0100
-+++ TTA_DS_protocol.h	2015-02-02 14:09:21.962746491 +0100
+--- TTA_DS_protocol.h.orig	2012-10-24 08:31:00.000000000 +0200
++++ TTA_DS_protocol.h	2017-03-30 14:46:56.057776854 +0200
 @@ -1,6 +1,6 @@
  
  /** Trusted Application Identifier **/
@@ -8,3 +8,21 @@
  
  #define TRUSTED_APP_ERROR_UNKNOWN_COMMAND                            0x00000001
  #define TRUSTED_APP_ERROR_BAD_PARAMETERS                             0x00000002
+@@ -98,7 +98,7 @@
+    char pObjectIDBuffer[], 
+    uint32_t nObjectIDBufferLen, 
+    char pObjectIDTable[MAX_NUMBER_OF_OBJECTS][TEE_OBJECT_ID_MAX_LEN], 
+-   size_t pObjectIDLenTable[], 
++   uint32_t pObjectIDLenTable[], 
+    uint32_t nObjectCount );
+ uint32_t retrieveUint32FromBuffer(char buffer[]);
+ TEE_ObjectHandle createPersistentObject_SetAccess(void *pObjectID, uint32_t nObjectIDSize, TEE_ObjectHandle  nObjectOrigin, uint32_t nFlags);
+@@ -109,7 +109,7 @@
+                         uint32_t buff_len,   /* size of the buffer to write to the stream */
+                         uint32_t* start,     /* output start offset */
+                         uint32_t* len);      /* length of what to read */
+-void objectWipeOut(char *pObjectID, size_t nObjectIDLen);
++void objectWipeOut(char *pObjectID, uint32_t nObjectIDLen);
+ TEE_Result CmdAllocateTransientChain(
+    void*       pSessionContext,
+    uint32_t    nParamTypes,

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_TCF.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter -Wno-int-to-pointer-cast

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF/code_patches/v1_1_0_4-2014_11_07/TTA_TCF.c.patch
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF/code_patches/v1_1_0_4-2014_11_07/TTA_TCF.c.patch
@@ -1,0 +1,56 @@
+--- TTA_TCF.c.orig	2017-03-30 15:07:39.953742721 +0200
++++ TTA_TCF.c	2017-03-30 15:06:40.266121485 +0200
+@@ -66,7 +66,7 @@
+ #include "tee_internal_api.h"
+ #include "TTA_TCF.h"
+ #include "TTA_TCF_common_protocol.h"
+-
++#include <assert.h>
+ 
+ /* ----------------------------------------------------------------------------
+  *   Trusted Application Entry Points
+@@ -190,7 +190,7 @@
+    return true;   // Identities are identical
+ }
+ 
+-bool areBinaryBlocksIdentical(const char *BinaryBlock1, size_t nLength1, const char *BinaryBlock2, size_t nLength2) // returns false if not identical, true otherwise
++bool areBinaryBlocksIdentical(const char *BinaryBlock1, uint32_t nLength1, const char *BinaryBlock2, uint32_t nLength2) // returns false if not identical, true otherwise
+ {
+    uint32_t i = 0;
+ 
+@@ -589,10 +589,10 @@
+    TEE_PropSetHandle nEnum;
+    TEE_PropSetHandle nPropSet;
+    char pPropName[PROPERTY_NAME_MAX_SIZE];
+-   size_t nPropNameSize = 0;
++   uint32_t nPropNameSize = 0;
+    char pOutputString1[PROPERTY_OUTPUT_STRING_MAX_SIZE], pOutputString2[PROPERTY_OUTPUT_STRING_MAX_SIZE];
+-   size_t nOutputString1Length = 0;
+-   size_t nOutputString2Length = 0;
++   uint32_t nOutputString1Length = 0;
++   uint32_t nOutputString2Length = 0;
+    bool nOutputBool1;
+    bool nOutputBool2;
+    uint32_t nOutputInt1;
+@@ -694,6 +694,7 @@
+ {
+    /** VARIABLES **/
+    TEE_Result cmdResult;
++   TEE_PropSetHandle nPropSet;
+ 
+    /** CODE **/
+    if (TEE_PARAM_TYPE_GET(nParamTypes, 0) != TEE_PARAM_TYPE_VALUE_OUTPUT)
+@@ -705,8 +706,11 @@
+    /* Read the output parameters */
+ 
+    /* if output data is correct */
+-   cmdResult = TEE_AllocatePropertyEnumerator((TEE_PropSetHandle*) &pParams[0].value.a);
+-
++   cmdResult = TEE_AllocatePropertyEnumerator(&nPropSet);
++#ifdef __LP64__
++   assert(!((uintptr_t)nPropSet >> 32));
++#endif
++   pParams[0].value.a = (uint32_t)(uintptr_t)nPropSet;
+    return cmdResult;
+ }
+ 

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF/code_patches/v1_1_0_4-2014_11_07/TTA_TCF.h.patch
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF/code_patches/v1_1_0_4-2014_11_07/TTA_TCF.h.patch
@@ -1,5 +1,5 @@
---- TTA_TCF.h.ori	2015-02-02 14:15:06.009054399 +0100
-+++ TTA_TCF.h	2015-02-02 14:20:46.799347192 +0100
+--- TTA_TCF.h.orig	2012-08-27 13:25:22.000000000 +0200
++++ TTA_TCF.h	2017-03-30 14:55:14.526597597 +0200
 @@ -46,10 +46,12 @@
  };
  
@@ -8,7 +8,8 @@
  bool areStringsIdentical(const char *string1, const char *string2);
  bool areUUIDsIdentical(TEE_UUID *UUID1, TEE_UUID *UUID2);
  bool areIdentitiesIdentical(TEE_Identity *Identity1, TEE_Identity *Identity2);
- bool areBinaryBlocksIdentical(const char *BinaryBlock1, size_t nLength1, const char *BinaryBlock2, size_t nLength2);
+-bool areBinaryBlocksIdentical(const char *BinaryBlock1, size_t nLength1, const char *BinaryBlock2, size_t nLength2);
++bool areBinaryBlocksIdentical(const char *BinaryBlock1, uint32_t nLength1, const char *BinaryBlock2, uint32_t nLength2);
 +void getUUIDFromBuffer(TEE_UUID *pTargetUUID, char uuidvalue[16]);
  enum propType getPropertyType(char *propString);
  TEE_Result CmdTEEGetPropertyAsString_withoutEnum(

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_ICA/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_ICA/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_TCF_ICA.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_ICA2/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_ICA2/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_TCF_ICA2.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_MultipleInstanceTA/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_MultipleInstanceTA/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_TCF_MultipleInstanceTA.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_SingleInstanceTA/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_TCF/TTA_TCF_SingleInstanceTA/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y += TTA_TCF_SingleInstanceTA.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Time/code_files/sub.mk
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/TTAs/TTA_Time/code_files/sub.mk
@@ -1,3 +1,2 @@
-global-incdirs-y += include
 srcs-y +=TTA_Time.c
-cflags-y := -include ../include/GP_defs.h
+cflags-y := -include ../include/GP_defs.h -Wno-unused-parameter

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/packages/ClientAPI/xslstable/TEE.xsl
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/packages/ClientAPI/xslstable/TEE.xsl
@@ -209,6 +209,8 @@ ADBG_CASE_DEFINE(regression, <xsl:value-of select="$position" />, xtest_tee_<xsl
 </xsl:when>
 <xsl:when test="(../type/@name='ALL_TEE_NAMES' and ./@name='NULL')"><xsl:text>_device</xsl:text>
 </xsl:when>
+<xsl:when test="(../type/@name='ALL_RETURN_ORIGINS' and ./@name='NULL')"><xsl:text>0</xsl:text>
+</xsl:when>
 <xsl:otherwise>
 <!--xsl:text>&amp;</xsl:text--><xsl:value-of select="./@name" />
 </xsl:otherwise>

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/packages/Crypto/xslstable/TEE_Crypto_API.xsl
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/packages/Crypto/xslstable/TEE_Crypto_API.xsl
@@ -312,6 +312,8 @@ ADBG_CASE_DEFINE(regression, <xsl:value-of select="$position" />, xtest_tee_<xsl
 </xsl:when>
 <xsl:when test="(../type/@name='ALL_TEE_NAMES' and ./@name='NULL')"><xsl:text>_device</xsl:text>
 </xsl:when>
+<xsl:when test="(../type/@name='ALL_RETURN_ORIGINS' and ./@name='NULL')"><xsl:text>0</xsl:text>
+</xsl:when>
 <xsl:otherwise>
 <!--xsl:text>&amp;</xsl:text--><xsl:value-of select="./@name" />
 </xsl:otherwise>

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/packages/DataStorage/xslstable/TEE_DataStorage_API.xsl
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/packages/DataStorage/xslstable/TEE_DataStorage_API.xsl
@@ -231,6 +231,8 @@ ADBG_CASE_DEFINE(regression, <xsl:value-of select="$position" />, xtest_tee_<xsl
 </xsl:when>
 <xsl:when test="(../type/@name='ALL_TEE_NAMES' and ./@name='NULL')"><xsl:text>_device</xsl:text>
 </xsl:when>
+<xsl:when test="(../type/@name='ALL_RETURN_ORIGINS' and ./@name='NULL')"><xsl:text>0</xsl:text>
+</xsl:when>
 <xsl:otherwise>
 <!--xsl:text>&amp;</xsl:text--><xsl:value-of select="./@name" />
 </xsl:otherwise>

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/packages/Time_Arithmetical/xslstable/TEE_TimeArithm_API.xsl
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/packages/Time_Arithmetical/xslstable/TEE_TimeArithm_API.xsl
@@ -215,6 +215,8 @@ ADBG_CASE_DEFINE(regression, <xsl:value-of select="$position" />, xtest_tee_<xsl
 </xsl:when>
 <xsl:when test="(../type/@name='ALL_TEE_NAMES' and ./@name='NULL')"><xsl:text>_device</xsl:text>
 </xsl:when>
+<xsl:when test="(../type/@name='ALL_RETURN_ORIGINS' and ./@name='NULL')"><xsl:text>0</xsl:text>
+</xsl:when>
 <xsl:otherwise>
 <!--xsl:text>&amp;</xsl:text--><xsl:value-of select="./@name" />
 </xsl:otherwise>

--- a/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/packages/TrustedCoreFw/xslstable/TEE_Internal_API.xsl
+++ b/package/testsuite/global_platform/api_1.0/GP_XSL_TEE_Initial_Configuration-Test_Suite_v1_0_0-2014-12-03-STM/packages/TrustedCoreFw/xslstable/TEE_Internal_API.xsl
@@ -207,6 +207,8 @@ ADBG_CASE_DEFINE(regression, <xsl:value-of select="$position" />, xtest_tee_<xsl
 </xsl:when>
 <xsl:when test="(../type/@name='ALL_TEE_NAMES' and ./@name='NULL')"><xsl:text>_device</xsl:text>
 </xsl:when>
+<xsl:when test="(../type/@name='ALL_RETURN_ORIGINS' and ./@name='NULL')"><xsl:text>0</xsl:text>
+</xsl:when>
 <xsl:otherwise>
 <!--xsl:text>&amp;</xsl:text--><xsl:value-of select="./@name" />
 </xsl:otherwise>


### PR DESCRIPTION
When the GlobalPlatform test suite is enabled, the build produces
*tons* of warnings. The build also prints some useless messages and
is silent on many operations.

This patch improves the situation by doing the following:
- Fix all the compiler warnings I found with GCC 4.9 (32- and 64-bit
  builds, for both TAs and xtest). Unused parameters, use of size_t
  when uint32_t is expected, constness of the TEE_GetInstanceData()
  parameter, copying a (64-bit) handle into a 32-bit value
  (params[x].value.a) and possibly a few others I don't remember.
- Remove "INFO:" messages
- Use the Kbuild format ("  OPER    path/to/target/file") to trace
  most build steps
Some more cleanup is required to avoid rebuilding stuff each time,
but that can be addressed later.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>