### PR TITLE
ta: don't include host_include/conf.mk

### DIFF
--- a/ta/Makefile
+++ b/ta/Makefile
@@ -8,7 +8,7 @@ ifeq ($(out-dir),)
 $(error invalid output directory (O=$(O)))
 endif
 
-include $(TA_DEV_KIT_DIR)/host_include/conf.mk
+include $(TA_DEV_KIT_DIR)/mk/conf.mk
 
 # Prevent use of LDFLAGS from the environment. For example, yocto exports
 # LDFLAGS that are suitable for the client applications, not for TAs

--- a/ta/aes_perf/Makefile
+++ b/ta/aes_perf/Makefile
@@ -1,13 +1,4 @@
 BINARY = e626662e-c0e2-485c-b8c8-09fbce6edf3d
 
-include $(TA_DEV_KIT_DIR)/host_include/conf.mk
-
-ifeq ($(CFG_CACHE_API),y)
-CFLAGS += -DCFG_CACHE_API=y
-endif
-ifeq ($(CFG_SECURE_DATA_PATH),y)
-CFLAGS += -DCFG_SECURE_DATA_PATH=y
-endif
-
 include ../ta_common.mk
 

--- a/ta/sdp_basic/Makefile
+++ b/ta/sdp_basic/Makefile
@@ -1,10 +1,4 @@
 BINARY = 12345678-5b69-11e4-9dbb-101f74f00099
 
-include $(TA_DEV_KIT_DIR)/host_include/conf.mk
-
-ifeq ($(CFG_CACHE_API),y)
-CFLAGS += -DCFG_CACHE_API=y
-endif
-
 include ../ta_common.mk
 


### PR DESCRIPTION
Don't include host_include/conf.mk when building the TA as many
unrelated variables are propagated. Some of those variables, for
instance, CFG_RESERVED_VASPACE_SIZE causes compile errors.

Relevant variables are already defined by the dev kit.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Needed by https://github.com/OP-TEE/optee_os/pull/2266