### PR TITLE
xtest: fix error: missing field 'param' initializer

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -280,7 +280,7 @@ static void xtest_crypto_test(struct xtest_crypto_session *cs)
 static void xtest_tee_test_1001(ADBG_Case_t *c)
 {
 	TEEC_Result res;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 
 	/* Pseudo TA is optional: warn and nicely exit if not found */
@@ -300,7 +300,7 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 static void xtest_tee_test_1002(ADBG_Case_t *c)
 {
 	TEEC_Result res;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t ret_orig;
 	uint8_t buf[16 * 1024];
@@ -349,7 +349,7 @@ struct test_1003_arg {
 static void *test_1003_thread(void *arg)
 {
 	struct test_1003_arg *a = arg;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	size_t rounds = 64 * 1024;
 	size_t n;
 
@@ -398,7 +398,7 @@ static void xtest_tee_test_1003(ADBG_Case_t *c)
 {
 	size_t num_threads = 3 * 2;
 	TEEC_Result res;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	size_t repeat = 20;
 	pthread_t thr[num_threads];
@@ -473,7 +473,7 @@ static void xtest_tee_test_1003(ADBG_Case_t *c)
 
 static void xtest_tee_test_1004(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	struct xtest_crypto_session cs = { c, &session, TA_CRYPT_CMD_SHA256,
 					   TA_CRYPT_CMD_AES256ECB_ENC,
@@ -497,7 +497,7 @@ static void xtest_tee_test_1004(ADBG_Case_t *c)
 
 static void xtest_tee_test_invalid_mem_access(ADBG_Case_t *c, uint32_t n)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t ret_orig;
 
@@ -546,7 +546,7 @@ static void xtest_tee_test_1005(ADBG_Case_t *c)
 
 static void xtest_tee_test_1006(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint8_t buf[32];
@@ -570,7 +570,7 @@ static void xtest_tee_test_1006(ADBG_Case_t *c)
 
 static void xtest_tee_test_1007(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -621,7 +621,7 @@ static FILE *open_ta_file(const TEEC_UUID *uuid, const char *mode)
 
 static bool load_corrupt_ta(ADBG_Case_t *c, size_t offs, uint8_t mask)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	TEEC_UUID uuid = PTA_SECSTOR_TA_MGMT_UUID;
 	TEEC_Result res;
@@ -676,8 +676,8 @@ out:
 
 static void xtest_tee_test_1008(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	TEEC_Session session_crypt = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
+	TEEC_Session session_crypt = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 
 	Do_ADBG_BeginSubCase(c, "Invoke command");
@@ -777,7 +777,7 @@ static void *cancellation_thread(void *arg)
 static void xtest_tee_test_1009_subcase(ADBG_Case_t *c, const char *subcase,
                                         uint32_t timeout, bool cancel)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	pthread_t thr;
 
@@ -845,7 +845,7 @@ static void xtest_tee_test_1010(ADBG_Case_t *c)
 
 static void xtest_tee_test_1011(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	struct xtest_crypto_session cs = {
 		c, &session, TA_RPC_CMD_CRYPT_SHA256,
@@ -892,8 +892,8 @@ static void xtest_tee_test_1011(ADBG_Case_t *c)
  */
 static void xtest_tee_test_1012(ADBG_Case_t *c)
 {
-	TEEC_Session session1 = { 0 };
-	TEEC_Session session2 = { 0 };
+	TEEC_Session session1 = TEEC_SESSION_INITIALIZER;
+	TEEC_Session session2 = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	TEEC_UUID uuid = sims_test_ta_uuid;
 
@@ -1010,7 +1010,7 @@ struct test_1013_thread_arg {
 static void *test_1013_thread(void *arg)
 {
 	struct test_1013_thread_arg *a = arg;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint8_t p2 = TEEC_NONE;
 	uint8_t p3 = TEEC_NONE;
@@ -1225,7 +1225,7 @@ static void xtest_tee_test_1014(ADBG_Case_t *c)
 static void xtest_tee_test_1015(ADBG_Case_t *c)
 {
 	TEEC_Result res;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 
 	/* Pseudo TA is optional: warn and nicely exit if not found */
@@ -1245,7 +1245,7 @@ static void xtest_tee_test_1015(ADBG_Case_t *c)
 
 static void xtest_tee_test_1016(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t ret_orig;
 

--- a/host/xtest/regression_2000.c
+++ b/host/xtest/regression_2000.c
@@ -269,7 +269,7 @@ static bool test_200x_tcp_write_cb(void *ptr, int fd, short *events)
 static void xtest_tee_test_2001(ADBG_Case_t *c)
 {
 	struct sock_server ts;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	uint32_t proto_error;
 	struct socket_handle sh;
@@ -423,7 +423,7 @@ static void *xtest_tee_test_2002_thread(void *arg)
 	struct test_2002_arg *a = arg;
 	TEE_Result res;
 	struct sock_server ts;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	uint32_t proto_error;
 	struct socket_handle sh;
@@ -560,7 +560,7 @@ static bool test_2003_accept_cb(void *ptr, int fd, short *events)
 static void xtest_tee_test_2003(ADBG_Case_t *c)
 {
 	struct sock_server ts;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	uint32_t proto_error;
 	struct socket_handle sh;
@@ -673,7 +673,7 @@ static void xtest_tee_test_2004(ADBG_Case_t *c)
 	bool ts_inited = false;
 	bool ts2_inited = false;
 	bool ts3_inited = false;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	uint32_t proto_error;
 	struct socket_handle sh;

--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -963,7 +963,7 @@ static const struct xtest_hash_case hash_cases[] = {
 
 static void xtest_tee_test_4001(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	size_t n;
 
@@ -1609,7 +1609,7 @@ static const struct xtest_mac_case mac_cases[] = {
 
 static void xtest_tee_test_4002(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	TEE_OperationHandle op1;
 	TEE_OperationHandle op2;
 	TEE_ObjectHandle key_handle;
@@ -2269,7 +2269,7 @@ static const struct xtest_ciph_case ciph_cases_xts[] = {
 
 static void xtest_tee_test_4003_no_xts(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	TEE_OperationHandle op;
 	TEE_ObjectHandle key1_handle = TEE_HANDLE_NULL;
 	TEE_ObjectHandle key2_handle = TEE_HANDLE_NULL;
@@ -2416,7 +2416,7 @@ out:
  */
 static void xtest_tee_test_4003_xts(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	TEE_OperationHandle op;
 	TEE_ObjectHandle key1_handle = TEE_HANDLE_NULL;
 	TEE_ObjectHandle key2_handle = TEE_HANDLE_NULL;
@@ -2563,7 +2563,7 @@ out:
 
 static void xtest_tee_test_4004(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	uint8_t buf1[45] = { 0 };
 	uint8_t buf2[45] = { 0 };
@@ -2686,7 +2686,7 @@ static const struct xtest_ae_case ae_cases[] = {
 
 static void xtest_tee_test_4005(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	TEE_OperationHandle op;
 	TEE_ObjectHandle key_handle = TEE_HANDLE_NULL;
 	TEE_Attribute key_attr;
@@ -3745,7 +3745,7 @@ static bool create_key(ADBG_Case_t *c, TEEC_Session *s,
 
 static void xtest_tee_test_4006(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	TEE_OperationHandle op = TEE_HANDLE_NULL;
 	TEE_ObjectHandle priv_key_handle = TEE_HANDLE_NULL;
 	TEE_ObjectHandle pub_key_handle = TEE_HANDLE_NULL;
@@ -4725,7 +4725,7 @@ static void xtest_test_keygen_ecc(ADBG_Case_t *c, TEEC_Session *session)
 
 static void xtest_tee_test_4007(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -4746,7 +4746,7 @@ static void xtest_tee_test_4007(ADBG_Case_t *c)
 
 static void xtest_tee_test_4008(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	TEE_OperationHandle op;
 	TEE_ObjectHandle key_handle;
@@ -4843,7 +4843,7 @@ out:
 
 static void xtest_tee_test_4009(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	TEE_OperationHandle op;
 	TEE_ObjectHandle key_handle;
@@ -4972,7 +4972,7 @@ noerror:
 
 static void xtest_tee_test_4010(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 	TEE_ObjectHandle o;
 	static const uint8_t large_key[1024] = { 1, 2, 3, 4, 5, 6 };
@@ -5002,7 +5002,7 @@ out:
 
 static void xtest_tee_test_4011(ADBG_Case_t *c)
 {
-	TEEC_Session s = { 0 };
+	TEEC_Session s = TEEC_SESSION_INITIALIZER;
 	size_t key_size = 512;
 	TEE_ObjectHandle key;
 	TEE_OperationHandle ops;

--- a/host/xtest/regression_5000.c
+++ b/host/xtest/regression_5000.c
@@ -482,7 +482,9 @@ out:
 
 static void xtest_teec_TEE(ADBG_Case_t *c)
 {
-	struct xtest_session connection = { c };
+	struct xtest_session connection;
+
+	connection.c = c;
 
 	CloseSession_null(&connection);
 

--- a/host/xtest/regression_8000.c
+++ b/host/xtest/regression_8000.c
@@ -725,7 +725,7 @@ static TEEC_Result enc_fs_km_self_test(TEEC_Session *sess)
 
 static void xtest_tee_test_8001(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = TEEC_SESSION_INITIALIZER;
 	uint32_t ret_orig;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,

--- a/host/xtest/xtest_helpers.h
+++ b/host/xtest/xtest_helpers.h
@@ -40,7 +40,8 @@ TEEC_Result xtest_teec_open_static_session(TEEC_Session *session,
 					   TEEC_Operation *op,
 					   uint32_t *ret_orig);
 
-#define TEEC_OPERATION_INITIALIZER { 0 }
+static const TEEC_Operation TEEC_OPERATION_INITIALIZER;
+static const TEEC_Session TEEC_SESSION_INITIALIZER;
 
 /* IO access macro */
 #define  IO(addr)  (*((volatile unsigned long *)(addr)))


### PR DESCRIPTION
GCC 4.9 generates below errors:

```
external/optee_test/host/xtest/regression_5000.c:485:40: error: missing field 'session' initializer [-Werror,-Wmissing-field-initializers]
        struct xtest_session connection = { c };
                                              ^

external/optee_test/host/xtest/regression_2000.c:46:22: error: missing field 'paramTypes' initializer [-Werror,-Wmissing-field-initializers]
        TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
                            ^
external/optee_test/host/xtest/xtest_helpers.h:43:40: note: expanded from macro 'TEEC_OPERATION_INITIALIZER'
#define TEEC_OPERATION_INITIALIZER { 0 }
                                       ^

external/optee_test/host/xtest/regression_2000.c:272:29: error: missing field 'session_id' initializer [-Werror,-Wmissing-field-initializers]
        TEEC_Session session = { 0 };
                                   ^
```

Signed-off-by: Victor Chong <victor.chong@linaro.org>