### PR TITLE
regression_*.c: move ADBG_CASE_DEFINE()

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -41,67 +41,6 @@
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #endif
 
-static void xtest_tee_test_1001(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1002(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1003(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1004(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1005(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1006(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1007(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1008(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1009(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1010(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1011(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1012(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1013(ADBG_Case_t *Case_p);
-#ifdef CFG_SECURE_DATA_PATH
-static void xtest_tee_test_1014(ADBG_Case_t *Case_p);
-#endif
-static void xtest_tee_test_1015(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1016(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1017(ADBG_Case_t *Case_p);
-static void xtest_tee_test_1018(ADBG_Case_t *Case_p);
-#if defined(CFG_TA_DYNLINK)
-static void xtest_tee_test_1019(ADBG_Case_t *Case_p);
-#endif
-
-ADBG_CASE_DEFINE(regression, 1001, xtest_tee_test_1001, "Core self tests");
-ADBG_CASE_DEFINE(regression, 1002, xtest_tee_test_1002, "PTA parameters");
-ADBG_CASE_DEFINE(regression, 1003, xtest_tee_test_1003,
-		 "Core internal read/write mutex");
-ADBG_CASE_DEFINE(regression, 1004, xtest_tee_test_1004, "Test User Crypt TA");
-ADBG_CASE_DEFINE(regression, 1005, xtest_tee_test_1005, "Many sessions");
-ADBG_CASE_DEFINE(regression, 1006, xtest_tee_test_1006,
-		"Test Basic OS features");
-ADBG_CASE_DEFINE(regression, 1007, xtest_tee_test_1007, "Test Panic");
-ADBG_CASE_DEFINE(regression, 1008, xtest_tee_test_1008,
-		"TEE internal client API");
-ADBG_CASE_DEFINE(regression, 1009, xtest_tee_test_1009, "TEE Wait");
-ADBG_CASE_DEFINE(regression, 1010, xtest_tee_test_1010,
-		"Invalid memory access");
-ADBG_CASE_DEFINE(regression, 1011, xtest_tee_test_1011,
-		"Test TA-to-TA features with User Crypt TA");
-ADBG_CASE_DEFINE(regression, 1012, xtest_tee_test_1012,
-		"Test Single Instance Multi Session features with SIMS TA");
-ADBG_CASE_DEFINE(regression, 1013, xtest_tee_test_1013,
-		"Test concurency with concurrent TA");
-#ifdef CFG_SECURE_DATA_PATH
-ADBG_CASE_DEFINE(regression, 1014, xtest_tee_test_1014,
-		"Test secure data path against SDP TAs and pTAs");
-#endif
-ADBG_CASE_DEFINE(regression, 1015, xtest_tee_test_1015,
-		"FS hash-tree corner cases");
-ADBG_CASE_DEFINE(regression, 1016, xtest_tee_test_1016,
-		"Test TA to TA transfers (in/out/inout memrefs on the stack)");
-ADBG_CASE_DEFINE(regression, 1017, xtest_tee_test_1017,
-		"Test coalescing memrefs");
-ADBG_CASE_DEFINE(regression, 1018, xtest_tee_test_1018,
-		"Test memref out of bounds");
-#if defined(CFG_TA_DYNLINK)
-ADBG_CASE_DEFINE(regression, 1019, xtest_tee_test_1019,
-		"Test dynamically linked TA");
-#endif
-
 struct xtest_crypto_session {
 	ADBG_Case_t *c;
 	TEEC_Session *session;
@@ -310,6 +249,7 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 		&session, PTA_INVOKE_TESTS_CMD_SELF_TESTS, NULL, &ret_orig));
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 1001, xtest_tee_test_1001, "Core self tests");
 
 static void xtest_tee_test_1002(ADBG_Case_t *c)
 {
@@ -348,6 +288,7 @@ static void xtest_tee_test_1002(ADBG_Case_t *c)
 out:
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 1002, xtest_tee_test_1002, "PTA parameters");
 
 struct test_1003_arg {
 	uint32_t test_type;
@@ -484,6 +425,8 @@ static void xtest_tee_test_1003(ADBG_Case_t *c)
 	Do_ADBG_Log("    Mean read concurrency: %g", mean_read_concurrency);
 	Do_ADBG_Log("    Mean read waiting: %g", mean_read_waiters);
 }
+ADBG_CASE_DEFINE(regression, 1003, xtest_tee_test_1003,
+		 "Core internal read/write mutex");
 
 static void xtest_tee_test_1004(ADBG_Case_t *c)
 {
@@ -503,6 +446,7 @@ static void xtest_tee_test_1004(ADBG_Case_t *c)
 
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 1004, xtest_tee_test_1004, "Test User Crypt TA");
 
 static void xtest_tee_test_invalid_mem_access(ADBG_Case_t *c, unsigned int n)
 {
@@ -593,6 +537,7 @@ static void xtest_tee_test_1005(ADBG_Case_t *c)
 	for (; --i >= 0; )
 		TEEC_CloseSession(&sessions[i]);
 }
+ADBG_CASE_DEFINE(regression, 1005, xtest_tee_test_1005, "Many sessions");
 
 static void xtest_tee_test_1006(ADBG_Case_t *c)
 {
@@ -617,6 +562,8 @@ static void xtest_tee_test_1006(ADBG_Case_t *c)
 
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 1006, xtest_tee_test_1006,
+		"Test Basic OS features");
 
 static void xtest_tee_test_1007(ADBG_Case_t *c)
 {
@@ -644,6 +591,7 @@ static void xtest_tee_test_1007(ADBG_Case_t *c)
 
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 1007, xtest_tee_test_1007, "Test Panic");
 
 #ifdef CFG_SECSTOR_TA_MGMT_PTA
 #ifndef TA_DIR
@@ -812,6 +760,8 @@ static void xtest_tee_test_1008(ADBG_Case_t *c)
 	Do_ADBG_EndSubCase(c, "Load corrupt TA");
 #endif /*CFG_SECSTOR_TA_MGMT_PTA*/
 }
+ADBG_CASE_DEFINE(regression, 1008, xtest_tee_test_1008,
+		"TEE internal client API");
 
 static void *cancellation_thread(void *arg)
 {
@@ -881,6 +831,7 @@ static void xtest_tee_test_1009(ADBG_Case_t *c)
 	xtest_tee_test_1009_subcase(c, "TEE Wait 2s cancel", 2000, true);
 	xtest_tee_test_1009_subcase(c, "TEE Wait 2s", 2000, false);
 }
+ADBG_CASE_DEFINE(regression, 1009, xtest_tee_test_1009, "TEE Wait");
 
 static void xtest_tee_test_1010(ADBG_Case_t *c)
 {
@@ -906,6 +857,8 @@ static void xtest_tee_test_1010(ADBG_Case_t *c)
 		}
 	}
 }
+ADBG_CASE_DEFINE(regression, 1010, xtest_tee_test_1010,
+		"Invalid memory access");
 
 static void xtest_tee_test_1011(ADBG_Case_t *c)
 {
@@ -946,6 +899,8 @@ static void xtest_tee_test_1011(ADBG_Case_t *c)
 
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 1011, xtest_tee_test_1011,
+		"Test TA-to-TA features with User Crypt TA");
 
 /*
  * Note that this test is failing when
@@ -1056,6 +1011,8 @@ static void xtest_tee_test_1012(ADBG_Case_t *c)
 		TEEC_CloseSession(&session1);
 	}
 }
+ADBG_CASE_DEFINE(regression, 1012, xtest_tee_test_1012,
+		"Test Single Instance Multi Session features with SIMS TA");
 
 struct test_1013_thread_arg {
 	const TEEC_UUID *uuid;
@@ -1247,6 +1204,8 @@ static void xtest_tee_test_1013(ADBG_Case_t *c)
 	Do_ADBG_EndSubCase(c, "Using large concurrency TA");
 #endif
 }
+ADBG_CASE_DEFINE(regression, 1013, xtest_tee_test_1013,
+		"Test concurency with concurrent TA");
 
 #ifdef CFG_SECURE_DATA_PATH
 static void xtest_tee_test_1014(ADBG_Case_t *c)
@@ -1284,7 +1243,9 @@ static void xtest_tee_test_1014(ADBG_Case_t *c)
 	ADBG_EXPECT(c, 1, ret);
 	Do_ADBG_EndSubCase(c, "SDP: NSec CA invokes SDP pTA (should fail)");
 }
-#endif
+ADBG_CASE_DEFINE(regression, 1014, xtest_tee_test_1014,
+		"Test secure data path against SDP TAs and pTAs");
+#endif /*CFG_SECURE_DATA_PATH*/
 
 static void xtest_tee_test_1015(ADBG_Case_t *c)
 {
@@ -1306,6 +1267,8 @@ static void xtest_tee_test_1015(ADBG_Case_t *c)
 				   NULL, &ret_orig));
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 1015, xtest_tee_test_1015,
+		"FS hash-tree corner cases");
 
 static void xtest_tee_test_1016(ADBG_Case_t *c)
 {
@@ -1327,6 +1290,8 @@ static void xtest_tee_test_1016(ADBG_Case_t *c)
 
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 1016, xtest_tee_test_1016,
+		"Test TA to TA transfers (in/out/inout memrefs on the stack)");
 
 static void xtest_tee_test_1017(ADBG_Case_t *c)
 {
@@ -1382,6 +1347,8 @@ static void xtest_tee_test_1017(ADBG_Case_t *c)
 out:
 	TEEC_ReleaseSharedMemory(&shm);
 }
+ADBG_CASE_DEFINE(regression, 1017, xtest_tee_test_1017,
+		"Test coalescing memrefs");
 
 static void xtest_tee_test_1018(ADBG_Case_t *c)
 {
@@ -1442,6 +1409,8 @@ static void xtest_tee_test_1018(ADBG_Case_t *c)
 out:
 	TEEC_ReleaseSharedMemory(&shm);
 }
+ADBG_CASE_DEFINE(regression, 1018, xtest_tee_test_1018,
+		"Test memref out of bounds");
 
 #if defined(CFG_TA_DYNLINK)
 static void xtest_tee_test_1019(ADBG_Case_t *c)
@@ -1467,4 +1436,6 @@ static void xtest_tee_test_1019(ADBG_Case_t *c)
 
 	TEEC_CloseSession(&session);
 }
-#endif
+ADBG_CASE_DEFINE(regression, 1019, xtest_tee_test_1019,
+		"Test dynamically linked TA");
+#endif /*CFG_TA_DYNLINK*/

--- a/host/xtest/regression_2000.c
+++ b/host/xtest/regression_2000.c
@@ -395,6 +395,8 @@ out_close_session:
 out:
 	sock_server_uninit(&ts);
 }
+ADBG_CASE_DEFINE(regression, 2001, xtest_tee_test_2001,
+		"Trivial TCP iSocket API tests");
 
 struct test_2002_barrier {
 	pthread_mutex_t mu;
@@ -543,6 +545,8 @@ static void xtest_tee_test_2002(ADBG_Case_t *c)
 
 	Do_ADBG_EndSubCase(c, "Stressing with %d threads", NUM_THREADS);
 }
+ADBG_CASE_DEFINE(regression, 2002, xtest_tee_test_2002,
+		"Concurrent stressing TCP iSocket API tests");
 
 static bool test_2003_accept_cb(void *ptr, int fd, short *events)
 {
@@ -638,6 +642,8 @@ out:
 	free(buf);
 	sock_server_uninit(&ts);
 }
+ADBG_CASE_DEFINE(regression, 2003, xtest_tee_test_2003,
+		"Timeout TCP iSocket API tests");
 
 static bool test_200x_udp_accept_cb(void *ptr, int fd, short *events)
 {
@@ -892,17 +898,5 @@ out:
 	if (ts3_inited)
 		sock_server_uninit(&ts3);
 }
-
-
-
-ADBG_CASE_DEFINE(regression, 2001, xtest_tee_test_2001,
-		"Trivial TCP iSocket API tests");
-
-ADBG_CASE_DEFINE(regression, 2002, xtest_tee_test_2002,
-		"Concurrent stressing TCP iSocket API tests");
-
-ADBG_CASE_DEFINE(regression, 2003, xtest_tee_test_2003,
-		"Timeout TCP iSocket API tests");
-
 ADBG_CASE_DEFINE(regression, 2004, xtest_tee_test_2004,
 		"UDP iSocket API tests");

--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -30,52 +30,6 @@
 
 #include <assert.h>
 
-static void xtest_tee_test_4001(ADBG_Case_t *Case_p);
-static void xtest_tee_test_4002(ADBG_Case_t *Case_p);
-static void xtest_tee_test_4003(ADBG_Case_t *Case_p);
-static void xtest_tee_test_4004(ADBG_Case_t *Case_p);
-static void xtest_tee_test_4005(ADBG_Case_t *Case_p);
-static void xtest_tee_test_4006(ADBG_Case_t *Case_p);
-static void xtest_tee_test_4007(ADBG_Case_t *Case_p);
-static void xtest_tee_test_4008(ADBG_Case_t *Case_p);
-static void xtest_tee_test_4009(ADBG_Case_t *Case_p);
-static void xtest_tee_test_4010(ADBG_Case_t *Case_p);
-static void xtest_tee_test_4011(ADBG_Case_t *Case_p);
-#ifdef CFG_SYSTEM_PTA
-static void xtest_tee_test_4012(ADBG_Case_t *Case_p);
-#endif
-
-ADBG_CASE_DEFINE(regression, 4001, xtest_tee_test_4001,
-		"Test TEE Internal API hash operations");
-ADBG_CASE_DEFINE(regression, 4002, xtest_tee_test_4002,
-		"Test TEE Internal API MAC operations");
-ADBG_CASE_DEFINE(regression, 4003, xtest_tee_test_4003,
-		"Test TEE Internal API cipher operations");
-ADBG_CASE_DEFINE(regression, 4004, xtest_tee_test_4004,
-		"Test TEE Internal API get random");
-ADBG_CASE_DEFINE(regression, 4005, xtest_tee_test_4005,
-		"Test TEE Internal API Authenticated Encryption operations");
-ADBG_CASE_DEFINE(regression, 4006, xtest_tee_test_4006,
-		"Test TEE Internal API Asymmetric Cipher operations");
-ADBG_CASE_DEFINE(regression, 4007, xtest_tee_test_4007,
-		"Test TEE Internal API Generate key");
-ADBG_CASE_DEFINE(regression, 4008, xtest_tee_test_4008,
-		"Test TEE Internal API Derive key");
-ADBG_CASE_DEFINE(regression, 4009, xtest_tee_test_4009,
-		"Test TEE Internal API Derive key ECDH");
-ADBG_CASE_DEFINE(regression, 4010, xtest_tee_test_4010,
-		"Test TEE Internal API create transient object (negative)");
-ADBG_CASE_DEFINE(regression, 4011, xtest_tee_test_4011,
-		"Test TEE Internal API Bleichenbacher attack (negative)");
-#ifdef CFG_SYSTEM_PTA
-ADBG_CASE_DEFINE(regression, 4012, xtest_tee_test_4012,
-		"Test seeding RNG entropy");
-#endif
-
-static TEEC_Result ta_crypt_cmd_random_number_generate(ADBG_Case_t *c,
-						       TEEC_Session *s,
-						       void *buf, size_t blen);
-
 static TEEC_Result ta_crypt_cmd_reset_operation(ADBG_Case_t *c, TEEC_Session *s,
 						TEE_OperationHandle oph)
 {
@@ -1067,6 +1021,8 @@ static void xtest_tee_test_4001(ADBG_Case_t *c)
 out:
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 4001, xtest_tee_test_4001,
+		"Test TEE Internal API hash operations");
 
 static const uint8_t mac_data_md5_key1[10] = {
 	0x6B, 0x65, 0x79, /* key */
@@ -1730,6 +1686,8 @@ static void xtest_tee_test_4002(ADBG_Case_t *c)
 out:
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 4002, xtest_tee_test_4002,
+		"Test TEE Internal API MAC operations");
 
 static const uint8_t ciph_data_aes_key1[] = {
 	0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, /* 01234567 */
@@ -2479,6 +2437,8 @@ static void xtest_tee_test_4003(ADBG_Case_t *c)
 out:
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 4003, xtest_tee_test_4003,
+		"Test TEE Internal API cipher operations");
 
 static void xtest_tee_test_4004(ADBG_Case_t *c)
 {
@@ -2516,7 +2476,8 @@ out:
 	TEEC_CloseSession(&session);
 	Do_ADBG_EndSubCase(c, "TEE get random");
 }
-
+ADBG_CASE_DEFINE(regression, 4004, xtest_tee_test_4004,
+		"Test TEE Internal API get random");
 
 struct xtest_ae_case {
 	uint32_t algo;
@@ -2758,6 +2719,8 @@ static void xtest_tee_test_4005(ADBG_Case_t *c)
 out:
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 4005, xtest_tee_test_4005,
+		"Test TEE Internal API Authenticated Encryption operations");
 
 struct xtest_ac_case {
 	unsigned int level;
@@ -4151,6 +4114,8 @@ static void xtest_tee_test_4006(ADBG_Case_t *c)
 out:
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 4006, xtest_tee_test_4006,
+		"Test TEE Internal API Asymmetric Cipher operations");
 
 #define KEY_ATTR(x, y) { #x, (x), y }
 
@@ -4670,6 +4635,8 @@ static void xtest_tee_test_4007(ADBG_Case_t *c)
 
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 4007, xtest_tee_test_4007,
+		"Test TEE Internal API Generate key");
 
 static void xtest_tee_test_4008(ADBG_Case_t *c)
 {
@@ -4767,6 +4734,8 @@ out:
 	Do_ADBG_EndSubCase(c, "Derive DH key success");
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 4008, xtest_tee_test_4008,
+		"Test TEE Internal API Derive key");
 
 static void xtest_tee_test_4009(ADBG_Case_t *c)
 {
@@ -4896,6 +4865,8 @@ out:
 noerror:
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 4009, xtest_tee_test_4009,
+		"Test TEE Internal API Derive key ECDH");
 
 static void xtest_tee_test_4010(ADBG_Case_t *c)
 {
@@ -4926,6 +4897,8 @@ static void xtest_tee_test_4010(ADBG_Case_t *c)
 out:
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 4010, xtest_tee_test_4010,
+		"Test TEE Internal API create transient object (negative)");
 
 static void xtest_tee_test_4011(ADBG_Case_t *c)
 {
@@ -5063,7 +5036,8 @@ static void xtest_tee_test_4011(ADBG_Case_t *c)
 out:
 	TEEC_CloseSession(&s);
 }
-
+ADBG_CASE_DEFINE(regression, 4011, xtest_tee_test_4011,
+		"Test TEE Internal API Bleichenbacher attack (negative)");
 
 #ifdef CFG_SYSTEM_PTA
 static void xtest_tee_test_4012(ADBG_Case_t *c)
@@ -5102,4 +5076,6 @@ static void xtest_tee_test_4012(ADBG_Case_t *c)
 					&ret_orig));
 	TEEC_CloseSession(&session);
 }
-#endif
+ADBG_CASE_DEFINE(regression, 4012, xtest_tee_test_4012,
+		"Test seeding RNG entropy");
+#endif /*CFG_SYSTEM_PTA*/

--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -29,6 +29,18 @@
 #endif
 #include <util.h>
 
+#define DEFINE_TEST_MULTIPLE_STORAGE_IDS(test_name)			     \
+static void test_name(ADBG_Case_t *c)					     \
+{									     \
+	size_t i;							     \
+									     \
+	for (i = 0; i < ARRAY_SIZE(storage_ids); i++) {			     \
+		Do_ADBG_BeginSubCase(c, "Storage id: %08x", storage_ids[i]); \
+		test_name##_single(c, storage_ids[i]);			     \
+		Do_ADBG_EndSubCase(c, "Storage id: %08x", storage_ids[i]);   \
+	}								     \
+}
+
 static uint32_t storage_ids[] = {
 	TEE_STORAGE_PRIVATE,
 #ifdef CFG_REE_FS
@@ -814,20 +826,9 @@ static void xtest_tee_test_6001_single(ADBG_Case_t *c, uint32_t storage_id)
 exit:
 	TEEC_CloseSession(&sess);
 }
-
-#define DEFINE_TEST_MULTIPLE_STORAGE_IDS(test_name)			     \
-static void test_name(ADBG_Case_t *c)					     \
-{									     \
-	size_t i;							     \
-									     \
-	for (i = 0; i < ARRAY_SIZE(storage_ids); i++) {			     \
-		Do_ADBG_BeginSubCase(c, "Storage id: %08x", storage_ids[i]); \
-		test_name##_single(c, storage_ids[i]);			     \
-		Do_ADBG_EndSubCase(c, "Storage id: %08x", storage_ids[i]);   \
-	}								     \
-}
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6001)
+ADBG_CASE_DEFINE(regression, 6001, xtest_tee_test_6001,
+		 "Test TEE_CreatePersistentObject");
 
 /* open */
 static void xtest_tee_test_6002_single(ADBG_Case_t *c, uint32_t storage_id)
