### PR TITLE
regression 1010: crash TA with SHM memref passed as parameter

### DIFF
--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -898,7 +898,9 @@ TEE_Result ta_entry_bad_mem_access(uint32_t param_types, TEE_Param params[4])
 	long stack;
 	long stack_addr = (long)&stack;
 
-	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT, 0, 0, 0))
+	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT, 0, 0, 0) &&
+	    param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+					   TEE_PARAM_TYPE_MEMREF_INOUT, 0, 0))
 		return TEE_ERROR_GENERIC;
 
 	switch (params[0].value.a) {


### PR DESCRIPTION
This adds few test cases in regression test 1010 to check TA crash
when the TA is provided a memref as invocation parameter. These
tests aims at checking the dump of memref parameter state in sane
when core detect TA crash and dumps the TA state for debug purpose.

Refer to https://github.com/OP-TEE/optee_os/pull/2117 which should fix the issue.

The issue can be reproduced on Qemu using this test and the following config:
`make all run CFG_TEE_CORE_LOG_LEVEL=3 CFG_WITH_PAGER=y CFG_TEE_CORE_DEBUG=n CFG_CORE_TZSRAM_EMUL_SIZE=0x40000`
