### PR TITLE
crypto: add ifdef guards to seed_rng_taf header

### DIFF
--- a/ta/crypt/include/seed_rng_taf.h
+++ b/ta/crypt/include/seed_rng_taf.h
@@ -6,8 +6,12 @@
 #ifndef SEED_RNG_TAF_H
 #define SEED_RNG_TAF_H
 
+#ifdef CFG_SYSTEM_PTA
+
 #include <pta_system.h>
 
 TEE_Result seed_rng_pool(uint32_t param_types, TEE_Param params[4]);
+
+#endif /* CFG_SYSTEM_PTA */
 
 #endif /* SEED_RNG_TAF_H */


### PR DESCRIPTION
Without these guards compiling optee_test fails because it can't find the
system_pta.h file.

Signed-off-by: Rouven Czerwinski <rouven@czerwinskis.de>