@@ -869,8 +870,9 @@ static void xtest_tee_test_6002_single(ADBG_Case_t *c, uint32_t storage_id)
 exit:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6002)
+ADBG_CASE_DEFINE(regression, 6002, xtest_tee_test_6002,
+		 "Test TEE_OpenPersistentObject");
 
 /* read */
 static void xtest_tee_test_6003_single(ADBG_Case_t *c, uint32_t storage_id)
@@ -912,8 +914,9 @@ static void xtest_tee_test_6003_single(ADBG_Case_t *c, uint32_t storage_id)
 exit:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6003)
+ADBG_CASE_DEFINE(regression, 6003, xtest_tee_test_6003,
+		 "Test TEE_ReadObjectData");
 
 /* write */
 static void xtest_tee_test_6004_single(ADBG_Case_t *c, uint32_t storage_id)
@@ -970,8 +973,9 @@ static void xtest_tee_test_6004_single(ADBG_Case_t *c, uint32_t storage_id)
 exit:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6004)
+ADBG_CASE_DEFINE(regression, 6004, xtest_tee_test_6004,
+		 "Test TEE_WriteObjectData");
 
 /* seek */
 static void xtest_tee_test_6005_single(ADBG_Case_t *c, uint32_t storage_id)
@@ -1013,8 +1017,9 @@ static void xtest_tee_test_6005_single(ADBG_Case_t *c, uint32_t storage_id)
 exit:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6005)
