### PR TITLE
xtest: Makefile: fix OpenSSL dependency on GP test suite support

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -25,7 +25,7 @@ OBJDUMP		?= $(CROSS_COMPILE)objdump
 READELF		?= $(CROSS_COMPILE)readelf
 
 # OpenSSL is used by GP tests series 8500 and Mbed TLS test 8103
-ifneq (,$(filter y,$(CFG_GP_PACKAGE_PATH) $(CFG_TA_MBEDTLS)))
+ifneq ($(CFG_GP_PACKAGE_PATH)$(filter y,$(CFG_TA_MBEDTLS)),)
 CFLAGS += -I../openssl/include -DOPENSSL_FOUND=1
 ifeq ($(COMPILE_NS_USER),32)
 LDFLAGS += ../openssl/lib/arm/libcrypto.a -ldl


### PR DESCRIPTION
CFG_GP_PACKAGE_PATH is not expected to store 'y' but a path, if
defined. This change corrects the test on CFG_GP_PACKAGE_PATH regarding
OpenSSL depedency.

Fixes: 43d58a5fce8f ("xtest: Makefile: link against OpenSSL if MBed TLS is enabled in TA")

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>