### PR TITLE
xtest: case TEEC_CONFIG_SHAREDMEM_MAX_SIZE == ULONG_MAX

### DIFF
--- a/host/xtest/regression_5000.c
+++ b/host/xtest/regression_5000.c
@@ -68,6 +68,12 @@ struct xtest_session {
 		} \
 	} while (0)
 
+/* Maximal value to be tested on TEEC_CONFIG_SHAREDMEM_MAX_SIZE tests: 512kB */
+#define TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE	0x80000
+#ifndef MIN
+#define MIN(a, b)		((a) < (b) ? (a) : (b))
+#endif
+
 /* Initiates the memory and allocates size uint32_t. */
 
 /* Registers the TEEC_SharedMemory to the TEE. */
@@ -428,11 +434,8 @@ out:
 
 static void Allocate_sharedMemory_maxSize(struct xtest_session *cs)
 {
-	uint32_t size_max = TEEC_CONFIG_SHAREDMEM_MAX_SIZE;
-
-	/* TEE Client API  v1.0: shall be at least 512kB */
-	if (size_max == ULONG_MAX)
-		size_max = 0x80000;
+	uint32_t size_max = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
+				TEEC_CONFIG_SHAREDMEM_MAX_SIZE);
 
 	Do_ADBG_BeginSubCase(cs->c,
 			     "Allocate_sharedMemory_MaxSize_Above_and_Below, allocate max size");