+ADBG_CASE_DEFINE(regression, 6005, xtest_tee_test_6005,
+		 "Test TEE_SeekObjectData");
 
 /* unlink */
 static void xtest_tee_test_6006_single(ADBG_Case_t *c, uint32_t storage_id)
@@ -1047,8 +1052,9 @@ static void xtest_tee_test_6006_single(ADBG_Case_t *c, uint32_t storage_id)
 exit:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6006)
+ADBG_CASE_DEFINE(regression, 6006, xtest_tee_test_6006,
+		 "Test TEE_CloseAndDeletePersistentObject");
 
 static void xtest_tee_test_6007_single(ADBG_Case_t *c, uint32_t storage_id)
 {
@@ -1064,8 +1070,9 @@ static void xtest_tee_test_6007_single(ADBG_Case_t *c, uint32_t storage_id)
 	test_file_hole(c, storage_id);
 	Do_ADBG_EndSubCase(c, "Test file hole");
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6007)
+ADBG_CASE_DEFINE(regression, 6007, xtest_tee_test_6007,
+		 "Test TEE_TruncateObjectData");
 
 static void xtest_tee_test_6008_single(ADBG_Case_t *c, uint32_t storage_id)
 {
@@ -1128,8 +1135,9 @@ static void xtest_tee_test_6008_single(ADBG_Case_t *c, uint32_t storage_id)
 exit:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6008)
