### PR TITLE
Cmake support for xtest only (not TAs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required (VERSION 3.2)
+
+# Default cross compile settings
+set (CMAKE_TOOLCHAIN_FILE CMakeToolchain.txt)
+
+################################################################################
+# Compiler flags:
+#   We want to use the same flags in the entire optee_client git
+################################################################################
+add_compile_options (
+	-Wall -Wbad-function-cast -Wcast-align
+	-Werror-implicit-function-declaration -Wextra
+	-Wfloat-equal -Wformat-nonliteral -Wformat-security
+	-Wformat=2 -Winit-self -Wmissing-declarations
+	-Wmissing-format-attribute -Wmissing-include-dirs
+	-Wmissing-noreturn -Wmissing-prototypes -Wnested-externs
+	-Wpointer-arith -Wshadow -Wstrict-prototypes
+	-Wswitch-default -Wunsafe-loop-optimizations
+	-Wwrite-strings -Werror -fPIC
+ 	-Wno-missing-field-initializers
+)
+
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+	set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+	set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif(CCACHE_FOUND)
+
+add_subdirectory (ta)
+add_subdirectory (host/xtest)

--- a/CMakeToolchain.txt
+++ b/CMakeToolchain.txt
@@ -1,0 +1,3 @@
+set (CMAKE_SYSTEM_NAME Linux)
+
+set (CMAKE_SYSTEM_PROCESSOR arm)

--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -1,0 +1,77 @@
+project (xtest C)
+
+include(${OPTEE_TEST_SDK}/host_include/conf.cmake)
+
+################################################################################
+# Packages
+################################################################################
+find_package(Threads REQUIRED)
+if(NOT THREADS_FOUND)
+	message(FATAL_ERROR "Threads not found")
+endif()
+
+include(GNUInstallDirs)
+
+set (SRC
+	adbg/src/adbg_case.c
+	adbg/src/adbg_enum.c
+	adbg/src/adbg_expect.c
+	adbg/src/adbg_log.c
+	adbg/src/adbg_run.c
+	adbg/src/security_utils_hex.c
+	aes_perf.c
+	benchmark_1000.c
+	benchmark_2000.c
+	regression_1000.c
+	regression_4000.c
+	regression_5000.c
+	regression_6000.c
+	regression_7000.c
+	regression_8000.c
+	sha_perf.c
+	xtest_helpers.c
+	xtest_main.c
+	xtest_test.c
+)
+
+if (CFG_GP_SOCKETS)
+	list (APPEND SRC
+		regression_2000.c
+		sock_server.c
+		rand_stream.c
+	)
+endif()
+
+if (CFG_SECSTOR_TA_MGMT_PTA)
+	list (APPEND SRC install_ta.c)
+endif()
+
+if (CFG_SECURE_DATA_PATH)
+	list (APPEND SRC sdp_basic.c)
+endif()
+
+################################################################################
+# Built binary
+################################################################################
+add_executable (${PROJECT_NAME} ${SRC})
+
+target_compile_options (${PROJECT_NAME} PRIVATE -include conf.h)
+
+target_include_directories(${PROJECT_NAME}
+	PRIVATE .
+	PRIVATE adbg/include
+	PRIVATE xml/include
+	PRIVATE ${OPTEE_TEST_SDK}/host_include
+)
+
+target_link_libraries (${PROJECT_NAME}
+	PRIVATE ${CMAKE_THREAD_LIBS_INIT}
+	PRIVATE xtest-ta-headers
+	PRIVATE teec
+	PRIVATE m
+)
+
+################################################################################
+# Install targets
+################################################################################
+install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/ta/CMakeLists.txt
+++ b/ta/CMakeLists.txt
@@ -1,0 +1,20 @@
+project (xtest-ta-headers)
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+target_include_directories(${PROJECT_NAME}
+	INTERFACE include
+	INTERFACE aes_perf/include
+	INTERFACE concurrent/include
+	INTERFACE concurrent_large/include
+	INTERFACE create_fail_test/include
+	INTERFACE crypt/include
+	INTERFACE enc_fs/include
+	INTERFACE os_test/include
+	INTERFACE rpc_test/include
+	INTERFACE sdp_basic/include
+	INTERFACE sha_perf/include
+	INTERFACE sims/include
+	INTERFACE socket/include
+	INTERFACE storage_benchmark/include
+)


### PR DESCRIPTION
This introduces support for building the host part (what's running in
linux user space) of xtest using CMake. TAs are as before built using TA
dev kit.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>