@@ -459,11 +462,8 @@ out:
 
 static void Allocate_sharedMemory_belowMaxSize(struct xtest_session *cs)
 {
-	unsigned long long size_below = TEEC_CONFIG_SHAREDMEM_MAX_SIZE - 1;
-
-	/* TEE Client API  v1.0: shall be at least 512kB */
-	if (size_below == ULONG_MAX - 1)
-		size_below = 0x80000;
+	uint32_t size_below = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
+				  TEEC_CONFIG_SHAREDMEM_MAX_SIZE) - 1;
 
 	Do_ADBG_BeginSubCase(cs->c,
 			     "Allocate_sharedMemory_MaxSize_Above_and_Below, "
@@ -492,12 +492,8 @@ out:
 
 static void Allocate_sharedMemory_aboveMaxSize(struct xtest_session *cs)
 {
-	unsigned long long size_above = TEEC_CONFIG_SHAREDMEM_MAX_SIZE;
-
-	if (size_above == ULONG_MAX)
-		return;
-
-	size_above++;
+	uint32_t size_above = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
+				  TEEC_CONFIG_SHAREDMEM_MAX_SIZE) + 1;
 
 	Do_ADBG_BeginSubCase(cs->c,
 			     "Allocate_sharedMemory_MaxSize_Above_and_Below, "
@@ -528,11 +524,8 @@ out:
 
 static void Register_sharedMemory_maxSize(struct xtest_session *cs)
 {
-	unsigned long long size_max = TEEC_CONFIG_SHAREDMEM_MAX_SIZE;
-
-	/* TEE Client API  v1.0: shall be at least 512kB */
-	if (size_max == ULONG_MAX)
-		size_max = 0x80000;
+	uint32_t size_max = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
+				TEEC_CONFIG_SHAREDMEM_MAX_SIZE);
 
 	Do_ADBG_BeginSubCase(cs->c, "Register_sharedMemory_maxSize");
 	{
@@ -562,7 +555,7 @@ static void Register_sharedMemory_aboveMaxSize(struct xtest_session *cs)
 	Do_ADBG_BeginSubCase(cs->c, "Register_sharedMemory_aboveMaxSize");
 	{
 		TEEC_Result res;
-		uint32_t size_aboveMax = 0xffffffff;
+		uint32_t size_aboveMax = UINT32_MAX;
 		uint8_t val[1];
 		TEEC_SharedMemory shm;
 
@@ -587,11 +580,8 @@ out:
 
 static void Register_sharedMemory_belowMaxSize(struct xtest_session *cs)
 {
-	unsigned long long size_belowMax = TEEC_CONFIG_SHAREDMEM_MAX_SIZE - 1;
-
-	/* TEE Client API  v1.0: shall be at least 512kB */
-	if (size_belowMax == ULONG_MAX - 1)
-		size_belowMax = 0x80000;
+	uint32_t size_belowMax = MIN(TEEC_CONFIG_SHAREDMEM_MAX_SIZE,
+			     TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE) - 1;
 
 	Do_ADBG_BeginSubCase(cs->c, "Register_sharedMemory_belowMaxSize");
 	{

--- a/host/xtest/regression_5000.c
+++ b/host/xtest/regression_5000.c
@@ -428,10 +428,14 @@ out:
 
 static void Allocate_sharedMemory_maxSize(struct xtest_session *cs)
 {
+	uint32_t size_max = TEEC_CONFIG_SHAREDMEM_MAX_SIZE;
+
+	if (size_max == ULONG_MAX)
+		return;
+
 	Do_ADBG_BeginSubCase(cs->c,
 			     "Allocate_sharedMemory_MaxSize_Above_and_Below, allocate max size");
 	{
-		uint32_t size_max = TEEC_CONFIG_SHAREDMEM_MAX_SIZE;
 		TEEC_SharedMemory shm;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
@@ -454,12 +458,16 @@ out:
 
 static void Allocate_sharedMemory_belowMaxSize(struct xtest_session *cs)
 {
+	unsigned long long size_below = TEEC_CONFIG_SHAREDMEM_MAX_SIZE - 1;
+
+	if (size_below == ULONG_MAX - 1)
+		return;
+
 	Do_ADBG_BeginSubCase(cs->c,
 			     "Allocate_sharedMemory_MaxSize_Above_and_Below, "
 			     "allocate just below max size");
 	{
 		TEEC_SharedMemory shm;
-		uint32_t size_below = TEEC_CONFIG_SHAREDMEM_MAX_SIZE - 1;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -482,13 +490,17 @@ out:
 
 static void Allocate_sharedMemory_aboveMaxSize(struct xtest_session *cs)
 {
+	unsigned long long size_above = TEEC_CONFIG_SHAREDMEM_MAX_SIZE + 1;
+
+	if (size_above == ULONG_MAX - 1)
+		return;
+
 	Do_ADBG_BeginSubCase(cs->c,
 			     "Allocate_sharedMemory_MaxSize_Above_and_Below, "
 			     "allocate just above max size");
 	{
 		TEEC_Result res;
 		TEEC_SharedMemory shm;
-		uint32_t size_above = TEEC_CONFIG_SHAREDMEM_MAX_SIZE + 1;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -512,9 +524,13 @@ out:
 
 static void Register_sharedMemory_maxSize(struct xtest_session *cs)
 {
+	unsigned long long size_max = TEEC_CONFIG_SHAREDMEM_MAX_SIZE;
+
+	if (size_max == ULONG_MAX)
+		return;
+
 	Do_ADBG_BeginSubCase(cs->c, "Register_sharedMemory_maxSize");
 	{
-		uint32_t size_max = TEEC_CONFIG_SHAREDMEM_MAX_SIZE;
 		uint8_t val[size_max];
 		TEEC_SharedMemory shm;
 
@@ -566,9 +582,13 @@ out:
 
 static void Register_sharedMemory_belowMaxSize(struct xtest_session *cs)
 {
+	unsigned long long size_belowMax = TEEC_CONFIG_SHAREDMEM_MAX_SIZE - 1;
+
+	if (size_belowMax == ULONG_MAX - 1)
+		return;
+
 	Do_ADBG_BeginSubCase(cs->c, "Register_sharedMemory_belowMaxSize");
 	{
-		uint32_t size_belowMax = TEEC_CONFIG_SHAREDMEM_MAX_SIZE - 1;
 		uint8_t val[size_belowMax];
 		TEEC_SharedMemory shm;
 

--- a/host/xtest/regression_5000.c
+++ b/host/xtest/regression_5000.c
@@ -430,8 +430,9 @@ static void Allocate_sharedMemory_maxSize(struct xtest_session *cs)
 {
 	uint32_t size_max = TEEC_CONFIG_SHAREDMEM_MAX_SIZE;
 
+	/* TEE Client API  v1.0: shall be at least 512kB */
 	if (size_max == ULONG_MAX)
-		return;
+		size_max = 0x80000;
 
 	Do_ADBG_BeginSubCase(cs->c,
 			     "Allocate_sharedMemory_MaxSize_Above_and_Below, allocate max size");
@@ -460,8 +461,9 @@ static void Allocate_sharedMemory_belowMaxSize(struct xtest_session *cs)
 {
 	unsigned long long size_below = TEEC_CONFIG_SHAREDMEM_MAX_SIZE - 1;
 
+	/* TEE Client API  v1.0: shall be at least 512kB */
 	if (size_below == ULONG_MAX - 1)
-		return;
+		size_below = 0x80000;
 
 	Do_ADBG_BeginSubCase(cs->c,
 			     "Allocate_sharedMemory_MaxSize_Above_and_Below, "
@@ -490,10 +492,12 @@ out:
 
 static void Allocate_sharedMemory_aboveMaxSize(struct xtest_session *cs)
 {
-	unsigned long long size_above = TEEC_CONFIG_SHAREDMEM_MAX_SIZE + 1;
+	unsigned long long size_above = TEEC_CONFIG_SHAREDMEM_MAX_SIZE;
 
-	if (size_above == ULONG_MAX - 1)
+	if (size_above == ULONG_MAX)
 		return;
+
+	size_above++;
 
 	Do_ADBG_BeginSubCase(cs->c,
 			     "Allocate_sharedMemory_MaxSize_Above_and_Below, "
@@ -526,8 +530,9 @@ static void Register_sharedMemory_maxSize(struct xtest_session *cs)
 {
 	unsigned long long size_max = TEEC_CONFIG_SHAREDMEM_MAX_SIZE;
 
+	/* TEE Client API  v1.0: shall be at least 512kB */
 	if (size_max == ULONG_MAX)
-		return;
+		size_max = 0x80000;
 
 	Do_ADBG_BeginSubCase(cs->c, "Register_sharedMemory_maxSize");
 	{
@@ -584,8 +589,9 @@ static void Register_sharedMemory_belowMaxSize(struct xtest_session *cs)
 {
 	unsigned long long size_belowMax = TEEC_CONFIG_SHAREDMEM_MAX_SIZE - 1;
 
+	/* TEE Client API  v1.0: shall be at least 512kB */
 	if (size_belowMax == ULONG_MAX - 1)
-		return;
+		size_belowMax = 0x80000;
 
 	Do_ADBG_BeginSubCase(cs->c, "Register_sharedMemory_belowMaxSize");
 	{

--- a/host/xtest/regression_5000.c
+++ b/host/xtest/regression_5000.c
@@ -78,7 +78,7 @@ struct xtest_session {
 
 /* Registers the TEEC_SharedMemory to the TEE. */
 static TEEC_Result RegisterSharedMemory(TEEC_Context *ctx,
-					TEEC_SharedMemory *shm, uint32_t size,
+					TEEC_SharedMemory *shm, size_t size,
 					uint32_t flags)
 {
 	shm->flags = flags;
@@ -88,7 +88,7 @@ static TEEC_Result RegisterSharedMemory(TEEC_Context *ctx,
 
 /* Allocates shared memory inside of the TEE. */
 static TEEC_Result AllocateSharedMemory(TEEC_Context *ctx,
-					TEEC_SharedMemory *shm, uint32_t size,
+					TEEC_SharedMemory *shm, size_t size,
 					uint32_t flags)
 {
 	shm->flags = flags;
@@ -111,7 +111,7 @@ static void Allocate_In(struct xtest_session *cs)
 	Do_ADBG_BeginSubCase(cs->c, "Allocate_In");
 	{
 		TEEC_SharedMemory shm;
-		uint32_t size = 1024;
+		size_t size = 1024;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -135,7 +135,7 @@ static void Allocate_out_of_memory(struct xtest_session *cs)
 	Do_ADBG_BeginSubCase(cs->c, "Allocate_out_of_memory");
 	{
 		TEEC_SharedMemory shm;
-		uint32_t SIZE_OVER_MEMORY_CAPACITY = INT32_MAX;
+		size_t SIZE_OVER_MEMORY_CAPACITY = INT32_MAX;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -352,7 +352,7 @@ static void AllocateThenRegister_SameMemory(struct xtest_session *cs)
 	Do_ADBG_BeginSubCase(cs->c, "AllocateThenRegister_SameMemory");
 	{
 		TEEC_SharedMemory shm;
-		uint32_t size_allocation = 32;
+		size_t size_allocation = 32;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -380,7 +380,7 @@ static void AllocateSameMemory_twice(struct xtest_session *cs)
 	Do_ADBG_BeginSubCase(cs->c, "AllocateSameMemory_twice");
 	{
 		TEEC_SharedMemory shm;
-		uint32_t size_allocation = 32;
+		size_t size_allocation = 32;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -434,7 +434,7 @@ out:
 
 static void Allocate_sharedMemory_maxSize(struct xtest_session *cs)
 {
-	uint32_t size_max = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
+	size_t size_max = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
 				TEEC_CONFIG_SHAREDMEM_MAX_SIZE);
 
 	Do_ADBG_BeginSubCase(cs->c,
@@ -462,7 +462,7 @@ out:
 
 static void Allocate_sharedMemory_belowMaxSize(struct xtest_session *cs)
 {
-	uint32_t size_below = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
+	size_t size_below = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
 				  TEEC_CONFIG_SHAREDMEM_MAX_SIZE) - 1;
 
 	Do_ADBG_BeginSubCase(cs->c,
@@ -492,7 +492,7 @@ out:
 
 static void Allocate_sharedMemory_aboveMaxSize(struct xtest_session *cs)
 {
-	uint32_t size_above = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
+	size_t size_above = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
 				  TEEC_CONFIG_SHAREDMEM_MAX_SIZE) + 1;
 
 	Do_ADBG_BeginSubCase(cs->c,
@@ -524,7 +524,7 @@ out:
 
 static void Register_sharedMemory_maxSize(struct xtest_session *cs)
 {
-	uint32_t size_max = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
+	size_t size_max = MIN(TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE,
 				TEEC_CONFIG_SHAREDMEM_MAX_SIZE);
 
 	Do_ADBG_BeginSubCase(cs->c, "Register_sharedMemory_maxSize");
@@ -555,7 +555,7 @@ static void Register_sharedMemory_aboveMaxSize(struct xtest_session *cs)
 	Do_ADBG_BeginSubCase(cs->c, "Register_sharedMemory_aboveMaxSize");
 	{
 		TEEC_Result res;
-		uint32_t size_aboveMax = UINT32_MAX;
+		size_t size_aboveMax = UINT32_MAX;
 		uint8_t val[1];
 		TEEC_SharedMemory shm;
 
@@ -580,7 +580,7 @@ out:
 
 static void Register_sharedMemory_belowMaxSize(struct xtest_session *cs)
 {
-	uint32_t size_belowMax = MIN(TEEC_CONFIG_SHAREDMEM_MAX_SIZE,
+	size_t size_belowMax = MIN(TEEC_CONFIG_SHAREDMEM_MAX_SIZE,
 			     TEE_CLIENT_API_LOWER_SHM_BUFFER_MAX_SIZE) - 1;
 
 	Do_ADBG_BeginSubCase(cs->c, "Register_sharedMemory_belowMaxSize");


### PR DESCRIPTION
When `TEEC_CONFIG_SHAREDMEM_MAX_SIZE` is `ULONG_MAX`, TEE has no reachable specific limit. Actually implementation may have impose a limit but it is not known.

2nd change propose the "Check that at least the 512kB lower bound of the TEE Client API (v1.0, v2.0) is supported. If agreed, will be squashed with former.