### PR TITLE
cmake: locate files WRT to project home directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project (optee_test C)
 # Default cross compile settings
 set (CMAKE_TOOLCHAIN_FILE CMakeToolchain.txt)
 
+set (OPTEE_TEST_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 ################################################################################
 # Compiler flags:
 #   We want to use the same flags in the entire optee_client git

--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -21,20 +21,20 @@ include(GNUInstallDirs)
 macro(EMBED_8100FILE prefix infile)
 	add_custom_command(
 		OUTPUT  regression_8100_${prefix}.h
-		COMMAND ../../scripts/file_to_c.py --inf ${infile}
+		COMMAND ${OPTEE_TEST_ROOT_DIR}/scripts/file_to_c.py --inf ${infile}
 	--out ${CMAKE_CURRENT_BINARY_DIR}/regression_8100_${prefix}.h
 	--name regression_8100_${prefix}
-		DEPENDS ../../scripts/file_to_c.py ${infile}
+		DEPENDS ${OPTEE_TEST_ROOT_DIR}/scripts/file_to_c.py ${infile}
 	)
 
 	set_property(SOURCE regression_8100.c APPEND PROPERTY OBJECT_DEPENDS
 		     ${CMAKE_CURRENT_BINARY_DIR}/regression_8100_${prefix}.h)
 endmacro(EMBED_8100FILE)
 
-EMBED_8100FILE(ca_crt ../../cert/ca.crt)
-EMBED_8100FILE(mid_crt ../../cert/mid.crt)
-EMBED_8100FILE(my_crt ../../cert/my.crt)
-EMBED_8100FILE(my_csr ../../cert/my.csr)
+EMBED_8100FILE(ca_crt ${OPTEE_TEST_ROOT_DIR}/cert/ca.crt)
+EMBED_8100FILE(mid_crt ${OPTEE_TEST_ROOT_DIR}/cert/mid.crt)
+EMBED_8100FILE(my_crt ${OPTEE_TEST_ROOT_DIR}/cert/my.crt)
+EMBED_8100FILE(my_csr ${OPTEE_TEST_ROOT_DIR}/cert/my.csr)
 
 set (SRC
 	adbg/src/adbg_case.c
@@ -88,6 +88,7 @@ target_include_directories(${PROJECT_NAME}
 	PRIVATE adbg/include
 	PRIVATE xml/include
 	PRIVATE ${OPTEE_TEST_SDK}/host_include
+	PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries (${PROJECT_NAME}


### PR DESCRIPTION
Build system can't find file_to_c.py and certificate files,
because CMakeLists.txt have an assumption about those files
locations. So, when you try to use separate build directory,
relative path in CMakeLists.txt are not working as expected.

It is better to use ${CMAKE_HOME_DIRECTORY} instead of assuming
that mentioned files can be reached from build directory.

Signed-off-by: Volodymyr Babchuk <vlad.babchuk@gmail.com>