### PR TITLE
regression: 1006: test passing a NULL reference with 0 size

### DIFF
--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -474,9 +474,12 @@ static TEE_Result test_mem_access_right(uint32_t param_types,
 		goto cleanup_return;
 	}
 
-	l_pts = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT, 0, 0, 0);
+	l_pts = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				TEE_PARAM_TYPE_MEMREF_INPUT, 0, 0);
 	l_params[0].memref.buffer = buf;
 	l_params[0].memref.size = sizeof(buf);
+	l_params[1].memref.buffer = NULL;
+	l_params[1].memref.size = 0;
 	res = TEE_InvokeTACommand(sess, 0, TA_OS_TEST_CMD_PARAMS_ACCESS,
 				  l_pts, l_params, &ret_orig);
 	if (res != TEE_SUCCESS) {
@@ -845,7 +848,8 @@ TEE_Result ta_entry_params_access_rights(uint32_t param_types, TEE_Param params[
 	TEE_Result res;
 
 	if (param_types !=
-	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT, 0, 0, 0))
+	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+			    TEE_PARAM_TYPE_MEMREF_INPUT, 0, 0))
 		return TEE_ERROR_GENERIC;
 
 	res = TEE_CheckMemoryAccessRights(TEE_MEMORY_ACCESS_READ |
@@ -860,6 +864,8 @@ TEE_Result ta_entry_params_access_rights(uint32_t param_types, TEE_Param params[
 					  params[0].memref.size);
 	if (res != TEE_ERROR_ACCESS_DENIED)
 		return TEE_ERROR_GENERIC;
+	if (params[1].memref.buffer || params[1].memref.size)
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	return TEE_SUCCESS;
 }


### PR DESCRIPTION
Test case for OP-TEE issue #2105 [1]: passing a NULL memref.buffer is
acceptable as long as memref.size is zero (GP Internal Core API
specification v1.1.2 section 4.9.4).

Link: [1] https://github.com/OP-TEE/optee_os/issues/2105
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Tested-by: Jerome Forissier <jerome.forissier@linaro.org> (QEMU)