### PR TITLE
ta/cryp_taf: correct return value

### DIFF
--- a/ta/crypt/cryp_taf.c
+++ b/ta/crypt/cryp_taf.c
@@ -426,8 +426,7 @@ TEE_Result ta_entry_copy_object_attributes(uint32_t param_type,
 			  (TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE,
 			   TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE));
 
-	TEE_CopyObjectAttributes1(dst, src);
-	return TEE_SUCCESS;
+	return TEE_CopyObjectAttributes1(dst, src);
 }
 
 TEE_Result ta_entry_generate_key(uint32_t param_type, TEE_Param params[4])


### PR DESCRIPTION
ta_entry_copy_object_attributes() should faithfully returns
TEE_CopyObjectAttributes1()'s value instead of always overwriting it with
TEE_SUCCESS.

Signed-off-by: Oliver Chiang <rockerfeynman@gmail.com>