### PR TITLE
Move ta_storage.h to common location

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -70,7 +70,7 @@ LOCAL_C_INCLUDES += $(LOCAL_PATH)/host/xtest \
 		$(LOCAL_PATH)/ta/os_test/include \
 		$(LOCAL_PATH)/ta/rpc_test/include \
 		$(LOCAL_PATH)/ta/sims/include \
-		$(LOCAL_PATH)/ta/storage/include \
+		$(LOCAL_PATH)/ta/include \
 		$(LOCAL_PATH)/ta/storage_benchmark/include \
 		$(LOCAL_PATH)/ta/sha_perf/include \
 		$(LOCAL_PATH)/ta/aes_perf/include \

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -81,13 +81,13 @@ endif
 CFLAGS += -I$(OPTEE_CLIENT_EXPORT)/include
 CFLAGS += -I$(TA_DEV_KIT_DIR)/host_include
 
+CFLAGS += -I../../ta/include
 CFLAGS += -I../../ta/create_fail_test/include
 CFLAGS += -I../../ta/crypt/include
 CFLAGS += -I../../ta/enc_fs/include
 CFLAGS += -I../../ta/os_test/include
 CFLAGS += -I../../ta/rpc_test/include
 CFLAGS += -I../../ta/sims/include
-CFLAGS += -I../../ta/storage/include
 CFLAGS += -I../../ta/storage_benchmark/include
 CFLAGS += -I../../ta/concurrent/include
 CFLAGS += -I../../ta/concurrent_large/include

--- a/ta/include/ta_storage.h
+++ b/ta/include/ta_storage.h
@@ -25,8 +25,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef TA_STORAGE_H
-#define TA_STORAGE_H
+#ifndef __TA_STORAGE_H
+#define __TA_STORAGE_H
 
 #define TA_STORAGE_UUID { 0xb689f2a7, 0x8adf, 0x477a, \
 	{ 0x9f, 0x99, 0x32, 0xe9, 0x0c, 0x0a, 0xd0, 0xa2 } }
@@ -56,4 +56,4 @@
 #define TA_STORAGE_CMD_RESET_OBJ		20
 #define TA_STORAGE_CMD_GET_OBJ_INFO		21
 
-#endif /*TA_SKELETON_H */
+#endif /*__TA_STORAGE_H*/

--- a/ta/storage/sub.mk
+++ b/ta/storage/sub.mk
@@ -1,3 +1,4 @@
 global-incdirs-y += include
+global-incdirs-y += ../include
 srcs-y += storage.c
 srcs-y += ta_entry.c

--- a/ta/storage2/include/ta_storage.h
+++ b/ta/storage2/include/ta_storage.h
@@ -1,1 +1,0 @@
-#include "../storage/include/ta_storage.h"

--- a/ta/storage2/sub.mk
+++ b/ta/storage2/sub.mk
@@ -1,3 +1,4 @@
 global-incdirs-y += include
+global-incdirs-y += ../include
 srcs-y += storage.c
 srcs-y += ta_entry.c


### PR DESCRIPTION
Since ta_storage.h is used by several TAs move it into a common
location.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>