### PR TITLE
ta: cmake: header files rely on C support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.2)
+project (optee_test C)
 
 # Default cross compile settings
 set (CMAKE_TOOLCHAIN_FILE CMakeToolchain.txt)

--- a/ta/CMakeLists.txt
+++ b/ta/CMakeLists.txt
@@ -1,4 +1,4 @@
-project (xtest-ta-headers)
+project (xtest-ta-headers C)
 
 add_library(${PROJECT_NAME} INTERFACE)
 


### PR DESCRIPTION
Without specify the TA header files are in C source file scope
cmake may attempt to look for resources as g++. When building
with environments that do not provide such tools as when building
from native buildroot ofr a qemu target, optee_client fails to
build. This change ensure a minimal C support allows to build
optee_client with cmake.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>