### PR TITLE
regression 1008: adjust TA corruption test for CFG_ULIBS_SHARED=y

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -756,7 +756,7 @@ static void xtest_tee_test_1008(ADBG_Case_t *c)
 	ADBG_EXPECT_TRUE(c,
 		load_corrupt_ta(c, sizeof(struct shdr) + 32, 1)); /* sig */
 	ADBG_EXPECT_TRUE(c, load_corrupt_ta(c, 3000, 1)); /* payload */
-	ADBG_EXPECT_TRUE(c, load_corrupt_ta(c, 30000, 1)); /* payload */
+	ADBG_EXPECT_TRUE(c, load_corrupt_ta(c, 8000, 1)); /* payload */
 	Do_ADBG_EndSubCase(c, "Load corrupt TA");
 #endif /*CFG_SECSTOR_TA_MGMT_PTA*/
 }


### PR DESCRIPTION
When TAs are linked against shared versions of libutee etc., the
size of the main binary is reduced significantly. This causes test
1008.4 to fail, because the size of the TA drops from ~121 KiB down
to ~9 KiB which is smaller than the offset supplied to
load_corrupt_ta(). Use a smaller offest to fix the issue.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>