### PR TITLE
crypto: add test case for seeding RNG pool

### DIFF
--- a/ta/crypt/include/seed_rng_taf.h
+++ b/ta/crypt/include/seed_rng_taf.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2018, Linaro Limited
+ */
+
+#ifndef SEED_RNG_TAF_H
+#define SEED_RNG_TAF_H
+
+#include <pta_system.h>
+
+TEE_Result seed_rng_pool(uint32_t param_types, TEE_Param params[4]);
+
+#endif /* SEED_RNG_TAF_H */

--- a/ta/crypt/include/ta_crypt.h
+++ b/ta/crypt/include/ta_crypt.h
@@ -378,4 +378,8 @@
  */
 #define TA_CRYPT_CMD_MBEDTLS_SIGN_CERT		44
 
+/*
+ * system pTA is used for adding entropy to RNG pool */
+#define TA_CRYPT_CMD_SEED_RNG_POOL 45
+
 #endif /*TA_CRYPT_H */

--- a/ta/crypt/seed_rng_taf.c
+++ b/ta/crypt/seed_rng_taf.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2018, Linaro Limited
+ */
+
+#include <tee_internal_api.h>
+
+#include "seed_rng_taf.h"
+
+TEE_Result seed_rng_pool(uint32_t param_types, TEE_Param params[4])
+{
+	static const TEE_UUID system_uuid = PTA_SYSTEM_UUID;
+	TEE_TASessionHandle sess = TEE_HANDLE_NULL;
+	TEE_Result res;
+	uint32_t ret_orig;
+
+	if (param_types !=
+	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+			    TEE_PARAM_TYPE_NONE,
+			    TEE_PARAM_TYPE_NONE,
+			    TEE_PARAM_TYPE_NONE)) {
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (!params[0].memref.size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = TEE_OpenTASession(&system_uuid, 0, 0, NULL, &sess, &ret_orig);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_OpenTASession failed");
+		goto cleanup_return;
+	}
+
+	res = TEE_InvokeTACommand(sess, 0, PTA_SYSTEM_ADD_RNG_ENTROPY,
+				  param_types, params, &ret_orig);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_InvokeTACommand failed");
+		goto cleanup_return;
+	}
+
+
+cleanup_return:
+	TEE_CloseTASession(sess);
+	return res;
+}

--- a/ta/crypt/sub.mk
+++ b/ta/crypt/sub.mk
@@ -4,6 +4,7 @@ srcs-y += aes_taf.c
 srcs-y += cryp_taf.c
 srcs-y += sha2_impl.c
 srcs-y += sha2_taf.c
+srcs-$(CFG_SYSTEM_PTA) += seed_rng_taf.c
 srcs-y += ta_entry.c
 srcs-$(CFG_TA_MBEDTLS) += mbedtls_taf.c
 

--- a/ta/crypt/ta_entry.c
+++ b/ta/crypt/ta_entry.c
@@ -28,6 +28,7 @@
 #include <aes_taf.h>
 #include <cryp_taf.h>
 #include <mbedtls_taf.h>
+#include <seed_rng_taf.h>
 #include <sha2_taf.h>
 #include <ta_crypt.h>
 #include <tee_ta_api.h>
@@ -229,7 +230,10 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_CRYPT_CMD_MBEDTLS_SIGN_CERT:
 		return ta_entry_mbedtls_sign_cert(nParamTypes, pParams);
 #endif
-
+#ifdef CFG_SYSTEM_PTA
+	case TA_CRYPT_CMD_SEED_RNG_POOL:
+		return seed_rng_pool(nParamTypes, pParams);
+#endif
 	default:
 		return TEE_ERROR_BAD_PARAMETERS;
 	}


### PR DESCRIPTION
Add test case for testing system pTA functionality for seeding RNG pool.

Relates to: https://github.com/OP-TEE/optee_os/pull/2340

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`