+ADBG_CASE_DEFINE(regression, 6008, xtest_tee_test_6008,
+		 "Test TEE_RenamePersistentObject");
 
 static void xtest_tee_test_6009_single(ADBG_Case_t *c, uint32_t storage_id)
 {
@@ -1234,8 +1242,9 @@ static void xtest_tee_test_6009_single(ADBG_Case_t *c, uint32_t storage_id)
 exit:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6009)
+ADBG_CASE_DEFINE(regression, 6009, xtest_tee_test_6009,
+	"Test TEE Internal API Persistent Object Enumeration Functions");
 
 static void xtest_tee_test_6010_single(ADBG_Case_t *c, uint32_t storage_id)
 {
@@ -1435,8 +1444,8 @@ seek_write_read_out:
 
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6010)
+ADBG_CASE_DEFINE(regression, 6010, xtest_tee_test_6010, "Test Storage");
 
 #ifdef WITH_GP_TESTS
 static void xtest_tee_test_6011(ADBG_Case_t *c)
@@ -1473,6 +1482,8 @@ static void xtest_tee_test_6011(ADBG_Case_t *c)
 exit:
     TEEC_CloseSession(&sess);
 }
+ADBG_CASE_DEFINE(regression, 6011, xtest_tee_test_6011,
+		 "Test TEE GP TTA DS init objects");
 #endif /*WITH_GP_TESTS*/
 
 static void xtest_tee_test_6012_single(ADBG_Case_t *c, uint32_t storage_id)
