### PR TITLE
regression 1010: fix wrong printf format specifier

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -889,11 +889,11 @@ static void xtest_tee_test_1010(ADBG_Case_t *c)
 	for (idx = 0; idx < ARRAY_SIZE(memref_sz); idx++) {
 		for (n = 1; n <= 5; n++) {
 			Do_ADBG_BeginSubCase(c,
-				"Invalid memory access %u with %d bytes memref",
+				"Invalid memory access %u with %zu bytes memref",
 				n, memref_sz[idx]);
 			xtest_tee_test_invalid_mem_access2(c, n, memref_sz[idx]);
 			Do_ADBG_EndSubCase(c,
-				"Invalid memory access %u with %d bytes memref",
+				"Invalid memory access %u with %zu bytes memref",
 				n, memref_sz[idx]);
 		}
 	}


### PR DESCRIPTION
Fix wrong format specifier, which causes build errors:
error: format '%d' expects argument of type 'int', but argument 4 has type
'size_t {aka long unsigned int}' [-Werror=format=]
     "Invalid memory access %u with %d bytes memref",

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`