### PR TITLE
regression: split 4007 into key types

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -4335,43 +4335,23 @@ static bool generate_and_test_key(ADBG_Case_t *c, TEEC_Session *s,
 	return ret_val;
 }
 
-static void xtest_test_keygen_noparams(ADBG_Case_t *c, TEEC_Session *session)
+struct key_types_noparam {
+	unsigned level;
+	const char *name;
+	uint32_t key_type;
+	uint32_t quanta;
+	uint32_t min_size;
+	uint32_t max_size;
+};
+
+static void keygen_noparams(ADBG_Case_t *c, TEEC_Session *session,
+			    const struct key_types_noparam *key_types,
+			    size_t num_key_types)
 {
 	size_t n;
 	uint32_t key_size;
-	static const struct {
-		unsigned level;
-		const char *name;
-		uint32_t key_type;
-		uint32_t quanta;
-		uint32_t min_size;
-		uint32_t max_size;
-	} key_types[] = {
-		{ 0, "AES", TEE_TYPE_AES, 64, 128,
-		  256 /* valid sizes 128, 192, 256 */ },
-		{ 0, "DES", TEE_TYPE_DES, 56, 56, 56 /* valid size 56 */ },
-		{ 0, "DES3", TEE_TYPE_DES3, 56, 112,
-		  168 /* valid sizes 112, 168 */ },
-		{ 0, "HMAC-MD5", TEE_TYPE_HMAC_MD5, 8, 64, 512 },
-		{ 0, "HMAC-SHA1", TEE_TYPE_HMAC_SHA1, 8, 80, 512 },
-		{ 0, "HMAC-SHA224", TEE_TYPE_HMAC_SHA224, 8, 112, 512 },
-		{ 0, "HMAC-SHA256", TEE_TYPE_HMAC_SHA256, 8, 192, 1024 },
-		{ 0, "HMAC-SHA384", TEE_TYPE_HMAC_SHA384, 8, 256, 1024 },
-		{ 0, "HMAC-SHA512", TEE_TYPE_HMAC_SHA512, 8, 256, 1024 },
-		{ 0, "Generic secret", TEE_TYPE_GENERIC_SECRET, 8, 128, 4096 },
-		{ 1, "RSA-2048", TEE_TYPE_RSA_KEYPAIR, 1, 2048, 2048 },
 
-		/* New tests added to check non-regression of issue #5398 */
-		{ 0, "RSA-256", TEE_TYPE_RSA_KEYPAIR, 1, 256, 256 },
-		{ 1, "RSA-384", TEE_TYPE_RSA_KEYPAIR, 1, 384, 384 },
-		{ 1, "RSA-512", TEE_TYPE_RSA_KEYPAIR, 1, 512, 512 },
-		{ 1, "RSA-640", TEE_TYPE_RSA_KEYPAIR, 1, 640, 640 },
-		{ 1, "RSA-768", TEE_TYPE_RSA_KEYPAIR, 1, 768, 768 },
-		{ 1, "RSA-896", TEE_TYPE_RSA_KEYPAIR, 1, 896, 896 },
-		{ 1, "RSA-1024", TEE_TYPE_RSA_KEYPAIR, 1, 1024, 1024 },
-	};
-
-	for (n = 0; n < ARRAY_SIZE(key_types); n++) {
+	for (n = 0; n < num_key_types; n++) {
 		uint32_t min_size = key_types[n].min_size;
 		uint32_t max_size = key_types[n].max_size;
 		uint32_t quanta = key_types[n].quanta;
@@ -4393,8 +4373,70 @@ static void xtest_test_keygen_noparams(ADBG_Case_t *c, TEEC_Session *session)
 	}
 }
 
-static void xtest_test_keygen_dh(ADBG_Case_t *c, TEEC_Session *session)
+static void xtest_tee_test_4007_symmetric(ADBG_Case_t *c)
 {
+	TEEC_Session session = { 0 };
+	uint32_t ret_orig;
+	static const struct key_types_noparam key_types[] = {
+		{ 0, "AES", TEE_TYPE_AES, 64, 128,
+		  256 /* valid sizes 128, 192, 256 */ },
+		{ 0, "DES", TEE_TYPE_DES, 56, 56, 56 /* valid size 56 */ },
+		{ 0, "DES3", TEE_TYPE_DES3, 56, 112,
+		  168 /* valid sizes 112, 168 */ },
+		{ 0, "HMAC-MD5", TEE_TYPE_HMAC_MD5, 8, 64, 512 },
+		{ 0, "HMAC-SHA1", TEE_TYPE_HMAC_SHA1, 8, 80, 512 },
+		{ 0, "HMAC-SHA224", TEE_TYPE_HMAC_SHA224, 8, 112, 512 },
+		{ 0, "HMAC-SHA256", TEE_TYPE_HMAC_SHA256, 8, 192, 1024 },
+		{ 0, "HMAC-SHA384", TEE_TYPE_HMAC_SHA384, 8, 256, 1024 },
+		{ 0, "HMAC-SHA512", TEE_TYPE_HMAC_SHA512, 8, 256, 1024 },
+		{ 0, "Generic secret", TEE_TYPE_GENERIC_SECRET, 8, 128, 4096 },
+	};
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
+					&ret_orig)))
+		return;
+
+	keygen_noparams(c, &session, key_types, ARRAY_SIZE(key_types));
+
+	TEEC_CloseSession(&session);
+}
+ADBG_CASE_DEFINE(regression, 4007_symmetric, xtest_tee_test_4007_symmetric,
+		"Test TEE Internal API Generate Symmetric key");
+
+static void xtest_tee_test_4007_rsa(ADBG_Case_t *c)
+{
+	TEEC_Session session = { 0 };
+	uint32_t ret_orig;
+	static const struct key_types_noparam key_types[] = {
+		{ 0, "RSA-256", TEE_TYPE_RSA_KEYPAIR, 1, 256, 256 },
+		{ 1, "RSA-384", TEE_TYPE_RSA_KEYPAIR, 1, 384, 384 },
+		{ 1, "RSA-512", TEE_TYPE_RSA_KEYPAIR, 1, 512, 512 },
+		{ 1, "RSA-640", TEE_TYPE_RSA_KEYPAIR, 1, 640, 640 },
+		{ 1, "RSA-768", TEE_TYPE_RSA_KEYPAIR, 1, 768, 768 },
+		{ 1, "RSA-896", TEE_TYPE_RSA_KEYPAIR, 1, 896, 896 },
+		{ 1, "RSA-1024", TEE_TYPE_RSA_KEYPAIR, 1, 1024, 1024 },
+		{ 1, "RSA-2048", TEE_TYPE_RSA_KEYPAIR, 1, 2048, 2048 },
+		{ 1, "RSA-3072", TEE_TYPE_RSA_KEYPAIR, 1, 3072, 3072 },
+		{ 1, "RSA-4096", TEE_TYPE_RSA_KEYPAIR, 1, 4096, 4096 },
+	};
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
+					&ret_orig)))
+		return;
+
+	keygen_noparams(c, &session, key_types, ARRAY_SIZE(key_types));
+
+	TEEC_CloseSession(&session);
+}
+ADBG_CASE_DEFINE(regression, 4007_rsa, xtest_tee_test_4007_rsa,
+		"Test TEE Internal API Generate RSA key");
+
+static void xtest_tee_test_4007_dh(ADBG_Case_t *c)
+{
+	TEEC_Session session = { 0 };
+	uint32_t ret_orig;
 	size_t n;
 	size_t param_count;
 	/*
@@ -4459,6 +4501,10 @@ static void xtest_test_keygen_dh(ADBG_Case_t *c, TEEC_Session *session)
 		{ 1, 2048, XTEST_DH_GK_DATA_SUBPRIME(keygen_dh2048_subprime) }
 	};
 
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
+					&ret_orig)))
+		return;
 
 	for (n = 0; n < ARRAY_SIZE(key_types); n++) {
 		if (key_types[n].level > level)
@@ -4495,7 +4541,7 @@ static void xtest_test_keygen_dh(ADBG_Case_t *c, TEEC_Session *session)
 		}
 
 		if (!ADBG_EXPECT_TRUE(c,
-			generate_and_test_key(c, session, TEE_TYPE_DH_KEYPAIR,
+			generate_and_test_key(c, &session, TEE_TYPE_DH_KEYPAIR,
 				*key_types[n].private_bits,
 				key_types[n]. key_size, params, param_count)))
 			break;
@@ -4505,10 +4551,16 @@ static void xtest_test_keygen_dh(ADBG_Case_t *c, TEEC_Session *session)
 				   key_types[n].key_size,
 				   *key_types[n].private_bits);
 	}
-}
 
-static void xtest_test_keygen_dsa(ADBG_Case_t *c, TEEC_Session *session)
+	TEEC_CloseSession(&session);
+}
+ADBG_CASE_DEFINE(regression, 4007_dh, xtest_tee_test_4007_dh,
+		"Test TEE Internal API Generate DH key");
+
+static void xtest_tee_test_4007_dsa(ADBG_Case_t *c)
 {
+	TEEC_Session session = { 0 };
+	uint32_t ret_orig;
 	size_t n;
 	size_t param_count;
 	TEE_Attribute params[4];
@@ -4539,6 +4591,11 @@ static void xtest_test_keygen_dsa(ADBG_Case_t *c, TEEC_Session *session)
 		{ 1, 1024, XTEST_DSA_GK_DATA(keygen_dsa1024) },
 	};
 
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
+					&ret_orig)))
+		return;
+
 	for (n = 0; n < ARRAY_SIZE(key_types); n++) {
 		if (key_types[n].level > level)
 			continue;
@@ -4559,7 +4616,7 @@ static void xtest_test_keygen_dsa(ADBG_Case_t *c, TEEC_Session *session)
 			       key_types[n].base, key_types[n].base_len);
 
 		if (!ADBG_EXPECT_TRUE(c,
-			generate_and_test_key(c, session, TEE_TYPE_DSA_KEYPAIR,
+			generate_and_test_key(c, &session, TEE_TYPE_DSA_KEYPAIR,
 				1, key_types[n]. key_size, params,
 				param_count)))
 			break;
@@ -4567,10 +4624,16 @@ static void xtest_test_keygen_dsa(ADBG_Case_t *c, TEEC_Session *session)
 		Do_ADBG_EndSubCase(c, "Generate DSA key %d bits",
 				   key_types[n].key_size);
 	}
-}
 
-static void xtest_test_keygen_ecc(ADBG_Case_t *c, TEEC_Session *session)
+	TEEC_CloseSession(&session);
+}
+ADBG_CASE_DEFINE(regression, 4007_dsa, xtest_tee_test_4007_dsa,
+		"Test TEE Internal API Generate DSA key");
+
+static void xtest_tee_test_4007_ecc(ADBG_Case_t *c)
 {
+	TEEC_Session session = { 0 };
+	uint32_t ret_orig;
 	size_t n;
 	size_t param_count;
 	TEE_Attribute params[4];
@@ -4607,6 +4670,11 @@ static void xtest_test_keygen_ecc(ADBG_Case_t *c, TEEC_Session *session)
 		521 },
 	};
 
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
+					&ret_orig)))
+		return;
+
 	for (n = 0; n < ARRAY_SIZE(key_types); n++) {
 		if (key_types[n].level > level)
 			continue;
@@ -4618,37 +4686,18 @@ static void xtest_test_keygen_ecc(ADBG_Case_t *c, TEEC_Session *session)
 			             key_types[n].curve, 0);
 
 		if (!ADBG_EXPECT_TRUE(c,
-			generate_and_test_key(c, session, key_types[n].algo,
+			generate_and_test_key(c, &session, key_types[n].algo,
 				0, key_types[n].key_size, params,
 				param_count)))
 			break;
 
 		Do_ADBG_EndSubCase(c, "Generate %s", key_types[n].name);
 	}
-}
-
-static void xtest_tee_test_4007(ADBG_Case_t *c)
-{
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-
-	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
-		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
-					&ret_orig)))
-		return;
-
-	xtest_test_keygen_noparams(c, &session);
-
-	xtest_test_keygen_dh(c, &session);
-
-	xtest_test_keygen_dsa(c, &session);
-
-	xtest_test_keygen_ecc (c, &session);
 
 	TEEC_CloseSession(&session);
 }
-ADBG_CASE_DEFINE(regression, 4007, xtest_tee_test_4007,
-		"Test TEE Internal API Generate key");
+ADBG_CASE_DEFINE(regression, 4007_ecc, xtest_tee_test_4007_ecc,
+		"Test TEE Internal API Generate ECC key");
 
 static void xtest_tee_test_4008(ADBG_Case_t *c)
 {


### PR DESCRIPTION
Splits regression case 4007 into
- 4007_symmetric for symmetric keys
- 4007_rsa for RSA keys, which also is complemented with 3072 and 4096 keys
- 4007_dh for Diffie-Hellman keys
- 4007_ecc for ECC keys

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>