### PR TITLE
regression 4100: update string conversion loop

### DIFF
--- a/host/xtest/regression_4100.c
+++ b/host/xtest/regression_4100.c
@@ -446,15 +446,18 @@ static TEEC_Result convert_from_string(ADBG_Case_t *c, TEEC_Session *s,
 
 	while (spos) {
 		nibble = digit_value(str[spos - 1]);
-		if (nibble == -1)
+		if (nibble == -1) {
+			spos--;
 			break;
+		}
 		os[ospos] = nibble;
 
 		if (spos > 1) {
 			nibble = digit_value(str[spos - 2]);
-			if (nibble == -1)
+			if (nibble == -1) {
+				spos -= 2;
 				break;
-
+			}
 			os[ospos] |= nibble << 4;
 			ospos--;
 			spos--;

--- a/host/xtest/regression_4100.c
+++ b/host/xtest/regression_4100.c
@@ -445,21 +445,21 @@ static TEEC_Result convert_from_string(ADBG_Case_t *c, TEEC_Session *s,
 		return TEEC_ERROR_OUT_OF_MEMORY;
 
 	while (spos) {
-		spos--;
-		nibble = digit_value(str[spos]);
+		nibble = digit_value(str[spos - 1]);
 		if (nibble == -1)
 			break;
 		os[ospos] = nibble;
 
-		if (!spos)
-			break;
-		spos--;
-		nibble = digit_value(str[spos]);
-		if (nibble == -1)
-			break;
+		if (spos > 1) {
+			nibble = digit_value(str[spos - 2]);
+			if (nibble == -1)
+				break;
 
-		os[ospos] |= nibble << 4;
-		ospos--;
+			os[ospos] |= nibble << 4;
+			ospos--;
+			spos--;
+		}
+		spos--;
 	}
 
 	if (spos)


### PR DESCRIPTION
Change the loop used to convert string into numerical value.
The original loop was fine but its implementation hits toolchain
unsafe-loop-optimizations feature. The new implementation
proposed here simplifies a bit the loop and prevents toolchain
from complaining when directive -Werror=unsafe-loop-optimizations
is enabled.

Issue reported by the Buildroot cross toolchain [1] with the
following error traces:

build/armv7/build/optee-test-3.4.0/host/xtest/regression_4100.c:447:8: error: missed loop optimization, the loop counter may overflow [-Werror=unsafe-loop-optimizations]
  while (spos) {
        ^
build/optee-test-3.4.0/host/xtest/regression_4100.c:454:6: error: missed loop optimization, the loop counter may overflow [-Werror=unsafe-loop-optimizations]
   if (!spos)
      ^

[1] arm-buildroot-linux-uclibcgnueabihf-gcc.br_real (Buildroot 2019.02-git-00933-gb75e93c) 7.4.0

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>