### PR TITLE
Android.mk: make xtest installed in the vendor partition

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -19,7 +19,10 @@ TA_DEV_KIT_DIR ?= ../invalid_include_path
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := xtest
+LOCAL_VENDOR_MODULE := true
 LOCAL_SHARED_LIBRARIES := libteec
+
+TA_DIR ?= /vendor/lib/optee_armtz
 
 srcs := regression_1000.c
 
@@ -96,6 +99,10 @@ LOCAL_CFLAGS += -include conf.h
 LOCAL_CFLAGS += -pthread
 LOCAL_CFLAGS += -g3
 LOCAL_CFLAGS += -Wno-missing-field-initializers -Wno-format-zero-length
+
+ifneq ($(TA_DIR),)
+LOCAL_CFLAGS += -DTA_DIR=\"$(TA_DIR)\"
+endif
 
 ## $(OPTEE_BIN) is the path of tee.bin like
 ## out/target/product/hikey/optee/arm-plat-hikey/core/tee.bin

--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -648,7 +648,7 @@ static void xtest_tee_test_1007(ADBG_Case_t *c)
 #ifdef CFG_SECSTOR_TA_MGMT_PTA
 #ifndef TA_DIR
 # ifdef __ANDROID__
-#define TA_DIR "/system/lib/optee_armtz"
+#define TA_DIR "/vendor/lib/optee_armtz"
 # else
 #define TA_DIR "/lib/optee_armtz"
 # endif


### PR DESCRIPTION
so that we could make optee work with Treble enabled builds too

Acked-by: Victor Chong <victor.chong@linaro.org>
Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>