### PR TITLE
[RFC] Add test case for dlopen()/dlsym()/dlclose() (1021)

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -1473,3 +1473,31 @@ out:
 }
 ADBG_CASE_DEFINE(regression, 1020, xtest_tee_test_1020,
 		"Test lockdep algorithm");
+
+#if defined(CFG_TA_DL)
+static void xtest_tee_test_1021(ADBG_Case_t *c)
+{
+	TEEC_Session session = { 0 };
+	uint32_t ret_orig;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		xtest_teec_open_session(&session, &os_test_ta_uuid, NULL,
+		                        &ret_orig)))
+		return;
+
+	(void)ADBG_EXPECT_TEEC_SUCCESS(c,
+		TEEC_InvokeCommand(&session, TA_OS_TEST_CMD_CALL_LIB_DL, NULL,
+				   &ret_orig));
+
+	(void)ADBG_EXPECT_TEEC_RESULT(c,
+		TEEC_ERROR_TARGET_DEAD,
+		TEEC_InvokeCommand(&session, TA_OS_TEST_CMD_CALL_LIB_DL_PANIC,
+				   NULL, &ret_orig));
+
+	(void)ADBG_EXPECT_TEEC_ERROR_ORIGIN(c, TEEC_ORIGIN_TEE, ret_orig);
+
+	TEEC_CloseSession(&session);
+}
+ADBG_CASE_DEFINE(regression, 1021, xtest_tee_test_1021,
+		"Test dlopen()/dlsym()/dlclose() API");
+#endif /*CFG_TA_DYNLINK*/

--- a/ta/Makefile
+++ b/ta/Makefile
@@ -18,9 +18,14 @@ ifeq ($(CFG_TA_DYNLINK),y)
 OS_TEST_LIB := os_test_lib
 endif
 
+ifeq ($(CFG_TA_DL),y)
+OS_TEST_LIB_DL := os_test_lib_dl
+endif
+
 TA_DIRS := create_fail_test \
 	   crypt \
 	   $(OS_TEST_LIB) \
+	   $(OS_TEST_LIB_DL) \
 	   os_test \
 	   rpc_test \
 	   sims \

--- a/ta/os_test/Makefile
+++ b/ta/os_test/Makefile
@@ -10,4 +10,8 @@ ifeq ($(CFG_TA_DYNLINK),y)
 LDADD = -L$(subst os_test,os_test_lib,$(abspath $(link-out-dir))) -los_test
 endif
 
+ifeq ($(CFG_TA_DL),y)
+LDADD += -ldl
+endif
+
 include ../ta_common.mk

