### PR TITLE
Add regression_1016: TA to TA buffer manipulations

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -47,6 +47,7 @@ static void xtest_tee_test_1013(ADBG_Case_t *Case_p);
 static void xtest_tee_test_1014(ADBG_Case_t *Case_p);
 #endif
 static void xtest_tee_test_1015(ADBG_Case_t *Case_p);
+static void xtest_tee_test_1016(ADBG_Case_t *Case_p);
 
 ADBG_CASE_DEFINE(regression, 1001, xtest_tee_test_1001, "Core self tests");
 ADBG_CASE_DEFINE(regression, 1004, xtest_tee_test_1004, "Test User Crypt TA");
@@ -71,6 +72,8 @@ ADBG_CASE_DEFINE(regression, 1014, xtest_tee_test_1014,
 #endif
 ADBG_CASE_DEFINE(regression, 1015, xtest_tee_test_1015,
 		"FS hash-tree corner cases");
+ADBG_CASE_DEFINE(regression, 1016, xtest_tee_test_1016,
+		"Test TA to TA transfers (in/out/inout memrefs on the stack)");
 
 struct xtest_crypto_session {
 	ADBG_Case_t *c;
@@ -1140,5 +1143,26 @@ static void xtest_tee_test_1015(ADBG_Case_t *c)
 	ADBG_EXPECT_TEEC_SUCCESS(c,
 		TEEC_InvokeCommand(&session, PTA_INVOKE_TESTS_CMD_FS_HTREE,
 				   NULL, &ret_orig));
+	TEEC_CloseSession(&session);
+}
+
+static void xtest_tee_test_1016(ADBG_Case_t *c)
+{
+	TEEC_Session session = { 0 };
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t ret_orig;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		xtest_teec_open_session(&session, &os_test_ta_uuid, NULL,
+		                        &ret_orig)))
+		return;
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_NONE, TEEC_NONE, TEEC_NONE,
+					 TEEC_NONE);
+
+	(void)ADBG_EXPECT_TEEC_SUCCESS(c,
+		TEEC_InvokeCommand(&session, TA_OS_TEST_CMD_TA2TA_MEMREF, &op,
+				   &ret_orig));
+
 	TEEC_CloseSession(&session);
 }

--- a/ta/os_test/include/os_test.h
+++ b/ta/os_test/include/os_test.h
@@ -38,5 +38,8 @@ TEE_Result ta_entry_client(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_params_access_rights(uint32_t p_types, TEE_Param params[4]);
 TEE_Result ta_entry_wait(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_bad_mem_access(uint32_t param_types, TEE_Param params[4]);
+TEE_Result ta_entry_ta2ta_memref(uint32_t param_types, TEE_Param params[4]);
+TEE_Result ta_entry_ta2ta_memref_mix(uint32_t param_types,
+				     TEE_Param params[4]);
 
 #endif /*OS_TEST_H */

--- a/ta/os_test/include/ta_os_test.h
+++ b/ta/os_test/include/ta_os_test.h
@@ -41,5 +41,7 @@
 #define TA_OS_TEST_CMD_PARAMS_ACCESS        8
 #define TA_OS_TEST_CMD_WAIT                 9
 #define TA_OS_TEST_CMD_BAD_MEM_ACCESS       10
+#define TA_OS_TEST_CMD_TA2TA_MEMREF         11
+#define TA_OS_TEST_CMD_TA2TA_MEMREF_MIX     12
 
 #endif /*TA_OS_TEST_H */

--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -100,6 +100,12 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_OS_TEST_CMD_BAD_MEM_ACCESS:
 		return ta_entry_bad_mem_access(nParamTypes, pParams);
 
+	case TA_OS_TEST_CMD_TA2TA_MEMREF:
+		return ta_entry_ta2ta_memref(nParamTypes, pParams);
+
+	case TA_OS_TEST_CMD_TA2TA_MEMREF_MIX:
+		return ta_entry_ta2ta_memref_mix(nParamTypes, pParams);
+
 	default:
 		return TEE_ERROR_BAD_PARAMETERS;
 	}


### PR DESCRIPTION
This test case is derived from gp_8040 which was found to be failing on
HiKey with a preliminary version of the 64-bit pager enabled
(CFG_ARM64_core=y CFG_WITH_PAGER=y CFG_PAGED_USER_TA=y). This new
regression_1016 test fails in the same circumstances, but also when
paging is enabled in a 32-bit build of the TEE core.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>