### PR TITLE
regression 6018: reduce even more blocks

### DIFF
--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -1827,7 +1827,7 @@ static void xtest_tee_test_6018_single(ADBG_Case_t *c, uint32_t storage_id)
 
 	if (storage_is(storage_id, TEE_STORAGE_PRIVATE_RPMB)) {
 		/* RPMB FS is a bit resource constrained */
-		num_blocks = 10;
+		num_blocks = 2;
 		block_size = 1024;
 	} else {
 		num_blocks = 20;


### PR DESCRIPTION
We are still getting out-of-memory errors in 6018 when we have enabled
the pager and are using RPMB on HiKey. By reducing the number of blocks
written to RPMB a bit more we get rid of the problem. The problem seems
to be that the heap gets too fragmented when we are using the pager, so
even though this solves the problem here and now, we would need to look
into whether we can do something about the fragmented heap in the long
run.

Related, we have reduced this in the past:
  20949ea945f2 ("regression 6018: reduce the number of blocks written")

Fixes: https://github.com/OP-TEE/optee_os/issues/2580

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Tested-by: Joakim Bech <joakim.bech@linaro.org> (HiKey 6220)