### PR TITLE
add checkpatch scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,15 @@ patch:
 	$(q) echo "Please define CFG_GP_PACKAGE_PATH" && false
 endif
 
+.PHONY: checkpatch checkpatch-staging checkpatch-working
+checkpatch: checkpatch-staging checkpatch-working
+
+checkpatch-working:
+	@./scripts/checkpatch.sh
+
+checkpatch-staging:
+	@./scripts/checkpatch.sh --cached
+
 install:
 	$(echo) '  INSTALL ${DESTDIR}/lib/optee_armtz'
 	$(q)mkdir -p ${DESTDIR}/lib/optee_armtz

--- a/scripts/checkpatch.sh
+++ b/scripts/checkpatch.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -z "$OPTEE_OS_PATH" ]; then
+   OPTEE_OS_PATH="../optee_os";
+fi
+
+source $OPTEE_OS_PATH/scripts/checkpatch.sh "$@"

--- a/typedefs.checkpatch
+++ b/typedefs.checkpatch
@@ -1,0 +1,2 @@
+TEE_Result
+TEE_UUID


### PR DESCRIPTION
copied the checkpatch-helper scripts from optee_os repo
fixed README.md to reflect checkpatch targets still missing

Signed-off-by: Markus S. Wamser <markus.wamser@mixed-mode.de>