### PR TITLE
Add outbound SHM and SDP memref case

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -1257,6 +1257,11 @@ static void xtest_tee_test_1014(ADBG_Case_t *c)
 	ret = sdp_basic_test(test, size, loop, ion_heap, rnd_offset, 0);
 	ADBG_EXPECT(c, 1, ret);
 	Do_ADBG_EndSubCase(c, "SDP: NSec CA invokes SDP pTA (should fail)");
+
+	Do_ADBG_BeginSubCase(c, "SDP: Invoke TA with out of bounds SDP memref");
+	ret = sdp_out_of_bounds_memref_test(size, ion_heap, 0);
+	ADBG_EXPECT(c, 0, ret);
+	Do_ADBG_EndSubCase(c, NULL);
 }
 ADBG_CASE_DEFINE(regression, 1014, xtest_tee_test_1014,
 		"Test secure data path against SDP TAs and pTAs");

--- a/host/xtest/sdp_basic.h
+++ b/host/xtest/sdp_basic.h
@@ -45,4 +45,6 @@ int sdp_basic_test(enum test_target_ta ta,
 			  size_t size, size_t loop, int ion_heap,
 			  int rnd_offset, int verbosity);
 
+int sdp_out_of_bounds_memref_test(size_t size, int ion_heap, int verbosity);
+
 #endif /* XTEST_SDP_BASIC_H */


### PR DESCRIPTION
Depends on https://github.com/linaro-swg/linux/pull/61 (at least for the changes in regression 1018).