### PR TITLE
xtest: prevent potential overflow

### DIFF
--- a/host/xtest/adbg/src/adbg_run.c
+++ b/host/xtest/adbg/src/adbg_run.c
@@ -100,7 +100,7 @@ int Do_ADBG_AppendToSuite(
 		snprintf(p, size, "%s+%s", Dest_p->SuiteID_p,
 			 Source_p->SuiteID_p);
 	else
-		strncpy(p, Source_p->SuiteID_p, size);
+		snprintf(p, size, "%s", Source_p->SuiteID_p);
 	free((void *)Dest_p->SuiteID_p);
 	Dest_p->SuiteID_p = p;
 

--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -5018,18 +5018,28 @@ static void xtest_tee_test_4011(ADBG_Case_t *c)
 				out, out_size, tmp, &tmp_size)))
 			goto out;
 
+		if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, tmp_size, <=, sizeof(tmp)))
+			goto out;
+
 		/* 4.1 */
-		for (n = 0; n < tmp_size; n++)
+		for (n = 0; n < tmp_size - i; n++)
 			if (tmp[n] == 0xff)
 				break;
+
+		/* Shall find at least a padding start before buffer end */
+	        if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, n, <, tmp_size - i - 1))
+			goto out;
+
 		for (m = n + 1; m < tmp_size; m++)
 			if (tmp[m] != 0xff)
 				break;
+
 		/* 4.2 */
 		memmove(tmp + n + i, tmp + m, tmp_size - m);
+
 		/* 4.3 */
-		for (n = n + tmp_size - m + i; n < tmp_size; n++)
-			tmp[n] = 0;
+		n = n + i + tmp_size - m;
+		memset(tmp + n, 0, tmp_size - n);
 
 		/* 5 */
 		out_size = sizeof(out);


### PR DESCRIPTION
**(edited)**

Fix issues reported by GCC 8.1.0 with  `-Werror=stringop-overflow=.` **as reported per https://github.com/OP-TEE/optee_test/issues/296**.
**Issues also reported with a GCC 8.2.0 from a standard build command, i.e:
`make TA_DEV_KIT_DIR=path/to/devkit OPTEE_CLIENT_EXPORT=path/to/client-export`**

  host/xtest/adbg/src/adbg_run.c:103:3: error: 'strncpy' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]

  host/xtest/regression_4000.c:4986:3: error: 'memmove' pointer overflow between offset [0, 8] and size [4294967295, 2147483647] accessing array 'tmp' with type 'uint8_t[1024]' {aka 'unsigned char[1024]'} [-Werror=array-bounds]

Fixes issue https://github.com/OP-TEE/optee_test/issues/296

~~This change also adds test on buffer size output value to prevent buffer overflows in few other specific cases.~~

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
Signed-off-by: Simon Hughes <simon.hughes@arm.com>