### PR TITLE
xtest/sdp: sync with ION udpates from linux kernel 4.12

### DIFF
--- a/host/xtest/include/uapi/linux/ion.h
+++ b/host/xtest/include/uapi/linux/ion.h
@@ -20,8 +20,6 @@
 #include <linux/ioctl.h>
 #include <linux/types.h>
 
-typedef int ion_user_handle_t;
-
 /**
  * enum ion_heap_types - list of all possible types of heaps
  * @ION_HEAP_TYPE_SYSTEM:	 memory allocated via vmalloc
@@ -30,7 +28,8 @@ typedef int ion_user_handle_t;
  *				 carveout heap, allocations are physically
  *				 contiguous
  * @ION_HEAP_TYPE_DMA:		 memory allocated via DMA API
- * @ION_HEAP_TYPE_UNMAPPED:	 memory not mappable into linux address space
+ * @ION_HEAP_TYPE_UNMAPPED:	 memory not intended to be mapped into the
+ *				 linux address space unless for debug cases
  * @ION_NUM_HEAPS:		 helper for iterating over heaps, a bit mask
  *				 is used to identify the heaps, so only 32
  *				 total heap types are supported
@@ -78,7 +77,6 @@ enum ion_heap_type {
 /**
  * struct ion_allocation_data - metadata passed from userspace for allocations
  * @len:		size of the allocation
- * @align:		required alignment of the allocation
  * @heap_id_mask:	mask of heap ids to allocate from
  * @flags:		flags passed to heap
  * @handle:		pointer that will be populated with a cookie to use to
@@ -87,47 +85,11 @@ enum ion_heap_type {
  * Provided by userspace as an argument to the ioctl
  */
 struct ion_allocation_data {
-	size_t len;
-	size_t align;
-	unsigned int heap_id_mask;
-	unsigned int flags;
-	ion_user_handle_t handle;
-};
-
-/**
- * struct ion_fd_data - metadata passed to/from userspace for a handle/fd pair
- * @handle:	a handle
- * @fd:		a file descriptor representing that handle
- *
- * For ION_IOC_SHARE or ION_IOC_MAP userspace populates the handle field with
- * the handle returned from ion alloc, and the kernel returns the file
- * descriptor to share or map in the fd field.  For ION_IOC_IMPORT, userspace
- * provides the file descriptor and the kernel returns the handle.
- */
-struct ion_fd_data {
-	ion_user_handle_t handle;
-	int fd;
-};
-
-/**
- * struct ion_handle_data - a handle passed to/from the kernel
- * @handle:	a handle
- */
-struct ion_handle_data {
-	ion_user_handle_t handle;
-};
-
-/**
- * struct ion_custom_data - metadata passed to/from userspace for a custom ioctl
- * @cmd:	the custom ioctl function to call
- * @arg:	additional data to pass to the custom ioctl, typically a user
- *		pointer to a predefined structure
- *
- * This works just like the regular cmd and arg fields of an ioctl.
- */
-struct ion_custom_data {
-	unsigned int cmd;
-	unsigned long arg;
+	__u64 len;
+	__u32 heap_id_mask;
+	__u32 flags;
+	__u32 fd;
+	__u32 unused;
 };
 
 #define MAX_HEAP_NAME			32
