### PR TITLE
[RFC] sdp: add a searchable test OK message

### DIFF
--- a/host/xtest/sdp_basic.c
+++ b/host/xtest/sdp_basic.c
@@ -644,5 +644,11 @@ int sdp_basic_runner_cmd_parser(int argc, char *argv[])
 			     rnd_offset, verbosity);
 	CHECK_RESULT(err, 1, return 1);
 
+	/* 
+	 * Make sure this string is printed after all subtests has been running.
+	 * This string is used by automatic testing. I.e., we are searching for
+	 * this string to figure out whether the SDP tests passed or not.
+	 */
+	fprintf(stdout, "All SDP test cases passed!\n");
 	return 0;
 }


### PR DESCRIPTION
I want to have something like this merged, but I'm putting this as an RFC, since eventually we should have some kind of standard prefix that makes it easy go "grep" from automated test environment. In this commit I have **no** such thing. But we could for example change/add this to all test cases with something like:
* `[op-tee: sdp: ok]` when **everything** in that suite has passed.
* `[op-tee: sdp: fail]` when **something** in that suite has failed.

Similar we could add the same to standard xtest.
* `[op-tee: xtest standard: ok]` when **everything** in that suite has passed.
* `[op-tee: xtest standard: fail]` when **something** in that suite has failed.
* `[op-tee: xtest l15: ok]` when **everything** in that suite has passed (xtest -l15)
* `[op-tee: xtest l15: fail]` when **something** in that suite has failed (xtest -l15).
etc ... you get the idea.

Something like that should be unique enough to not get mixed with other stuff.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>