### PR TITLE
Android.mk: workaround missing-field-initializers error

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -81,6 +81,7 @@ LOCAL_C_INCLUDES += $(LOCAL_PATH)/host/xtest \
 LOCAL_CFLAGS += -include conf.h
 LOCAL_CFLAGS += -pthread
 LOCAL_CFLAGS += -g3
+LOCAL_CFLAGS += -Wno-missing-field-initializers -Wno-format-zero-length
 
 ## $(OPTEE_BIN) is the path of tee.bin like
 ## out/target/product/hikey/optee/arm-plat-hikey/core/tee.bin


### PR DESCRIPTION
Without `-Wno-missing-field-initializers`, GCC 4.9 generates below
errors, so add it to `Android.mk`. While we're at it, also add
`-Wno-format-zero-length` to sync with `host/xtest/Makefile`.

```
external/optee_test/host/xtest/regression_5000.c:485:40: error: missing field 'session' initializer [-Werror,-Wmissing-field-initializers]
        struct xtest_session connection = { c };
                                              ^

external/optee_test/host/xtest/regression_2000.c:46:22: error: missing field 'paramTypes' initializer [-Werror,-Wmissing-field-initializers]
        TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
                            ^
external/optee_test/host/xtest/xtest_helpers.h:43:40: note: expanded from macro 'TEEC_OPERATION_INITIALIZER'
                                       ^

external/optee_test/host/xtest/regression_2000.c:272:29: error: missing field 'session_id' initializer [-Werror,-Wmissing-field-initializers]
        TEEC_Session session = { 0 };
                                   ^
```

Signed-off-by: Victor Chong <victor.chong@linaro.org>