@@ -1545,8 +1556,9 @@ bail2:
 bail1:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6012)
+ADBG_CASE_DEFINE(regression, 6012, xtest_tee_test_6012,
+		 "Test TEE GP TTA DS init objects");
 
 static void xtest_tee_test_6013_single(ADBG_Case_t *c, uint32_t storage_id)
 {
@@ -1568,8 +1580,9 @@ static void xtest_tee_test_6013_single(ADBG_Case_t *c, uint32_t storage_id)
 
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6013)
+ADBG_CASE_DEFINE(regression, 6013, xtest_tee_test_6013,
+		 "Key usage in Persistent objects");
 
 static void xtest_tee_test_6014_single(ADBG_Case_t *c, uint32_t storage_id)
 {
@@ -1590,8 +1603,9 @@ static void xtest_tee_test_6014_single(ADBG_Case_t *c, uint32_t storage_id)
 
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6014)
+ADBG_CASE_DEFINE(regression, 6014, xtest_tee_test_6014,
+		 "Loop on Persistent objects");
 
 static void xtest_tee_test_6015_single(ADBG_Case_t *c, uint32_t storage_id)
 {
@@ -1632,9 +1646,8 @@ exit:
 exit2:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6015)
-
+ADBG_CASE_DEFINE(regression, 6015, xtest_tee_test_6015, "Storage isolation");
 
 struct test_6016_thread_arg {
 	ADBG_Case_t *case_t;
@@ -1742,8 +1755,8 @@ static void xtest_tee_test_6016_single(ADBG_Case_t *c, uint32_t storage_id)
 	for (i = 0; i < loops; i++)
 		xtest_tee_test_6016_loop(c, storage_id);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6016)
