### PR TITLE
xtest/Makefile: remove extra '@'

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -152,7 +152,7 @@ all: xtest
 
 xtest: $(objs)
 	@echo "  LD      $(out-dir)/xtest/$@"
-	$(q)@$(CC) -o $(out-dir)/xtest/$@ $+ $(LDFLAGS)
+	$(q)$(CC) -o $(out-dir)/xtest/$@ $+ $(LDFLAGS)
 
 $(out-dir)/xtest/%.o: $(CURDIR)/%.c
 	$(q)mkdir -p $(out-dir)/xtest/adbg/src


### PR DESCRIPTION
Due to an extra '@', 'make V=1' won't print the link command for xtest.
Fix that.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>