### PR TITLE
Android.mk: add required header files to LOCAL_ADDITIONAL_DEPENDENCIES

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -65,7 +65,8 @@ $(TARGET_OUT_HEADERS)/$(1).h: $(LOCAL_PATH)/$(2)
 	@echo '  GEN     $$@'
 	@$(LOCAL_PATH)/scripts/file_to_c.py --inf $$< --out $$@ --name $(1)
 
-$(LOCAL_PATH)/host/xtest/regression_8100.c: $(TARGET_OUT_HEADERS)/$(1).h
+LOCAL_ADDITIONAL_DEPENDENCIES += $(TARGET_OUT_HEADERS)/$(1).h
+
 endef
 
 $(eval $(call my-embed-file,regression_8100_ca_crt,cert/ca.crt))
@@ -107,7 +108,7 @@ endif
 ## out/target/product/hikey/optee/arm-plat-hikey/core/tee.bin
 ## it will be generated after build the optee_os with target BUILD_OPTEE_OS
 ## which is defined in the common ta build mk file included before,
-LOCAL_ADDITIONAL_DEPENDENCIES := $(OPTEE_BIN)
+LOCAL_ADDITIONAL_DEPENDENCIES += $(OPTEE_BIN)
 
 include $(BUILD_EXECUTABLE)
 


### PR DESCRIPTION
 Android.mk: add required header files to LOCAL_ADDITIONAL_DEPENDENCIES

to avoid making them depenencies for regression_8100.c file
to workaround the PHONY target limitation.
https://android.googlesource.com/platform/build/+/HEAD/Changes.md#phony_targets

Otherwise, it will report "writing to readonly directory:" for regression_8100.c file
during the android aosp master build

As if we use $(LOCAL_PATH)/host/xtest/regression_8100.c as target,
it will break the 2nd rule of following:
    The target is a real file, but it's outside the output directories.
    All outputs from the build system should be within the output directory,
    otherwise m clean is unable to clean the build, and future builds may not work properly.
like described in the ".PHONY rule enforcement" section here:
https://android.googlesource.com/platform/build/+/master/Changes.md#phony_targets

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>