### PR TITLE
Allow memrefs with size 0

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -1909,3 +1909,77 @@ static void xtest_tee_test_1024(ADBG_Case_t *c)
 ADBG_CASE_DEFINE(regression, 1024, xtest_tee_test_1024,
 		 "Test PTA_SYSTEM_GET_TPM_EVENT_LOG Service");
 #endif /* CFG_CORE_TPM_EVENT_LOG */
+
+static void xtest_tee_test_1025(ADBG_Case_t *c)
+{
+	TEEC_Session session = {};
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t ret_orig = 0;
+	uint8_t *empty_buf = NULL;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+				      xtest_teec_open_session(&session,
+							      &os_test_ta_uuid,
+							      NULL, &ret_orig)))
+		return;
+
+	empty_buf = malloc(1);
+	if (!empty_buf) {
+		(void)ADBG_EXPECT_TEEC_SUCCESS(c, TEEC_ERROR_OUT_OF_MEMORY);
+		goto out;
+	}
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
+					 TEEC_MEMREF_TEMP_INPUT,
+					 TEEC_MEMREF_TEMP_OUTPUT,
+					 TEEC_MEMREF_TEMP_OUTPUT);
+
+	Do_ADBG_BeginSubCase(c,
+			     "Input/Output MEMREF Buffer NULL - Size 0 bytes");
+
+	op.params[0].tmpref.buffer = empty_buf;
+	op.params[0].tmpref.size = 0;
+
+	op.params[1].tmpref.buffer = NULL;
+	op.params[1].tmpref.size = 0;
+
+	op.params[2].tmpref.buffer = empty_buf;
+	op.params[2].tmpref.size = 0;
+
+	op.params[3].tmpref.buffer = NULL;
+	op.params[3].tmpref.size = 0;
+
+	ADBG_EXPECT(c, TEE_SUCCESS,
+		    TEEC_InvokeCommand(&session,
+				       TA_OS_TEST_CMD_NULL_MEMREF_PARAMS, &op,
+				       &ret_orig));
+
+	Do_ADBG_EndSubCase(c, "Input/Output MEMREF Buffer NULL - Size 0 bytes");
+
+	Do_ADBG_BeginSubCase(c, "Input MEMREF Buffer NULL - Size non 0 bytes");
+
+	op.params[0].tmpref.buffer = empty_buf;
+	op.params[0].tmpref.size = 1;
+
+	op.params[1].tmpref.buffer = NULL;
+	op.params[1].tmpref.size = 0;
+
+	op.params[2].tmpref.buffer = empty_buf;
+	op.params[2].tmpref.size = 0;
+
+	op.params[3].tmpref.buffer = NULL;
+	op.params[3].tmpref.size = 0;
+
+	ADBG_EXPECT(c, TEE_ERROR_BAD_PARAMETERS,
+		    TEEC_InvokeCommand(&session,
+				       TA_OS_TEST_CMD_NULL_MEMREF_PARAMS, &op,
+				       &ret_orig));
+
+	Do_ADBG_EndSubCase(c, "Input MEMREF Buffer NULL - Size non 0 bytes");
+
+out:
+	TEEC_CloseSession(&session);
+	free(empty_buf);
+}
+ADBG_CASE_DEFINE(regression, 1025, xtest_tee_test_1025,
+		 "Test memref NULL and/or 0 bytes size");

--- a/ta/os_test/include/os_test.h
+++ b/ta/os_test/include/os_test.h
@@ -42,6 +42,7 @@ TEE_Result ta_entry_ta2ta_memref(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_ta2ta_memref_mix(uint32_t param_types,
 				     TEE_Param params[4]);
 TEE_Result ta_entry_params(uint32_t param_types, TEE_Param params[4]);
+TEE_Result ta_entry_null_memref(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_call_lib(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_call_lib_panic(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_call_lib_dl(uint32_t param_types, TEE_Param params[4]);

--- a/ta/os_test/include/ta_os_test.h
+++ b/ta/os_test/include/ta_os_test.h
@@ -49,5 +49,6 @@
 #define TA_OS_TEST_CMD_CALL_LIB_DL          16
 #define TA_OS_TEST_CMD_CALL_LIB_DL_PANIC    17
 #define TA_OS_TEST_CMD_GET_GLOBAL_VAR       18
+#define TA_OS_TEST_CMD_NULL_MEMREF_PARAMS   19
 
 #endif /*TA_OS_TEST_H */

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -1068,6 +1068,30 @@ TEE_Result ta_entry_params(uint32_t param_types, TEE_Param params[4])
 	return TEE_SUCCESS;
 }
 
+TEE_Result ta_entry_null_memref(uint32_t param_types, TEE_Param params[4])
+{
+	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+					   TEE_PARAM_TYPE_MEMREF_INPUT,
+					   TEE_PARAM_TYPE_MEMREF_OUTPUT,
+					   TEE_PARAM_TYPE_MEMREF_OUTPUT))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/*
+	 * Tests how client can provide null or non-null memref parameters
+	 * param[0] expected as a 0 byte input mapped memeref.
+	 * param[1] expected as a 0 byte input not-mapped memeref.
+	 * param[2] expected as a 0 byte output mapped memeref.
+	 * param[3] expected as a 0 byte output not-mapped memeref.
+	 */
+	if (!params[0].memref.buffer || params[0].memref.size ||
+	    params[1].memref.buffer || params[1].memref.size ||
+	    !params[2].memref.buffer || params[2].memref.size ||
+	    params[3].memref.buffer || params[3].memref.size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	return TEE_SUCCESS;
+}
+
 TEE_Result ta_entry_call_lib(uint32_t param_types,
 			     TEE_Param params[4] __unused)
 {

--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -109,6 +109,9 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_OS_TEST_CMD_PARAMS:
 		return ta_entry_params(nParamTypes, pParams);
 
+	case TA_OS_TEST_CMD_NULL_MEMREF_PARAMS:
+		return ta_entry_null_memref(nParamTypes, pParams);
+
 	case TA_OS_TEST_CMD_CALL_LIB:
 		return ta_entry_call_lib(nParamTypes, pParams);
 


### PR DESCRIPTION
Add test 1025 verifying temporary memref of 0 bytes or NULL pointer
      buffer conforming with:
      GlobalPlatform Client API v1.0c (section 3.2.5 memory references), which
      can be found at [1].
    
      Link: [1] http://www.globalplatform.org/specificationsdevice.asp

Signed-off-by: Cedric Neveux <cedric.neveux@nxp.com>