@@ -179,16 +141,6 @@ struct ion_heap_query {
 #define ION_IOC_FREE		_IOWR(ION_IOC_MAGIC, 1, struct ion_handle_data)
 
 /**
- * DOC: ION_IOC_MAP - get a file descriptor to mmap
- *
- * Takes an ion_fd_data struct with the handle field populated with a valid
- * opaque handle.  Returns the struct with the fd field set to a file
- * descriptor open in the current address space.  This file descriptor
- * can then be used as an argument to mmap.
- */
-#define ION_IOC_MAP		_IOWR(ION_IOC_MAGIC, 2, struct ion_fd_data)
-
-/**
  * DOC: ION_IOC_SHARE - creates a file descriptor to use to share an allocation
  *
  * Takes an ion_fd_data struct with the handle field populated with a valid
@@ -198,33 +150,6 @@ struct ion_heap_query {
  * be retrieved via ION_IOC_IMPORT.
  */
 #define ION_IOC_SHARE		_IOWR(ION_IOC_MAGIC, 4, struct ion_fd_data)
-
-/**
- * DOC: ION_IOC_IMPORT - imports a shared file descriptor
- *
- * Takes an ion_fd_data struct with the fd field populated with a valid file
- * descriptor obtained from ION_IOC_SHARE and returns the struct with the handle
- * filed set to the corresponding opaque handle.
- */
-#define ION_IOC_IMPORT		_IOWR(ION_IOC_MAGIC, 5, struct ion_fd_data)
-
-/**
- * DOC: ION_IOC_SYNC - syncs a shared file descriptors to memory
- *
- * Deprecated in favor of using the dma_buf api's correctly (syncing
- * will happen automatically when the buffer is mapped to a device).
- * If necessary should be used after touching a cached buffer from the cpu,
- * this will make the buffer in memory coherent.
- */
-#define ION_IOC_SYNC		_IOWR(ION_IOC_MAGIC, 7, struct ion_fd_data)
-
-/**
- * DOC: ION_IOC_CUSTOM - call architecture specific ion ioctl
- *
- * Takes the argument of the architecture specific ioctl to call and
- * passes appropriate userdata for that ioctl
- */
-#define ION_IOC_CUSTOM		_IOWR(ION_IOC_MAGIC, 6, struct ion_custom_data)
 
 /**
  * DOC: ION_IOC_HEAP_QUERY - information about available heaps

--- a/host/xtest/sdp_basic.c
+++ b/host/xtest/sdp_basic.c
@@ -171,11 +171,13 @@ static int create_tee_ctx(struct tee_ctx *ctx, enum test_target_ta target_ta)
 
 	teerc = TEEC_OpenSession(&ctx->ctx, &ctx->sess, uuid,
 			       TEEC_LOGIN_PUBLIC, NULL, NULL, &err_origin);
-	if (teerc != TEEC_SUCCESS)
+	if (teerc != TEEC_SUCCESS) {
 		fprintf(stderr, "Error: open session to target test %s failed %x %d\n",
 			(target_ta == TEST_NS_TO_PTA) ? "pTA" : "TA",
 			teerc, err_origin);
 
+		TEEC_FinalizeContext(&ctx->ctx);
+	}
 	return (teerc == TEEC_SUCCESS) ? 0 : -1;
 }
 
@@ -442,24 +444,24 @@ int sdp_basic_test(enum test_target_ta ta, size_t size, size_t loop,
 	ref_buf = malloc(size);
 	if (!test_buf || !ref_buf) {
 		verbose("failed to allocate memory\n");
-		goto out;
+		goto bail1;
 	}
 
 	fd = allocate_ion_buffer(sdp_size, ion_heap, verbosity);
 	if (fd < 0) {
 		verbose("Failed to allocate SDP buffer (%zu bytes) in ION heap %d: %d\n",
 				sdp_size, ion_heap, fd);
-		goto out;
+		goto bail1;
 	}
 
 	/* register secure buffer to TEE */
 	ctx = malloc(sizeof(*ctx));
 	if (!ctx)
-		goto out;
+		goto bail1;
 	if (create_tee_ctx(ctx, ta))
-		goto out;
+		goto bail1;
 	if (tee_register_buffer(ctx, &shm_ref, fd))
-		goto out;
+		goto bail2;
 
 	/* release registered fd: tee should still hold refcount on resource */
 	close(fd);
@@ -469,37 +471,38 @@ int sdp_basic_test(enum test_target_ta ta, size_t size, size_t loop,
 	for (loop_cnt = loop; loop_cnt; loop_cnt--) {
 		/* get an buffer of random-like values */
 		if (get_random_bytes((char *)ref_buf, size))
-			goto out;
+			goto bail2;
 		memcpy(test_buf, ref_buf, size);
 		/* random offset [0 255] */
 		offset = (unsigned int)*ref_buf;
 
 		/* TA writes into SDP buffer */
 		if (inject_sdp_data(ctx, test_buf, offset, size, shm_ref, ta))
-			goto out;
+			goto bail2;
 
 		/* TA reads/writes into SDP buffer */
 		if (transform_sdp_data(ctx, offset, size, shm_ref, ta))
-			goto out;
+			goto bail2;
 
 		/* TA reads into SDP buffer */
 		if (dump_sdp_data(ctx, test_buf, offset, size, shm_ref, ta))
-			goto out;
+			goto bail2;
 
 		/* check dumped data are the expected ones */
 		if (check_sdp_dumped(ctx, ref_buf, size, test_buf)) {
 			fprintf(stderr, "check SDP data: %d errors\n", err);
-			goto out;
+			goto bail2;
 		}
 	}
 
 	err = 0;
-out:
+bail2:
 	if (fd >= 0)
 		close(fd);
 	if (shm_ref)
 		tee_deregister_buffer(ctx, shm_ref);
 	finalize_tee_ctx(ctx);
+bail1:
 	free(ctx);
 	free(ref_buf);
 	free(test_buf);


### PR DESCRIPTION
This change depends on integration of the optee-next branch of the linux kernel.
Do not merge until optee relies on k4.12 with updated ION drivers.