+ADBG_CASE_DEFINE(regression, 6016, xtest_tee_test_6016, "Storage concurency");
 
 static void xtest_tee_test_6017_single(ADBG_Case_t *c, uint32_t storage_id)
 {
@@ -1796,8 +1809,9 @@ static void xtest_tee_test_6017_single(ADBG_Case_t *c, uint32_t storage_id)
 exit:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6017)
+ADBG_CASE_DEFINE(regression, 6017, xtest_tee_test_6017,
+		 "Test Persistent objects info");
 
 static void xtest_tee_test_6018_single(ADBG_Case_t *c, uint32_t storage_id)
 {
@@ -1887,8 +1901,8 @@ static void xtest_tee_test_6018_single(ADBG_Case_t *c, uint32_t storage_id)
 exit:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6018)
+ADBG_CASE_DEFINE(regression, 6018, xtest_tee_test_6018, "Large object");
 
 static void xtest_tee_test_6019_single(ADBG_Case_t *c, uint32_t storage_id)
 {
@@ -1968,8 +1982,8 @@ exit2:
 exit3:
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6019)
+ADBG_CASE_DEFINE(regression, 6019, xtest_tee_test_6019, "Storage independence");
 
 /*
  * According to the GP spec V1.1, the object_id in create/open/rename
@@ -2185,45 +2199,6 @@ exit1:
 	ADBG_EXPECT_TEEC_SUCCESS(c, fs_unlink(&sess, obj));
 	TEEC_CloseSession(&sess);
 }
-
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6020)
-
-ADBG_CASE_DEFINE(regression, 6001, xtest_tee_test_6001,
-		 "Test TEE_CreatePersistentObject");
-ADBG_CASE_DEFINE(regression, 6002, xtest_tee_test_6002,
-		 "Test TEE_OpenPersistentObject");
-ADBG_CASE_DEFINE(regression, 6003, xtest_tee_test_6003,
-		 "Test TEE_ReadObjectData");
-ADBG_CASE_DEFINE(regression, 6004, xtest_tee_test_6004,
-		 "Test TEE_WriteObjectData");
-ADBG_CASE_DEFINE(regression, 6005, xtest_tee_test_6005,
-		 "Test TEE_SeekObjectData");
-ADBG_CASE_DEFINE(regression, 6006, xtest_tee_test_6006,
-		 "Test TEE_CloseAndDeletePersistentObject");
-ADBG_CASE_DEFINE(regression, 6007, xtest_tee_test_6007,
-		 "Test TEE_TruncateObjectData");
-ADBG_CASE_DEFINE(regression, 6008, xtest_tee_test_6008,
-		 "Test TEE_RenamePersistentObject");
-ADBG_CASE_DEFINE(regression, 6009, xtest_tee_test_6009,
-	"Test TEE Internal API Persistent Object Enumeration Functions");
-ADBG_CASE_DEFINE(regression, 6010, xtest_tee_test_6010, "Test Storage");
-
-#ifdef WITH_GP_TESTS
-ADBG_CASE_DEFINE(regression, 6011, xtest_tee_test_6011,
-		 "Test TEE GP TTA DS init objects");
-#endif
-
-ADBG_CASE_DEFINE(regression, 6012, xtest_tee_test_6012,
-		 "Test TEE GP TTA DS init objects");
-ADBG_CASE_DEFINE(regression, 6013, xtest_tee_test_6013,
-		 "Key usage in Persistent objects");
-ADBG_CASE_DEFINE(regression, 6014, xtest_tee_test_6014,
-		 "Loop on Persistent objects");
-ADBG_CASE_DEFINE(regression, 6015, xtest_tee_test_6015, "Storage isolation");
-ADBG_CASE_DEFINE(regression, 6016, xtest_tee_test_6016, "Storage concurency");
-ADBG_CASE_DEFINE(regression, 6017, xtest_tee_test_6017,
-		 "Test Persistent objects info");
-ADBG_CASE_DEFINE(regression, 6018, xtest_tee_test_6018, "Large object");
-ADBG_CASE_DEFINE(regression, 6019, xtest_tee_test_6019, "Storage independence");
 ADBG_CASE_DEFINE(regression, 6020, xtest_tee_test_6020,
 		 "Object IDs in SHM (negative)");

--- a/host/xtest/regression_7000.c
+++ b/host/xtest/regression_7000.c
@@ -100,6 +100,8 @@ static void xtest_tee_7001(ADBG_Case_t *c)
 	TEEC_ReleaseSharedMemory(SHARE_MEM01);
 	TEEC_FinalizeContext(CONTEXT01);
 }
+ADBG_CASE_DEFINE(regression, 7001, xtest_tee_7001,
+	"Allocate_In RELEASE_SHARED_MEMORY_WHEN_ALLOCATED");
 
 /*29-c2-4c*/
 static void xtest_tee_7002(ADBG_Case_t *c)
@@ -113,6 +115,8 @@ static void xtest_tee_7002(ADBG_Case_t *c)
 					 SIZE_OVER_MEMORY, TEEC_MEM_INPUT));
 	TEEC_FinalizeContext(CONTEXT01);
 }
+ADBG_CASE_DEFINE(regression, 7002, xtest_tee_7002,
+	"Allocate_out_of_memory INITIALIZE_CONTEXT_NAMES");
 
 /*29-b0-da*/
 static void xtest_tee_7003(ADBG_Case_t *c)
@@ -128,6 +132,8 @@ static void xtest_tee_7003(ADBG_Case_t *c)
 	TEEC_ReleaseSharedMemory(SHARE_MEM01);
 	TEEC_FinalizeContext(CONTEXT01);
 }
