### PR TITLE
Make sure AES GCM does not buffer data

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -2755,6 +2755,9 @@ static void xtest_tee_test_4005(ADBG_Case_t *c)
 						&out_size)))
 					goto out;
 				out_offs += out_size;
+				if (ae_cases[n].algo == TEE_ALG_AES_GCM)
+					ADBG_EXPECT_COMPARE_UNSIGNED(c,
+					  out_size, ==, ae_cases[n].in_incr);
 			}
 		} else {
 			if (ae_cases[n].ctx != NULL) {
@@ -2765,6 +2768,9 @@ static void xtest_tee_test_4005(ADBG_Case_t *c)
 						&out_size)))
 					goto out;
 				out_offs += out_size;
+				if (ae_cases[n].algo == TEE_ALG_AES_GCM)
+					ADBG_EXPECT_COMPARE_UNSIGNED(c,
+					  out_size, ==, ae_cases[n].in_incr);
 			}
 		}
 


### PR DESCRIPTION
The documentation [1] for TEE_AEUpdate() states that "Unless one or
more calls of this function have supplied sufficient input data, no
output is generated". This can be understood as: "As soon as sufficient
input data have been supplied, some output is generated".

AES GCM effectively works as a stream cipher, so that any amount of
data passed to the algorithm should produce as much output data
immediately. In other words, calling TEE_AEUpdate() with N bytes of
input should generate N bytes of output for any N >= 1.

This commit updates regression_4005 to check the above assertion.

[1] GlobalPlatform TEE Internal Core API Specification v1.1

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>