### PR TITLE
regression 6018: reduce the number of blocks written

### DIFF
--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -1713,7 +1713,7 @@ static void xtest_tee_test_6018_single(ADBG_Case_t *c, uint32_t storage_id)
 
 	if (storage_is(storage_id, TEE_STORAGE_PRIVATE_RPMB)) {
 		/* RPMB FS is a bit resource constrained */
-		num_blocks = 20;
+		num_blocks = 10;
 		block_size = 1024;
 	} else {
 		num_blocks = 40;


### PR DESCRIPTION
Reduces the number of blocks written when testing RPMB filesystem to
avoid occasional out of memory errors.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>