### PR TITLE
Make sure AES CTR does not buffer data

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -2375,6 +2375,10 @@ static void xtest_tee_test_4003_no_xts(ADBG_Case_t *c)
 				&out_size)))
 			goto out;
 
+		if (ciph_cases[n].algo == TEE_ALG_AES_CTR)
+			ADBG_EXPECT_COMPARE_UNSIGNED(c, out_size, ==,
+				ciph_cases[n].in_incr);
+
 		out_offs += out_size;
 		out_size = sizeof(out) - out_offs;
 


### PR DESCRIPTION
Similar to commit c13fafac91ae ("Make sure AES GCM does not buffer
data"), update regression_4003_NO_XTS to check that TEE_CipherUpdate()
does not not buffer data when algorithm is TEE_ALG_AES_CTR.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>