+ADBG_CASE_DEFINE(regression, 7003, xtest_tee_7003,
+	"ReleaseSharedMemory_null RELEASE_SHARED_MEMORY_WHEN_ALLOCATED");
 
 /*29-1c-00*/
 static void xtest_tee_7004(ADBG_Case_t *c)
@@ -142,6 +148,8 @@ static void xtest_tee_7004(ADBG_Case_t *c)
 	TEEC_ReleaseSharedMemory(SHARE_MEM01);
 	TEEC_FinalizeContext(CONTEXT01);
 }
+ADBG_CASE_DEFINE(regression, 7004, xtest_tee_7004,
+	"Allocate_InOut RELEASE_SHARED_MEMORY_WHEN_ALLOCATED");
 
 /*29-9f-a2*/
 static void xtest_tee_7005(ADBG_Case_t *c)
@@ -156,6 +164,8 @@ static void xtest_tee_7005(ADBG_Case_t *c)
 	TEEC_ReleaseSharedMemory(SHARE_MEM01);
 	TEEC_FinalizeContext(CONTEXT01);
 }
+ADBG_CASE_DEFINE(regression, 7005, xtest_tee_7005,
+	"Register_In RELEASE_SHARED_MEMORY_WHEN_REGISTERED");
 
 /*29-11-02*/
 static void xtest_tee_7006(ADBG_Case_t *c)
@@ -170,6 +180,8 @@ static void xtest_tee_7006(ADBG_Case_t *c)
 	TEEC_ReleaseSharedMemory(SHARE_MEM01);
 	TEEC_FinalizeContext(CONTEXT01);
 }
+ADBG_CASE_DEFINE(regression, 7006, xtest_tee_7006,
+	"Register_notZeroLength_Out RELEASE_SHARED_MEMORY_WHEN_REGISTERED");
 
 /*29-1f-a2*/
 static void xtest_tee_7007(ADBG_Case_t *c)
@@ -184,6 +196,8 @@ static void xtest_tee_7007(ADBG_Case_t *c)
 	TEEC_ReleaseSharedMemory(SHARE_MEM01);
 	TEEC_FinalizeContext(CONTEXT01);
 }
+ADBG_CASE_DEFINE(regression, 7007, xtest_tee_7007,
+	"Register_InOut RELEASE_SHARED_MEMORY_WHEN_REGISTERED");
 
 /*29-2e-8d*/
 static void xtest_tee_7008(ADBG_Case_t *c)
@@ -198,6 +212,8 @@ static void xtest_tee_7008(ADBG_Case_t *c)
 	TEEC_ReleaseSharedMemory(SHARE_MEM01);
 	TEEC_FinalizeContext(CONTEXT01);
 }
+ADBG_CASE_DEFINE(regression, 7008, xtest_tee_7008,
+	"Register_zeroLength_Out RELEASE_SHARED_MEMORY_WHEN_REGISTERED");
 
 /*29-2b-3f*/
 static void xtest_tee_7009(ADBG_Case_t *c)
@@ -211,6 +227,8 @@ static void xtest_tee_7009(ADBG_Case_t *c)
 			TEEC_ORIGIN_ANY_NOT_TRUSTED_APP, TEEC_UNDEFINED_ERROR);
 	TEEC_FinalizeContext(CONTEXT01);
 }
+ADBG_CASE_DEFINE(regression, 7009, xtest_tee_7009,
+	"OpenSession_error_notExistingTA OPEN_SESSION_TARGET_TRUSTED_APP");
 
 /*29-cd-39*/
 static void xtest_tee_7010(ADBG_Case_t *c)
@@ -225,6 +243,8 @@ static void xtest_tee_7010(ADBG_Case_t *c)
 	TEEC_ReleaseSharedMemory(SHARE_MEM01);
 	TEEC_FinalizeContext(CONTEXT01);
 }
+ADBG_CASE_DEFINE(regression, 7010, xtest_tee_7010,
+	"Allocate_Out RELEASE_SHARED_MEMORY_WHEN_ALLOCATED");
 
 /*29-a2-e3*/
 static void xtest_tee_7013(ADBG_Case_t *c)
@@ -239,6 +259,8 @@ static void xtest_tee_7013(ADBG_Case_t *c)
 			TEEC_ORIGIN_ANY_NOT_TRUSTED_APP, TEEC_UNDEFINED_ERROR);
 	TEEC_FinalizeContext(CONTEXT01);
 }
+ADBG_CASE_DEFINE(regression, 7013, xtest_tee_7013,
+	"OpenSession_error_originTEE OPEN_SESSION_TARGET_TRUSTED_APP");
 
 /*29-db-48*/
 static void xtest_tee_7016(ADBG_Case_t *c)
@@ -248,6 +270,8 @@ static void xtest_tee_7016(ADBG_Case_t *c)
 	TEEC_SelectApp(CLIENT_APP01, THREAD01_DEFAULT);
 	TEEC_CloseSession(NULL);
 }
+ADBG_CASE_DEFINE(regression, 7016, xtest_tee_7016,
+	"CloseSession_null CLOSE_SESSION_IGNORE_SESSION_NULL");
 
 /*29-a1-83*/
 static void xtest_tee_7017(ADBG_Case_t *c)
@@ -258,6 +282,8 @@ static void xtest_tee_7017(ADBG_Case_t *c)
 	XML_InitializeContext(c, INVALID_NOT_EXISTING_TEE, CONTEXT01,
 			      TEEC_UNDEFINED_ERROR);
 }