--- a/ta/os_test/include/os_test.h
+++ b/ta/os_test/include/os_test.h
@@ -44,5 +44,7 @@ TEE_Result ta_entry_ta2ta_memref_mix(uint32_t param_types,
 TEE_Result ta_entry_params(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_call_lib(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_call_lib_panic(uint32_t param_types, TEE_Param params[4]);
+TEE_Result ta_entry_call_lib_dl(uint32_t param_types, TEE_Param params[4]);
+TEE_Result ta_entry_call_lib_dl_panic(uint32_t param_types, TEE_Param params[4]);
 
 #endif /*OS_TEST_H */

--- a/ta/os_test/include/ta_os_test.h
+++ b/ta/os_test/include/ta_os_test.h
@@ -46,5 +46,7 @@
 #define TA_OS_TEST_CMD_PARAMS               13
 #define TA_OS_TEST_CMD_CALL_LIB             14
 #define TA_OS_TEST_CMD_CALL_LIB_PANIC       15
+#define TA_OS_TEST_CMD_CALL_LIB_DL          16
+#define TA_OS_TEST_CMD_CALL_LIB_DL_PANIC    17
 
 #endif /*TA_OS_TEST_H */

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -1100,7 +1100,6 @@ TEE_Result ta_entry_call_lib_dl(uint32_t param_types __maybe_unused,
 	int (*add_func)(int a, int b) = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	void *handle = NULL;
-	void *this_func = NULL;
 
 	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE,
 					   TEE_PARAM_TYPE_NONE,
@@ -1123,10 +1122,6 @@ TEE_Result ta_entry_call_lib_dl(uint32_t param_types __maybe_unused,
 	if (!add_func)
 		goto err;
 	if (add_func(5, 6) != 11)
-		goto err;
-
-	this_func = dlsym(NULL, "ta_entry_call_lib_dl");
-	if (this_func != (void *)ta_entry_call_lib_dl)
 		goto err;
 
 	res = TEE_SUCCESS;

--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -115,6 +115,12 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_OS_TEST_CMD_CALL_LIB_PANIC:
 		return ta_entry_call_lib_panic(nParamTypes, pParams);
 
+	case TA_OS_TEST_CMD_CALL_LIB_DL:
+		return ta_entry_call_lib_dl(nParamTypes, pParams);
+
+	case TA_OS_TEST_CMD_CALL_LIB_DL_PANIC:
+		return ta_entry_call_lib_dl_panic(nParamTypes, pParams);
+
 	default:
 		return TEE_ERROR_BAD_PARAMETERS;
 	}

--- a/ta/os_test_lib_dl/Android.mk
+++ b/ta/os_test_lib_dl/Android.mk
@@ -1,0 +1,4 @@
+LOCAL_PATH := $(call my-dir)
+
+local_module := b3091a65-9751-4784-abf7-0298a7cc35ba.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/os_test_lib_dl/Makefile
+++ b/ta/os_test_lib_dl/Makefile
@@ -1,0 +1,14 @@
+include $(TA_DEV_KIT_DIR)/mk/conf.mk
+
+ifeq ($(CFG_TA_DL),y) # OP-TEE provides libdl
+
+SHLIBNAME = libos_test_dl
+SHLIBUUID = b3091a65-9751-4784-abf7-0298a7cc35ba
+include ../ta_common.mk
+
+else
+
+# For the buildroot environment
+all:
+
+endif

--- a/ta/os_test_lib_dl/include/os_test_lib_dl.h
+++ b/ta/os_test_lib_dl/include/os_test_lib_dl.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019, Linaro Limited
+ */
+
+#ifndef _OS_TEST_LIB_DL_H_
+#define _OS_TEST_LIB_DL_H_
+
+#if defined(CFG_TA_DL)
+
+int os_test_shlib_dl_add(int a, int b);
+void os_test_shlib_dl_panic(void);
+
+#else
+
+#include <compiler.h>
+#include <tee_internal_api.h>
+
+static inline int os_test_shlib_dl_add(int a __unused, int b __unused)
+{
+	TEE_Panic(0);
+	return 0;
+}
+
+static inline void os_test_shlib_dl_panic(void)
+{
+}
+
+#endif /* CFG_TA_DL */
+
+#endif /* _OS_TEST_LIB_DL_H_ */

--- a/ta/os_test_lib_dl/os_test_lib_dl.c
+++ b/ta/os_test_lib_dl/os_test_lib_dl.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2018, Linaro Limited
+ */
+
+#include "os_test_lib_dl.h"
+#include <tee_internal_api.h>
+
+int os_test_shlib_dl_add(int a, int b)
+{
+	return a + b;
+}
+
+void os_test_shlib_dl_panic(void)
+{
+	TEE_Panic(0);
+}

--- a/ta/os_test_lib_dl/sub.mk
+++ b/ta/os_test_lib_dl/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += include
+srcs-y += os_test_lib_dl.c


### PR DESCRIPTION
Adds a new test case for the dynamic link API in libdl. This is enabled
when CFG_TA_DL=y.
- A new shared library is added in ta/os_test_lib_dl. It contains two
  funtions: one performs a simple operation (adds two integers) and
  the other one calls TEE_Panic(), which triggers a nice crash dump on
  the secure console, allowing to check how things are actually mapped
  in the TA memory.
- In xtest 1021, the dl API is used to load the test library and
  retrieve pointers to the functions which are then executed. dlsym()
  is also used to get a pointer to a function in the main executable.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>