### PR TITLE
aes_perf: add missing #include <trace.h>

### DIFF
--- a/ta/aes_perf/ta_entry.c
+++ b/ta/aes_perf/ta_entry.c
@@ -26,6 +26,7 @@
  */
 
 #include <tee_ta_api.h>
+#include <trace.h>
 
 #include "ta_aes_perf.h"
 #include "ta_aes_perf_priv.h"


### PR DESCRIPTION
Since ta/aes_perf/ta_entry.c uses EMSG() it must include the proper
header file.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>