### PR TITLE
Some minor cleaning in xtest

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -181,8 +181,7 @@ static void xtest_crypto_test(struct xtest_crypto_session *cs)
 	}
 	Do_ADBG_EndSubCase(cs->c, "SHA-256 test, 3 bytes input");
 
-	Do_ADBG_BeginSubCase(cs->c,
-			     "AES-256 ECB encrypt test, 32 bytes input, with fixed key");
+	Do_ADBG_BeginSubCase(cs->c, "AES-256 ECB encrypt (32B, fixed key)");
 	{
 		TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 		static const uint8_t in[] = {
@@ -222,11 +221,9 @@ static void xtest_crypto_test(struct xtest_crypto_session *cs)
 			Do_ADBG_HexLog(out, sizeof(out), 16);
 		}
 	}
-	Do_ADBG_EndSubCase(cs->c,
-			   "AES-256 ECB encrypt test, 32 bytes input, with fixed key");
+	Do_ADBG_EndSubCase(cs->c, "AES-256 ECB encrypt (32B, fixed key)");
 
-	Do_ADBG_BeginSubCase(cs->c,
-			     "AES-256 ECB decrypt test, 32 bytes input, with fixed key");
+	Do_ADBG_BeginSubCase(cs->c, "AES-256 ECB decrypt (32B, fixed key)");
 	{
 		TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 		static const uint8_t in[] = {
@@ -266,8 +263,7 @@ static void xtest_crypto_test(struct xtest_crypto_session *cs)
 			Do_ADBG_HexLog(out, sizeof(out), 16);
 		}
 	}
-	Do_ADBG_EndSubCase(cs->c,
-			   "AES-256 ECB decrypt test, 32 bytes input, with fixed key");
+	Do_ADBG_EndSubCase(cs->c, "AES-256 ECB decrypt (32B, fixed key)");
 }
 
 static void xtest_tee_test_1001(ADBG_Case_t *c)
@@ -1160,10 +1156,10 @@ static void xtest_tee_test_1014(ADBG_Case_t *c)
 	Do_ADBG_EndSubCase(c, "SDP: SDP TA invokes a SDP pTA");
 
 	test = TEST_NS_TO_PTA;
-	Do_ADBG_BeginSubCase(c, "SDP: NonSecure client invokes SDP pTA (should fail)");
+	Do_ADBG_BeginSubCase(c, "SDP: NSec CA invokes SDP pTA (should fail)");
 	ret = sdp_basic_test(test, size, loop, ion_heap, rnd_offset, 0);
 	ADBG_EXPECT(c, 1, ret);
-	Do_ADBG_EndSubCase(c, "SDP: NonSecure client invokes SDP pTA (should fail)");
+	Do_ADBG_EndSubCase(c, "SDP: NSec CA invokes SDP pTA (should fail)");
 }
 #endif
 

--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -272,14 +272,14 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 	TEEC_Session session = { 0 };
 	uint32_t ret_orig;
 
+	/* Pseudo TA is optional: warn and nicely exit if not found */
 	res = xtest_teec_open_session(&session, &pta_invoke_tests_ta_uuid, NULL,
 				      &ret_orig);
-	/*
-	 * If the static TA (which is optional) isn't available, skip this
-	 * test.
-	 */
-	if (res != TEEC_SUCCESS)
+	if (res == TEEC_ERROR_ITEM_NOT_FOUND) {
+		Do_ADBG_Log(" - 1001 -   skip test, pseudo TA not found");
 		return;
+	}
+	ADBG_EXPECT_TEEC_SUCCESS(c, res);
 
 	(void)ADBG_EXPECT_TEEC_SUCCESS(c, TEEC_InvokeCommand(
 		&session, PTA_INVOKE_TESTS_CMD_SELF_TESTS, NULL, &ret_orig));
@@ -296,14 +296,14 @@ static void xtest_tee_test_1002(ADBG_Case_t *c)
 	uint8_t exp_sum = 0;
 	size_t n;
 
+	/* Pseudo TA is optional: warn and nicely exit if not found */
 	res = xtest_teec_open_session(&session, &pta_invoke_tests_ta_uuid, NULL,
 				      &ret_orig);
-	/*
-	 * If the pseudo TA (which is optional) isn't available, skip this
-	 * test.
-	 */
-	if (res != TEEC_SUCCESS)
+	if (res == TEEC_ERROR_ITEM_NOT_FOUND) {
+		Do_ADBG_Log(" - 1002 -   skip test, pseudo TA not found");
 		return;
+	}
+	ADBG_EXPECT_TEEC_SUCCESS(c, res);
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INOUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
@@ -1169,14 +1169,14 @@ static void xtest_tee_test_1015(ADBG_Case_t *c)
 	TEEC_Session session = { 0 };
 	uint32_t ret_orig;
 
+	/* Pseudo TA is optional: warn and nicely exit if not found */
 	res = xtest_teec_open_session(&session, &pta_invoke_tests_ta_uuid, NULL,
 				      &ret_orig);
-	/*
-	 * If the static TA (which is optional) isn't available, skip this
-	 * test.
-	 */
-	if (res != TEEC_SUCCESS)
+	if (res == TEEC_ERROR_ITEM_NOT_FOUND) {
+		Do_ADBG_Log(" - 1015 -   skip test, pseudo TA not found");
 		return;
+	}
+	ADBG_EXPECT_TEEC_SUCCESS(c, res);
 
 	ADBG_EXPECT_TEEC_SUCCESS(c,
 		TEEC_InvokeCommand(&session, PTA_INVOKE_TESTS_CMD_FS_HTREE,

--- a/host/xtest/xtest_test.h
+++ b/host/xtest/xtest_test.h
@@ -38,17 +38,6 @@ ADBG_ENUM_TABLE_DECLARE(TEEC_ErrorOrigin);
 #define ADBG_EXPECT_TEEC_ERROR_ORIGIN(c, exp, got) \
 	ADBG_EXPECT_ENUM(c, exp, got, ADBG_EnumTable_TEEC_ErrorOrigin)
 
-/* bass_return_code */
-ADBG_ENUM_TABLE_DECLARE(bass_return_code);
-
-#define ADBG_EXPECT_BASS_RETURN_CODE(c, exp, got) \
-	ADBG_EXPECT_ENUM(c, exp, got, ADBG_EnumTable_bass_return_code)
-
-#define ADBG_EXPECT_BASS_RC_SUCCESS(c, got) \
-	ADBG_EXPECT_ENUM(c, BASS_RC_SUCCESS, got, \
-			 ADBG_EnumTable_bass_return_code)
-
-
 extern const char crypt_user_ta[];
 extern const unsigned int crypt_user_ta_size;
 


### PR DESCRIPTION
Keep a 80char/line alignment in regression_1000.c.
Info trace from xtest when regression 10xx test is skip because test materials (pTA) missing in TEE core.
Remove deprecated defines.