+ADBG_CASE_DEFINE(regression, 7017, xtest_tee_7017,
+	"InitializeContext_NotExistingTEE INITIALIZE_CONTEXT_NAMES");
 
 /*29-c1-a5*/
 static void xtest_tee_7018(ADBG_Case_t *c)
@@ -267,6 +293,8 @@ static void xtest_tee_7018(ADBG_Case_t *c)
 	TEEC_SelectApp(CLIENT_APP01, THREAD01_DEFAULT);
 	TEEC_FinalizeContext(NULL);
 }
+ADBG_CASE_DEFINE(regression, 7018, xtest_tee_7018,
+	"FinalizeContext_null FINALIZE_CONTEXT_IGNORE_NULL");
 
 /*29-91-aa*/
 static void xtest_tee_7019(ADBG_Case_t *c)
@@ -283,34 +311,5 @@ static void xtest_tee_7019(ADBG_Case_t *c)
 	TEEC_SelectApp(CLIENT_APP01, THREAD01_DEFAULT);
 	TEEC_FinalizeContext(CONTEXT01);
 }
-
-ADBG_CASE_DEFINE(regression, 7001, xtest_tee_7001,
-	"Allocate_In RELEASE_SHARED_MEMORY_WHEN_ALLOCATED");
-ADBG_CASE_DEFINE(regression, 7002, xtest_tee_7002,
-	"Allocate_out_of_memory INITIALIZE_CONTEXT_NAMES");
-ADBG_CASE_DEFINE(regression, 7003, xtest_tee_7003,
-	"ReleaseSharedMemory_null RELEASE_SHARED_MEMORY_WHEN_ALLOCATED");
-ADBG_CASE_DEFINE(regression, 7004, xtest_tee_7004,
-	"Allocate_InOut RELEASE_SHARED_MEMORY_WHEN_ALLOCATED");
-ADBG_CASE_DEFINE(regression, 7005, xtest_tee_7005,
-	"Register_In RELEASE_SHARED_MEMORY_WHEN_REGISTERED");
-ADBG_CASE_DEFINE(regression, 7006, xtest_tee_7006,
-	"Register_notZeroLength_Out RELEASE_SHARED_MEMORY_WHEN_REGISTERED");
-ADBG_CASE_DEFINE(regression, 7007, xtest_tee_7007,
-	"Register_InOut RELEASE_SHARED_MEMORY_WHEN_REGISTERED");
-ADBG_CASE_DEFINE(regression, 7008, xtest_tee_7008,
-	"Register_zeroLength_Out RELEASE_SHARED_MEMORY_WHEN_REGISTERED");
-ADBG_CASE_DEFINE(regression, 7009, xtest_tee_7009,
-	"OpenSession_error_notExistingTA OPEN_SESSION_TARGET_TRUSTED_APP");
-ADBG_CASE_DEFINE(regression, 7010, xtest_tee_7010,
-	"Allocate_Out RELEASE_SHARED_MEMORY_WHEN_ALLOCATED");
-ADBG_CASE_DEFINE(regression, 7013, xtest_tee_7013,
-	"OpenSession_error_originTEE OPEN_SESSION_TARGET_TRUSTED_APP");
-ADBG_CASE_DEFINE(regression, 7016, xtest_tee_7016,
-	"CloseSession_null CLOSE_SESSION_IGNORE_SESSION_NULL");
-ADBG_CASE_DEFINE(regression, 7017, xtest_tee_7017,
-	"InitializeContext_NotExistingTEE INITIALIZE_CONTEXT_NAMES");
-ADBG_CASE_DEFINE(regression, 7018, xtest_tee_7018,
-	"FinalizeContext_null FINALIZE_CONTEXT_IGNORE_NULL");
 ADBG_CASE_DEFINE(regression, 7019, xtest_tee_7019,
 	"InitializeContext_concurrentContext INITIALIZE_CONTEXT_NAMES");

--- a/host/xtest/regression_8000.c
+++ b/host/xtest/regression_8000.c
@@ -23,14 +23,6 @@
 #define WITH_CONCAT_KDF 1
 #define WITH_PBKDF2 1
 
-static void xtest_tee_test_8001(ADBG_Case_t *c);
-static void xtest_tee_test_8002(ADBG_Case_t *c);
-
-ADBG_CASE_DEFINE(regression, 8001, xtest_tee_test_8001,
-		 "Test TEE Internal API key derivation extensions");
-ADBG_CASE_DEFINE(regression, 8002, xtest_tee_test_8002,
-	"Secure Storage Key Manager API Self Test");
-
 /*
  * HKDF test data from RFC 5869
  */
@@ -745,6 +737,8 @@ static void xtest_tee_test_8001(ADBG_Case_t *c)
 
 	TEEC_CloseSession(&session);
 }
+ADBG_CASE_DEFINE(regression, 8001, xtest_tee_test_8001,
+		 "Test TEE Internal API key derivation extensions");
 
 /* secure storage key manager self test */
 static void xtest_tee_test_8002(ADBG_Case_t *c)
@@ -768,3 +762,5 @@ static void xtest_tee_test_8002(ADBG_Case_t *c)
 exit:
 	TEEC_CloseSession(&sess);
 }
+ADBG_CASE_DEFINE(regression, 8002, xtest_tee_test_8002,
+	"Secure Storage Key Manager API Self Test");


### PR DESCRIPTION
Moves all ADBG_CASE_DEFINE() to right after the function implementing
the test case.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>