### PR TITLE
xtest: Explicitly initialize local variables

### DIFF
--- a/host/xtest/adbg/src/adbg_case.c
+++ b/host/xtest/adbg/src/adbg_case.c
@@ -47,7 +47,7 @@ static const char *ADBG_Case_GetTestID(ADBG_Case_t *Case_p);
 *************************************************************************/
 ADBG_Case_t *ADBG_Case_New(const struct adbg_case_def *case_def)
 {
-	ADBG_Case_t *Case_p;
+	ADBG_Case_t *Case_p = NULL;
 
 	Case_p = calloc(1, sizeof(*Case_p));
 	if (Case_p)
@@ -160,7 +160,7 @@ void Do_ADBG_BeginSubCase(
 	}
 
 	va_list ArgList;
-	char Title[80];
+	char Title[80] = { };
 
 	va_start(ArgList, FormatTitle_p);
 	vsnprintf(Title, sizeof(Title), FormatTitle_p, ArgList);
@@ -189,7 +189,7 @@ void Do_ADBG_EndSubCase(
 	)
 {
 	va_list ArgList;
-	char Title[80];
+	char Title[80] = { };
 	ADBG_SubCase_t *SubCase_p = NULL;
 
 	if (Case_p == NULL) {
@@ -277,7 +277,7 @@ static ADBG_SubCase_t *ADBG_Case_CreateSubCase(
 	const char *const Title_p
 	)
 {
-	ADBG_SubCase_t *SubCase_p;
+	ADBG_SubCase_t *SubCase_p = NULL;
 
 	SubCase_p = calloc(1, sizeof(*SubCase_p));
 	if (SubCase_p == NULL)
@@ -301,7 +301,7 @@ static ADBG_SubCase_t *ADBG_Case_CreateSubCase(
 		Case_p->FirstSubCase_p = SubCase_p;
 	} else {
 		ADBG_SubCase_t *Parent_p = SubCase_p->Parent_p;
-		char PrefixTitle[80];
+		char PrefixTitle[80] = { };
 
 		/* Update parent SubCase */
 		Parent_p->Result.NumSubCases++;

--- a/host/xtest/adbg/src/adbg_log.c
+++ b/host/xtest/adbg/src/adbg_log.c
@@ -59,7 +59,7 @@ void Do_ADBG_HexLog(
 	)
 {
 	const uint8_t *Data_p = Buf_p;
-	size_t n;
+	size_t n = 0;
 
 	for (n = 0; n < Size; n += Cols) {
 		char HexBuffer[ADBG_STRING_LENGTH_MAX];

--- a/host/xtest/adbg/src/adbg_run.c
+++ b/host/xtest/adbg/src/adbg_run.c
@@ -60,7 +60,7 @@ int Do_ADBG_RunSuite(
 	char *argv[]
 	)
 {
-	ADBG_Runner_t *Runner_p;
+	ADBG_Runner_t *Runner_p = NULL;
 
 	Runner_p = calloc(1, sizeof(*Runner_p));
 	if (Runner_p == NULL) {
@@ -81,8 +81,8 @@ int Do_ADBG_AppendToSuite(
 	ADBG_Suite_Definition_t *Source_p
 	)
 {
-	char *p;
-	size_t size;
+	char *p = NULL;
+	size_t size = 0;
 
 	/* Append name of 'Source_p' to name of 'Dest_p' */
 	size = strlen(Source_p->SuiteID_p);
@@ -117,10 +117,10 @@ static int ADBG_RunSuite(
 	char *argv[]
 	)
 {
-	ADBG_Case_t *Case_p;
+	ADBG_Case_t *Case_p = NULL;
 	size_t NumSkippedTestCases = 0;
 	int failed_test = 0;
-	struct adbg_case_def *case_def;
+	struct adbg_case_def *case_def = NULL;
 
 	Do_ADBG_Log("######################################################");
 	Do_ADBG_Log("#");
@@ -131,7 +131,7 @@ static int ADBG_RunSuite(
 	TAILQ_FOREACH(case_def, &Runner_p->Suite_p->cases, link) {
 		if (argc > 0) {
 			bool HaveMatch = false;
-			int i;
+			int i = 0;
 
 			for (i = 0; i < argc; i++) {
 
@@ -191,7 +191,7 @@ static int ADBG_RunSuite(
 
 	Do_ADBG_Log("+-----------------------------------------------------");
 	if (argc > 0) {
-		int i;
+		int i = 0;
 
 		for (i = 0; i < argc; i++)
 			Do_ADBG_Log(

--- a/host/xtest/adbg/src/security_utils_hex.c
+++ b/host/xtest/adbg/src/security_utils_hex.c
@@ -152,12 +152,12 @@ size_t SecUtil_BufferToHex(
 	)
 {
 	const uint8_t *Data_p = Buffer_p;
-	size_t UsedDestLength;
-	size_t n;
+	size_t UsedDestLength = 0;
+	size_t n = 0;
 	const char *ByteSeparator_p = NULL;
 	const char *GroupSeparator_p = NULL;
 	const char *BytePrefix_p = NULL;
-	size_t BytePrefixLength;
+	size_t BytePrefixLength = 0;
 
 	if (DestinationLength > 1)
 		Destination_p[0] = '\0';
@@ -186,8 +186,8 @@ size_t SecUtil_BufferToHex(
 	 * the absense of both snprintf and strlcat
 	 */
 	for (n = 0; n < BufferLength; n++) {
-		const char *Separator_p;
-		size_t SeparatorLength;
+		const char *Separator_p = NULL;
+		size_t SeparatorLength = 0;
 
 		/* Establish separator for this byte and the next */
 		if (n == BufferLength - 1)
@@ -201,7 +201,7 @@ size_t SecUtil_BufferToHex(
 
 		/* Insert the Byte prefix */
 		if (UsedDestLength < DestinationLength) {
-			size_t CopyLength;
+			size_t CopyLength = 0;
 
 			CopyLength = MIN(BytePrefixLength,
 					 DestinationLength - UsedDestLength);
@@ -229,7 +229,7 @@ size_t SecUtil_BufferToHex(
 
 		/* Insert the separator */
 		if (UsedDestLength < DestinationLength) {
-			size_t CopyLength;
+			size_t CopyLength = 0;
 
 			CopyLength = MIN(SeparatorLength,
 					 DestinationLength - UsedDestLength);

--- a/host/xtest/aes_perf.c
+++ b/host/xtest/aes_perf.c
@@ -43,6 +43,7 @@
 #include <unistd.h>
 
 #include "crypto_common.h"
+#include "xtest_helpers.h"
 
 #ifdef CFG_SECURE_DATA_PATH
 #include "sdp_basic.h"
@@ -129,9 +130,9 @@ static void check_res(TEEC_Result res, const char *errmsg, uint32_t *orig)
 
 static void open_ta(void)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_UUID uuid = TA_AES_PERF_UUID;
-	uint32_t err_origin;
+	uint32_t err_origin = 0;
 
 	res = TEEC_InitializeContext(NULL, &ctx);
 	check_res(res, "TEEC_InitializeContext", NULL);
@@ -259,7 +260,7 @@ static void register_shm(TEEC_SharedMemory *shm, int fd)
 
 static void allocate_shm(TEEC_SharedMemory *shm, size_t sz)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 
 	shm->buffer = NULL;
 	shm->size = sz;
@@ -330,7 +331,7 @@ static void free_shm(int in_place)
 static ssize_t read_random(void *in, size_t rsize)
 {
 	static int rnd;
-	ssize_t s;
+	ssize_t s = 0;
 
 	if (!rnd) {
 		rnd = open("/dev/urandom", O_RDONLY);
@@ -371,12 +372,11 @@ static uint64_t timespec_diff_ns(struct timespec *start, struct timespec *end)
 
 static void prepare_key(int decrypt, int keysize, int mode)
 {
-	TEEC_Result res;
-	uint32_t ret_origin;
-	TEEC_Operation op;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t ret_origin = 0;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint32_t cmd = TA_AES_PERF_CMD_PREPARE_KEY;
 
-	memset(&op, 0, sizeof(op));
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_VALUE_INPUT,
 					 TEEC_NONE, TEEC_NONE);
 	op.params[0].value.a = decrypt;
@@ -389,8 +389,9 @@ static void prepare_key(int decrypt, int keysize, int mode)
 
 static void do_warmup(int warmup)
 {
-	struct timespec t0, t;
-	int i;
+	struct timespec t0 = { };
+	struct timespec t = { };
+	int i = 0;
 
 	get_current_time(&t0);
 	do {
@@ -447,11 +448,11 @@ void aes_perf_run_test(int mode, int keysize, int decrypt, size_t size, size_t u
 				unsigned int n, unsigned int l, int input_data_init,
 				int in_place, int warmup, int verbosity)
 {
-	struct statistics stats;
-	struct timespec ts;
-	TEEC_Operation op;
+	struct statistics stats = { };
+	struct timespec ts = { };
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	int n0 = n;
-	double sd;
+	double sd = 0;
 	uint32_t cmd = is_sdp_test ? TA_AES_PERF_CMD_PROCESS_SDP :
 				     TA_AES_PERF_CMD_PROCESS;
 
@@ -478,13 +479,10 @@ void aes_perf_run_test(int mode, int keysize, int decrypt, size_t size, size_t u
 	open_ta();
 	prepare_key(decrypt, keysize, mode);
 
-	memset(&stats, 0, sizeof(stats));
-
 	alloc_buffers(size, in_place, verbosity);
 	if (input_data_init == CRYPTO_USE_ZEROS)
 		run_feed_input(in_shm.buffer, size, 0);
 
-	memset(&op, 0, sizeof(op));
 	/* Using INOUT to handle the case in_place == 1 */
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_PARTIAL_INOUT,
 					 TEEC_MEMREF_PARTIAL_INOUT,
@@ -507,9 +505,10 @@ void aes_perf_run_test(int mode, int keysize, int decrypt, size_t size, size_t u
 		do_warmup(warmup);
 
 	while (n-- > 0) {
-		TEEC_Result res;
-		uint32_t ret_origin;
-		struct timespec t0, t1;
+		TEEC_Result res = TEEC_ERROR_GENERIC;
+		uint32_t ret_origin = 0;
+		struct timespec t0 = { };
+		struct timespec t1 = { };
 
 		if (input_data_init == CRYPTO_USE_RANDOM)
 			run_feed_input(in_shm.buffer, size, 1);
@@ -565,12 +564,10 @@ void aes_perf_run_test(int mode, int keysize, int decrypt, size_t size, size_t u
 
 int aes_perf_runner_cmd_parser(int argc, char *argv[])
 {
-	int i;
-
+	int i = 0;
 	/*
 	* Command line parameters
 	*/
-
 	size_t size = 1024;	/* Buffer size (-s) */
 	size_t unit = CRYPTO_DEF_UNIT_SIZE; /* Divide buffer (-u) */
 	unsigned int n = CRYPTO_DEF_COUNT; /*Number of measurements (-n)*/

--- a/host/xtest/benchmark_1000.c
+++ b/host/xtest/benchmark_1000.c
@@ -47,9 +47,9 @@ static TEEC_Result run_test_with_args(enum storage_benchmark_cmd cmd,
 		uint32_t arg3, uint32_t *out0, uint32_t *out1)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	TEEC_Result res;
-	TEEC_Session sess;
-	uint32_t orig;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	TEEC_Session sess = { };
+	uint32_t orig = 0;
 
 	res = xtest_teec_open_session(&sess, &storage_benchmark_ta_uuid, NULL, &orig);
 	if (res != TEEC_SUCCESS)
@@ -84,7 +84,7 @@ struct test_record {
 static TEEC_Result run_chunk_access_test(enum storage_benchmark_cmd cmd,
 		uint32_t data_size, uint32_t chunk_size, struct test_record *rec)
 {
-	TEE_Result res;
+	TEE_Result res = TEEC_ERROR_GENERIC;
 	uint32_t spent_time = 0;
 
 	res = run_test_with_args(cmd, data_size, chunk_size, DO_VERIFY, 0,
@@ -99,7 +99,7 @@ static TEEC_Result run_chunk_access_test(enum storage_benchmark_cmd cmd,
 
 static void show_test_result(struct test_record records[], size_t size)
 {
-	size_t i;
+	size_t i = 0;
 
 	printf("-----------------+---------------+----------------\n");
 	printf(" Data Size (B) \t | Time (s)\t | Speed (kB/s)\t \n");
@@ -119,7 +119,7 @@ static void chunk_test(ADBG_Case_t *c, enum storage_benchmark_cmd cmd)
 {
 	uint32_t chunk_size = DEFAULT_CHUNK_SIZE;
 	struct test_record records[ARRAY_SIZE(data_size_table) - 1];
-	size_t i;
+	size_t i = 0;
 
 	for (i = 0; data_size_table[i]; i++) {
 		ADBG_EXPECT_TEEC_SUCCESS(c,

--- a/host/xtest/install_ta.c
+++ b/host/xtest/install_ta.c
@@ -20,15 +20,17 @@
 #include <sys/types.h>
 #include <tee_client_api.h>
 #include <unistd.h>
-#include "xtest_test.h"
+
 #include "install_ta.h"
+#include "xtest_helpers.h"
+#include "xtest_test.h"
 
 static void *read_ta(const char *dname, const char *fname, size_t *size)
 {
 	char nbuf[PATH_MAX];
-	FILE *f;
-	void *buf;
-	size_t s;
+	FILE *f = NULL;
+	void *buf = NULL;
+	size_t s = 0;
 
 	if (dname)
 		snprintf(nbuf, sizeof(nbuf), "%s/%s", dname, fname);
@@ -58,11 +60,10 @@ static void *read_ta(const char *dname, const char *fname, size_t *size)
 
 static void install_ta(TEEC_Session *sess, void *buf, size_t blen)
 {
-	TEEC_Result res;
-	uint32_t err_origin;
-	TEEC_Operation op;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t err_origin = 0;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 
-	memset(&op, 0, sizeof(op));
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
 	op.params[0].tmpref.buffer = buf;
@@ -78,8 +79,8 @@ static void install_ta(TEEC_Session *sess, void *buf, size_t blen)
 static void install_file(TEEC_Session *sess, const char *dirname,
 			 const char *filename)
 {
-	void *ta;
-	size_t ta_size;
+	void *ta = NULL;
+	size_t ta_size = 0;
 
 	printf("Installing \"%s\"\n", filename);
 	ta = read_ta(dirname, filename, &ta_size);
@@ -89,7 +90,7 @@ static void install_file(TEEC_Session *sess, const char *dirname,
 
 static void install_dir(TEEC_Session *sess, const char *dirname)
 {
-	DIR *dirp;
+	DIR *dirp = NULL;
 
 	printf("Searching directory \"%s\" for TAs\n", dirname);
 	dirp = opendir(dirname);
@@ -113,12 +114,12 @@ static void install_dir(TEEC_Session *sess, const char *dirname)
 
 int install_ta_runner_cmd_parser(int argc, char *argv[])
 {
-	TEEC_Result res;
-	uint32_t err_origin;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t err_origin = 0;
 	TEEC_UUID uuid = PTA_SECSTOR_TA_MGMT_UUID;
-	TEEC_Context ctx;
-	TEEC_Session sess;
-	int i;
+	TEEC_Context ctx = { };
+	TEEC_Session sess = { };
+	int i = 0;
 
 	res = TEEC_InitializeContext(NULL, &ctx);
 	if (res)
@@ -131,7 +132,7 @@ int install_ta_runner_cmd_parser(int argc, char *argv[])
 			res, err_origin);
 
 	for (i = 1; i < argc; i++) {
-		struct stat sb;
+		struct stat sb = { };
 
 		if (stat(argv[i], &sb)) {
 			printf("Skipping \"%s\": %s", argv[i], strerror(errno));

--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -51,8 +51,8 @@ struct xtest_crypto_session {
 
 static void xtest_crypto_test(struct xtest_crypto_session *cs)
 {
-	uint32_t ret_orig;
-	uint8_t crypt_out[16];
+	uint32_t ret_orig = 0;
+	uint8_t crypt_out[16] = { };
 	uint8_t crypt_in[16] = { 22, 17 };
 
 	crypt_in[15] = 60;
@@ -81,7 +81,7 @@ static void xtest_crypto_test(struct xtest_crypto_session *cs)
 	Do_ADBG_BeginSubCase(cs->c, "AES decrypt");
 	{
 		TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-		uint8_t out[16];
+		uint8_t out[16] = { };
 
 		op.params[0].tmpref.buffer = crypt_out;
 		op.params[0].tmpref.size = sizeof(crypt_out);
@@ -118,7 +118,7 @@ static void xtest_crypto_test(struct xtest_crypto_session *cs)
 			0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
 			0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad
 		};
-		uint8_t out[32] = { 0 };
+		uint8_t out[32] = { };
 
 		op.params[0].tmpref.buffer = (void *)sha256_in;
 		op.params[0].tmpref.size = sizeof(sha256_in);
@@ -160,7 +160,7 @@ static void xtest_crypto_test(struct xtest_crypto_session *cs)
 			0xE9, 0xC3, 0xEF, 0x8A, 0xB2, 0x34, 0x53, 0xE6,
 			0xF0, 0x74, 0x9C, 0xD6, 0x36, 0xE7, 0xA8, 0x8E
 		};
-		uint8_t out[sizeof(exp_out)];
+		uint8_t out[sizeof(exp_out)] = { };
 
 		op.params[0].tmpref.buffer = (void *)in;
 		op.params[0].tmpref.size = sizeof(in);
@@ -202,7 +202,7 @@ static void xtest_crypto_test(struct xtest_crypto_session *cs)
 			0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
 			0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
 		};
-		uint8_t out[sizeof(exp_out)];
+		uint8_t out[sizeof(exp_out)] = { };
 
 		op.params[0].tmpref.buffer = (void *)in;
 		op.params[0].tmpref.size = sizeof(in);
@@ -232,9 +232,9 @@ static void xtest_crypto_test(struct xtest_crypto_session *cs)
 
 static void xtest_tee_test_1001(ADBG_Case_t *c)
 {
-	TEEC_Result res;
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 
 	/* Pseudo TA is optional: warn and nicely exit if not found */
 	res = xtest_teec_open_session(&session, &pta_invoke_tests_ta_uuid, NULL,
@@ -253,13 +253,13 @@ ADBG_CASE_DEFINE(regression, 1001, xtest_tee_test_1001, "Core self tests");
 
 static void xtest_tee_test_1002(ADBG_Case_t *c)
 {
-	TEEC_Result res;
-	TEEC_Session session = { 0 };
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
-	uint8_t buf[16 * 1024];
+	uint32_t ret_orig = 0;
+	uint8_t buf[16 * 1024] = { };
 	uint8_t exp_sum = 0;
-	size_t n;
+	size_t n = 0;
 
 	/* Pseudo TA is optional: warn and nicely exit if not found */
 	res = xtest_teec_open_session(&session, &pta_invoke_tests_ta_uuid, NULL,
@@ -304,9 +304,9 @@ struct test_1003_arg {
 static void *test_1003_thread(void *arg)
 {
 	struct test_1003_arg *a = arg;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = { };
 	size_t rounds = 64 * 1024;
-	size_t n;
+	size_t n = 0;
 
 	a->res = xtest_teec_open_session(&session, &pta_invoke_tests_ta_uuid,
 					 NULL, &a->error_orig);
@@ -349,25 +349,26 @@ static void *test_1003_thread(void *arg)
 	return NULL;
 }
 
+#define TEST_1003_THREAD_COUNT		(3 * 2)
+
 static void xtest_tee_test_1003(ADBG_Case_t *c)
 {
-	size_t num_threads = 3 * 2;
-	TEEC_Result res;
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 	size_t repeat = 20;
-	pthread_t thr[num_threads];
-	struct test_1003_arg arg[num_threads];
+	struct test_1003_arg arg[TEST_1003_THREAD_COUNT] = { };
 	size_t max_read_concurrency = 0;
 	size_t max_read_waiters = 0;
 	size_t num_concurrent_read_lockers = 0;
 	size_t num_concurrent_read_waiters = 0;
-	size_t n;
-	size_t nt = num_threads;
-	double mean_read_concurrency;
-	double mean_read_waiters;
+	size_t n = 0;
+	size_t nt = TEST_1003_THREAD_COUNT;
+	double mean_read_concurrency = 0;
+	double mean_read_waiters = 0;
 	size_t num_writers = 0;
 	size_t num_readers = 0;
+	pthread_t thr[TEST_1003_THREAD_COUNT] = { };
 
 	/* Pseudo TA is optional: warn and nicely exit if not found */
 	res = xtest_teec_open_session(&session, &pta_invoke_tests_ta_uuid, NULL,
@@ -378,8 +379,6 @@ static void xtest_tee_test_1003(ADBG_Case_t *c)
 	}
 	ADBG_EXPECT_TEEC_SUCCESS(c, res);
 	TEEC_CloseSession(&session);
-
-	memset(arg, 0, sizeof(arg));
 
 	for (n = 0; n < nt; n++) {
 		if (n % 3) {
@@ -418,8 +417,8 @@ static void xtest_tee_test_1003(ADBG_Case_t *c)
 	mean_read_waiters = (double)num_concurrent_read_waiters /
 			    (double)(repeat * num_readers);
 
-	Do_ADBG_Log("    Number of parallel threads: %zu (%zu writers and %zu readers)",
-		    num_threads, num_writers, num_readers);
+	Do_ADBG_Log("    Number of parallel threads: %d (%zu writers and %zu readers)",
+		    TEST_1003_THREAD_COUNT, num_writers, num_readers);
 	Do_ADBG_Log("    Max read concurrency: %zu", max_read_concurrency);
 	Do_ADBG_Log("    Max read waiters: %zu", max_read_waiters);
 	Do_ADBG_Log("    Mean read concurrency: %g", mean_read_concurrency);
@@ -430,8 +429,8 @@ ADBG_CASE_DEFINE(regression, 1003, xtest_tee_test_1003,
 
 static void xtest_tee_test_1004(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 	struct xtest_crypto_session cs = { c, &session, TA_CRYPT_CMD_SHA256,
 					   TA_CRYPT_CMD_AES256ECB_ENC,
 					   TA_CRYPT_CMD_AES256ECB_DEC };
@@ -450,9 +449,9 @@ ADBG_CASE_DEFINE(regression, 1004, xtest_tee_test_1004, "Test User Crypt TA");
 
 static void xtest_tee_test_invalid_mem_access(ADBG_Case_t *c, unsigned int n)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &os_test_ta_uuid, NULL,
@@ -481,12 +480,11 @@ static void xtest_tee_test_invalid_mem_access(ADBG_Case_t *c, unsigned int n)
 static void xtest_tee_test_invalid_mem_access2(ADBG_Case_t *c, unsigned int n,
 							       size_t size)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
-	TEEC_SharedMemory shm;
+	uint32_t ret_orig = 0;
+	TEEC_SharedMemory shm = { };
 
-	memset(&shm, 0, sizeof(shm));
 	shm.size = size;
 	shm.flags = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT;
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -521,10 +519,10 @@ static void xtest_tee_test_invalid_mem_access2(ADBG_Case_t *c, unsigned int n,
 
 static void xtest_tee_test_1005(ADBG_Case_t *c)
 {
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 #define MAX_SESSIONS    3
 	TEEC_Session sessions[MAX_SESSIONS];
-	int i;
+	int i = 0;
 
 	for (i = 0; i < MAX_SESSIONS; i++) {
 		if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -541,10 +539,10 @@ ADBG_CASE_DEFINE(regression, 1005, xtest_tee_test_1005, "Many sessions");
 
 static void xtest_tee_test_1006(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint8_t buf[32];
+	uint8_t buf[32] = { };
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &os_test_ta_uuid, NULL,
@@ -567,8 +565,8 @@ ADBG_CASE_DEFINE(regression, 1006, xtest_tee_test_1006,
 
 static void xtest_tee_test_1007(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &os_test_ta_uuid, NULL,
@@ -604,7 +602,7 @@ ADBG_CASE_DEFINE(regression, 1007, xtest_tee_test_1007, "Test Panic");
 
 static FILE *open_ta_file(const TEEC_UUID *uuid, const char *mode)
 {
-	char buf[PATH_MAX];
+	char buf[PATH_MAX] = { };
 
 	snprintf(buf, sizeof(buf),
 		"%s/%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x.ta",
@@ -619,16 +617,16 @@ static FILE *open_ta_file(const TEEC_UUID *uuid, const char *mode)
 
 static bool load_corrupt_ta(ADBG_Case_t *c, size_t offs, uint8_t mask)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	TEEC_UUID uuid = PTA_SECSTOR_TA_MGMT_UUID;
-	TEEC_Result res;
-	uint32_t ret_orig;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t ret_orig = 0;
 	FILE *f = NULL;
 	bool r = false;
 	uint8_t *buf = NULL;
-	size_t sz;
-	size_t fread_res;
+	size_t sz = 0;
+	size_t fread_res = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &uuid, NULL, &ret_orig)))
@@ -674,9 +672,9 @@ out:
 
 static void xtest_tee_test_1008(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	TEEC_Session session_crypt = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	TEEC_Session session_crypt = { };
+	uint32_t ret_orig = 0;
 
 	Do_ADBG_BeginSubCase(c, "Invoke command");
 	{
@@ -718,7 +716,7 @@ static void xtest_tee_test_1008(ADBG_Case_t *c)
 
 	Do_ADBG_BeginSubCase(c, "Create session fail");
 	{
-		size_t n;
+		size_t n = 0;
 
 		(void)ADBG_EXPECT_TEEC_RESULT(c, TEEC_ERROR_GENERIC,
 			xtest_teec_open_session(&session_crypt,
@@ -777,9 +775,11 @@ static void *cancellation_thread(void *arg)
 static void xtest_tee_test_1009_subcase(ADBG_Case_t *c, const char *subcase,
                                         uint32_t timeout, bool cancel)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 	pthread_t thr;
+
+	memset(&thr, 0, sizeof(thr));
 
 	Do_ADBG_BeginSubCase(c, "%s", subcase);
 	{
@@ -835,8 +835,8 @@ ADBG_CASE_DEFINE(regression, 1009, xtest_tee_test_1009, "TEE Wait");
 
 static void xtest_tee_test_1010(ADBG_Case_t *c)
 {
-	unsigned int n;
-	unsigned int idx;
+	unsigned int n = 0;
+	unsigned int idx = 0;
 	size_t memref_sz[] = { 1024, 65536 };
 
 	for (n = 1; n <= 5; n++) {
@@ -862,8 +862,8 @@ ADBG_CASE_DEFINE(regression, 1010, xtest_tee_test_1010,
 
 static void xtest_tee_test_1011(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 	struct xtest_crypto_session cs = {
 		c, &session, TA_RPC_CMD_CRYPT_SHA256,
 		TA_RPC_CMD_CRYPT_AES256ECB_ENC,
@@ -911,9 +911,9 @@ ADBG_CASE_DEFINE(regression, 1011, xtest_tee_test_1011,
  */
 static void xtest_tee_test_1012(ADBG_Case_t *c)
 {
-	TEEC_Session session1 = { 0 };
-	TEEC_Session session2 = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session1 = { };
+	TEEC_Session session2 = { };
+	uint32_t ret_orig = 0;
 	TEEC_UUID uuid = sims_test_ta_uuid;
 
 	Do_ADBG_BeginSubCase(c, "Single Instance Multi Session");
@@ -925,8 +925,8 @@ static void xtest_tee_test_1012(ADBG_Case_t *c)
 			0xE9, 0xC3, 0xEF, 0x8A, 0xB2, 0x34, 0x53, 0xE6,
 			0xF0, 0x74, 0x9C, 0xD6, 0x36, 0xE7, 0xA8, 0x8E
 		};
-		uint8_t out[32] = { 0 };
-		int i;
+		uint8_t out[32] = { };
+		int i = 0;
 
 		if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 			xtest_teec_open_session(&session1, &uuid, NULL,
@@ -1031,7 +1031,7 @@ struct test_1013_thread_arg {
 static void *test_1013_thread(void *arg)
 {
 	struct test_1013_thread_arg *a = arg;
-	TEEC_Session session = { 0 };
+	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	uint8_t p2 = TEEC_NONE;
 	uint8_t p3 = TEEC_NONE;
@@ -1071,14 +1071,12 @@ static void *test_1013_thread(void *arg)
 static void xtest_tee_test_1013_single(ADBG_Case_t *c, double *mean_concurrency,
 				       const TEEC_UUID *uuid)
 {
-	size_t num_threads = NUM_THREADS;
-	size_t nt;
-	size_t n;
+	size_t nt = 0;
+	size_t n = 0;
 	size_t repeat = 1000;
-	pthread_t thr[num_threads];
-	TEEC_SharedMemory shm;
-	size_t max_concurrency;
-	struct test_1013_thread_arg arg[num_threads];
+	TEEC_SharedMemory shm = { };
+	size_t max_concurrency = 0;
+	struct test_1013_thread_arg arg[NUM_THREADS] = { };
 	static const uint8_t sha256_in[] = { 'a', 'b', 'c' };
 	static const uint8_t sha256_out[] = {
 		0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
@@ -1086,12 +1084,12 @@ static void xtest_tee_test_1013_single(ADBG_Case_t *c, double *mean_concurrency,
 		0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
 		0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad
 	};
-	uint8_t out[32] = { 0 };
+	uint8_t out[32] = { };
+	pthread_t thr[NUM_THREADS] = { };
 
 	Do_ADBG_BeginSubCase(c, "Busy loop repeat %zu", repeat * 10);
 	*mean_concurrency = 0;
 
-	memset(&shm, 0, sizeof(shm));
 	shm.size = sizeof(struct ta_concurrent_shm);
 	shm.flags = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT;
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -1099,9 +1097,8 @@ static void xtest_tee_test_1013_single(ADBG_Case_t *c, double *mean_concurrency,
 		return;
 
 	memset(shm.buffer, 0, shm.size);
-	memset(arg, 0, sizeof(arg));
 	max_concurrency = 0;
-	nt = num_threads;
+	nt = NUM_THREADS;
 
 	for (n = 0; n < nt; n++) {
 		arg[n].uuid = uuid;
@@ -1127,7 +1124,7 @@ static void xtest_tee_test_1013_single(ADBG_Case_t *c, double *mean_concurrency,
 	 * best result there).
 	 */
 	(void)ADBG_EXPECT_COMPARE_UNSIGNED(c, max_concurrency, >, 0);
-	(void)ADBG_EXPECT_COMPARE_UNSIGNED(c, max_concurrency, <=, num_threads);
+	(void)ADBG_EXPECT_COMPARE_UNSIGNED(c, max_concurrency, <=, NUM_THREADS);
 	*mean_concurrency += max_concurrency;
 	Do_ADBG_EndSubCase(c, "Busy loop repeat %zu", repeat * 10);
 
@@ -1135,7 +1132,7 @@ static void xtest_tee_test_1013_single(ADBG_Case_t *c, double *mean_concurrency,
 	memset(shm.buffer, 0, shm.size);
 	memset(arg, 0, sizeof(arg));
 	max_concurrency = 0;
-	nt = num_threads;
+	nt = NUM_THREADS;
 
 	for (n = 0; n < nt; n++) {
 		arg[n].uuid = uuid;
@@ -1168,9 +1165,9 @@ static void xtest_tee_test_1013_single(ADBG_Case_t *c, double *mean_concurrency,
 
 static void xtest_tee_test_1013(ADBG_Case_t *c)
 {
-	int i;
-	double mean_concurrency;
-	double concurrency;
+	int i = 0;
+	double mean_concurrency = 0;
+	double concurrency = 0;
 	int nb_loops = 24;
 
 	if (level == 0)
@@ -1216,8 +1213,8 @@ static void xtest_tee_test_1014(ADBG_Case_t *c)
 	int loop = 10;
 	int ion_heap = DEFAULT_ION_HEAP_TYPE;
 	int rnd_offset = 1;
-	int test;
-	int ret;
+	int test = 0;
+	int ret = 0;
 
 	test = TEST_NS_TO_TA;
 	Do_ADBG_BeginSubCase(c, "SDP: NonSecure client invokes a SDP TA");
@@ -1249,9 +1246,9 @@ ADBG_CASE_DEFINE(regression, 1014, xtest_tee_test_1014,
 
 static void xtest_tee_test_1015(ADBG_Case_t *c)
 {
-	TEEC_Result res;
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 
 	/* Pseudo TA is optional: warn and nicely exit if not found */
 	res = xtest_teec_open_session(&session, &pta_invoke_tests_ta_uuid, NULL,
@@ -1272,9 +1269,9 @@ ADBG_CASE_DEFINE(regression, 1015, xtest_tee_test_1015,
 
 static void xtest_tee_test_1016(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &os_test_ta_uuid, NULL,
@@ -1295,13 +1292,12 @@ ADBG_CASE_DEFINE(regression, 1016, xtest_tee_test_1016,
 
 static void xtest_tee_test_1017(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
-	TEEC_SharedMemory shm;
+	uint32_t ret_orig = 0;
+	TEEC_SharedMemory shm = { };
 	size_t page_size = 4096;
 
-	memset(&shm, 0, sizeof(shm));
 	shm.size = 8 * page_size;
 	shm.flags = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT;
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -1352,13 +1348,12 @@ ADBG_CASE_DEFINE(regression, 1017, xtest_tee_test_1017,
 
 static void xtest_tee_test_1018(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
-	TEEC_SharedMemory shm;
+	uint32_t ret_orig = 0;
+	TEEC_SharedMemory shm = { };
 	size_t page_size = 4096;
 
-	memset(&shm, 0, sizeof(shm));
 	shm.size = 8 * page_size;
 	shm.flags = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT;
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -1415,8 +1410,8 @@ ADBG_CASE_DEFINE(regression, 1018, xtest_tee_test_1018,
 #if defined(CFG_TA_DYNLINK)
 static void xtest_tee_test_1019(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &os_test_ta_uuid, NULL,
@@ -1442,9 +1437,9 @@ ADBG_CASE_DEFINE(regression, 1019, xtest_tee_test_1019,
 
 static void xtest_tee_test_1020(ADBG_Case_t *c)
 {
-	TEEC_Result res;
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 
 	/* Pseudo TA is optional: warn and nicely exit if not found */
 	res = xtest_teec_open_session(&session, &pta_invoke_tests_ta_uuid, NULL,

--- a/host/xtest/regression_2000.c
+++ b/host/xtest/regression_2000.c
@@ -42,7 +42,7 @@ static TEE_Result socket_tcp_open(TEEC_Session *session, uint32_t ip_vers,
 				  struct socket_handle *handle,
 				  uint32_t *error, uint32_t *ret_orig)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 
 	memset(handle, 0, sizeof(*handle));
@@ -72,7 +72,7 @@ static TEE_Result socket_udp_open(TEEC_Session *session, uint32_t ip_vers,
 				  struct socket_handle *handle,
 				  uint32_t *error, uint32_t *ret_orig)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 
 	memset(handle, 0, sizeof(*handle));
@@ -102,7 +102,7 @@ static TEE_Result socket_send(TEEC_Session *session,
 			      const void *data, size_t *dlen,
 			      uint32_t timeout, uint32_t *ret_orig)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 
 	op.params[0].tmpref.buffer = handle->buf;
@@ -126,7 +126,7 @@ static TEE_Result socket_recv(TEEC_Session *session,
 			      void *data, size_t *dlen,
 			      uint32_t timeout, uint32_t *ret_orig)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 
 	op.params[0].tmpref.buffer = handle->buf;
@@ -149,7 +149,7 @@ static TEE_Result socket_get_error(TEEC_Session *session,
 			      struct socket_handle *handle,
 			      uint32_t *proto_error, uint32_t *ret_orig)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 
 	op.params[0].tmpref.buffer = handle->buf;
@@ -183,7 +183,7 @@ static TEE_Result socket_ioctl(TEEC_Session *session,
 			      struct socket_handle *handle, uint32_t ioctl_cmd,
 			      void *data, size_t *dlen, uint32_t *ret_orig)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 
 	op.params[0].tmpref.buffer = handle->buf;
@@ -230,9 +230,9 @@ static bool test_200x_tcp_accept_cb(void *ptr, int fd, short *events)
 static bool test_200x_tcp_read_cb(void *ptr, int fd, short *events)
 {
 	struct test_200x_io_state *iostate = ptr;
-	ssize_t r;
-	uint8_t buf[100];
-	uint8_t buf2[100];
+	ssize_t r = 0;
+	uint8_t buf[100] = { };
+	uint8_t buf2[100] = { };
 
 	(void)events;
 	r = read(fd, buf, sizeof(buf));
@@ -252,8 +252,8 @@ static bool test_200x_tcp_write_cb(void *ptr, int fd, short *events)
 {
 	struct test_200x_io_state *iostate = ptr;
 	size_t num_bytes = 100;
-	const void *bytes;
-	ssize_t r;
+	const void *bytes = NULL;
+	ssize_t r = 0;
 
 	(void)events;
 
@@ -268,16 +268,16 @@ static bool test_200x_tcp_write_cb(void *ptr, int fd, short *events)
 
 static void xtest_tee_test_2001(ADBG_Case_t *c)
 {
-	struct sock_server ts;
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	uint32_t proto_error;
-	struct socket_handle sh;
-	uint8_t buf[64];
-	uint8_t buf2[64];
-	size_t blen;
-	struct test_200x_io_state server_iostate;
-	struct test_200x_io_state local_iostate;
+	struct sock_server ts = { };
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	uint32_t proto_error = 9;
+	struct socket_handle sh = { };
+	uint8_t buf[64] = { };
+	uint8_t buf2[64] = { };
+	size_t blen = 0;
+	struct test_200x_io_state server_iostate = { };
+	struct test_200x_io_state local_iostate = { };
 	struct sock_io_cb cb = {
 		.accept = test_200x_tcp_accept_cb,
 		.read = test_200x_tcp_read_cb,
@@ -423,14 +423,14 @@ static void  xtest_2002_wait_barrier(struct test_2002_barrier *bar)
 static void *xtest_tee_test_2002_thread(void *arg)
 {
 	struct test_2002_arg *a = arg;
-	TEE_Result res;
-	struct sock_server ts;
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	uint32_t proto_error;
-	struct socket_handle sh;
-	struct test_200x_io_state server_iostate;
-	struct test_200x_io_state local_iostate;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct sock_server ts = { };
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	uint32_t proto_error = 0;
+	struct socket_handle sh = { };
+	struct test_200x_io_state server_iostate = { };
+	struct test_200x_io_state local_iostate = { };
 	struct sock_io_cb cb = {
 		.accept = test_200x_tcp_accept_cb,
 		.read = test_200x_tcp_read_cb,
@@ -464,10 +464,10 @@ static void *xtest_tee_test_2002_thread(void *arg)
 		goto out_close_session;
 
 	while (sent_bytes < send_limit && recvd_bytes < recv_limit) {
-		const void *peek;
-		uint8_t buf[64];
-		uint8_t buf2[64];
-		size_t blen;
+		const void *peek = NULL;
+		uint8_t buf[64] = { };
+		uint8_t buf2[64] = { };
+		size_t blen = 0;
 
 		blen = sizeof(buf);
 		peek = rand_stream_peek(local_iostate.write_rs, &blen);
@@ -511,11 +511,11 @@ out:
 
 static void xtest_tee_test_2002(ADBG_Case_t *c)
 {
-	pthread_t thr[NUM_THREADS];
 	struct test_2002_barrier bar = { .mu = PTHREAD_MUTEX_INITIALIZER };
-	struct test_2002_arg arg[NUM_THREADS];
-	size_t n;
-	size_t nt;
+	struct test_2002_arg arg[NUM_THREADS] = { };
+	size_t n = 0;
+	size_t nt = 0;
+	pthread_t thr[NUM_THREADS] = { };
 
 	Do_ADBG_BeginSubCase(c, "Stressing with %d threads", NUM_THREADS);
 
@@ -550,7 +550,7 @@ ADBG_CASE_DEFINE(regression, 2002, xtest_tee_test_2002,
 
 static bool test_2003_accept_cb(void *ptr, int fd, short *events)
 {
-	int val;
+	int val = 0;
 
 	(void)ptr;
 	(void)events;
@@ -563,15 +563,15 @@ static bool test_2003_accept_cb(void *ptr, int fd, short *events)
 
 static void xtest_tee_test_2003(ADBG_Case_t *c)
 {
-	struct sock_server ts;
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	uint32_t proto_error;
-	struct socket_handle sh;
-	void *buf;
+	struct sock_server ts = { };
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	uint32_t proto_error = 0;
+	struct socket_handle sh = { };
+	void *buf = NULL;
 	const size_t blen0 = 16 * 1024;
-	size_t blen;
-	uint32_t val;
+	size_t blen = 0;
+	uint32_t val = 0;
 	struct sock_io_cb cb = { .accept = test_2003_accept_cb };
 
 	Do_ADBG_BeginSubCase(c, "Start server");
@@ -608,7 +608,7 @@ static void xtest_tee_test_2003(ADBG_Case_t *c)
 
 	Do_ADBG_BeginSubCase(c, "TCP Socket send (10 ms timeout)");
 	while (true) {
-		TEE_Result res;
+		TEE_Result res = TEE_ERROR_GENERIC;
 
 		blen = blen0;
 		memset(buf, 0, blen0);
@@ -648,13 +648,13 @@ ADBG_CASE_DEFINE(regression, 2003, xtest_tee_test_2003,
 static bool test_200x_udp_accept_cb(void *ptr, int fd, short *events)
 {
 	struct test_200x_io_state *iostate = ptr;
-	struct sockaddr_storage sass;
+	struct sockaddr_storage sass = { };
 	struct sockaddr *sa = (struct sockaddr *)&sass;
 	socklen_t slen = sizeof(sass);
-	uint8_t buf[100];
-	uint8_t buf2[100];
-	ssize_t r;
-	size_t l;
+	uint8_t buf[100] = { };
+	uint8_t buf2[100] = { };
+	ssize_t r = 0;
+	size_t l = 0;
 
 	(void)events;
 
@@ -673,22 +673,22 @@ static bool test_200x_udp_accept_cb(void *ptr, int fd, short *events)
 
 static void xtest_tee_test_2004(ADBG_Case_t *c)
 {
-	struct sock_server ts;
-	struct sock_server ts2;
-	struct sock_server ts3;
+	struct sock_server ts = { };
+	struct sock_server ts2 = { };
+	struct sock_server ts3 = { };
 	bool ts_inited = false;
 	bool ts2_inited = false;
 	bool ts3_inited = false;
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	uint32_t proto_error;
-	struct socket_handle sh;
-	uint8_t buf[64];
-	uint8_t buf2[64];
-	size_t blen;
-	uint16_t port;
-	struct test_200x_io_state server_iostate;
-	struct test_200x_io_state local_iostate;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	uint32_t proto_error = 0;
+	struct socket_handle sh = { };
+	uint8_t buf[64] = { };
+	uint8_t buf2[64] = { };
+	size_t blen = 0;
+	uint16_t port = 0;
+	struct test_200x_io_state server_iostate = { };
+	struct test_200x_io_state local_iostate = { };
 	struct sock_io_cb cb = {
 		.accept = test_200x_udp_accept_cb,
 		.ptr = &server_iostate,

--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -34,9 +34,9 @@
 static TEEC_Result ta_crypt_cmd_reset_operation(ADBG_Case_t *c, TEEC_Session *s,
 						TEE_OperationHandle oph)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -56,9 +56,9 @@ static TEEC_Result ta_crypt_cmd_copy_operation(ADBG_Case_t *c,
 					       TEE_OperationHandle dst_oph,
 					       TEE_OperationHandle src_oph)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)dst_oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)dst_oph;
@@ -83,9 +83,9 @@ static TEEC_Result ta_crypt_cmd_digest_update(ADBG_Case_t *c, TEEC_Session *s,
 					      const void *chunk,
 					      size_t chunk_size)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -112,9 +112,9 @@ static TEEC_Result ta_crypt_cmd_digest_do_final(ADBG_Case_t *c, TEEC_Session *s,
 						size_t chunk_len, void *hash,
 						size_t *hash_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -149,9 +149,9 @@ static TEE_Result ta_crypt_cmd_set_operation_key2(ADBG_Case_t *c,
 						  TEE_ObjectHandle key1,
 						  TEE_ObjectHandle key2)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -179,9 +179,9 @@ static TEEC_Result ta_crypt_cmd_mac_init(ADBG_Case_t *c, TEEC_Session *s,
 					 TEE_OperationHandle oph,
 					 const void *iv, size_t iv_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -211,9 +211,9 @@ static TEEC_Result ta_crypt_cmd_mac_update(ADBG_Case_t *c, TEEC_Session *s,
 					   TEE_OperationHandle oph,
 					   const void *chunk, size_t chunk_size)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -243,9 +243,9 @@ static TEEC_Result ta_crypt_cmd_mac_final_compute(ADBG_Case_t *c,
 						  void *hash,
 						  size_t *hash_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -278,9 +278,9 @@ static TEEC_Result ta_crypt_cmd_cipher_init(ADBG_Case_t *c, TEEC_Session *s,
 					    TEE_OperationHandle oph,
 					    const void *iv, size_t iv_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -312,9 +312,9 @@ static TEEC_Result ta_crypt_cmd_cipher_update(ADBG_Case_t *c, TEEC_Session *s,
 					      const void *src, size_t src_len,
 					      void *dst, size_t *dst_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -350,9 +350,9 @@ static TEEC_Result ta_crypt_cmd_cipher_do_final(ADBG_Case_t *c,
 						void *dst,
 						size_t *dst_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -386,9 +386,9 @@ static TEEC_Result ta_crypt_cmd_random_number_generate(ADBG_Case_t *c,
 						       void *buf,
 						       size_t blen)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].tmpref.buffer = buf;
 	op.params[0].tmpref.size = blen;
@@ -415,9 +415,9 @@ static TEEC_Result ta_crypt_cmd_ae_init(ADBG_Case_t *c, TEEC_Session *s,
 					size_t tag_len, size_t aad_len,
 					size_t payload_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -446,9 +446,9 @@ static TEEC_Result ta_crypt_cmd_ae_update_aad(ADBG_Case_t *c, TEEC_Session *s,
 					      TEE_OperationHandle oph,
 					      const void *aad, size_t aad_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -478,9 +478,9 @@ static TEEC_Result ta_crypt_cmd_ae_update(ADBG_Case_t *c,
 					  void *dst,
 					  size_t *dst_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -516,9 +516,9 @@ static TEEC_Result ta_crypt_cmd_ae_encrypt_final(ADBG_Case_t *c,
 						 size_t *dst_len, void *tag,
 						 size_t *tag_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -560,9 +560,9 @@ static TEEC_Result ta_crypt_cmd_ae_decrypt_final(ADBG_Case_t *c,
 						 void *dst, size_t *dst_len,
 						 const void *tag, size_t tag_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -606,11 +606,11 @@ static TEEC_Result ta_crypt_cmd_asymmetric_operate(ADBG_Case_t *c,
 						   void *dst,
 						   size_t *dst_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
-	uint8_t *buf;
-	size_t blen;
+	uint32_t ret_orig = 0;
+	uint8_t *buf = NULL;
+	size_t blen = 0;
 
 	res = pack_attrs(params, paramCount, &buf, &blen);
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c, res))
@@ -704,11 +704,11 @@ static TEEC_Result ta_crypt_cmd_asymmetric_verify(ADBG_Case_t *c,
 						  const void *signature,
 						  size_t signature_len)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
-	uint8_t *buf;
-	size_t blen;
+	uint32_t ret_orig = 0;
+	uint8_t *buf = NULL;
+	size_t blen = 0;
 
 	res = pack_attrs(params, paramCount, &buf, &blen);
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c, res))
@@ -750,9 +750,9 @@ static TEEC_Result ta_crypt_cmd_get_object_value_attribute(ADBG_Case_t *c,
 							   uint32_t *valuea,
 							   uint32_t *valueb)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)o <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)o;
@@ -783,11 +783,11 @@ static TEEC_Result ta_crypt_cmd_generate_key(ADBG_Case_t *c,
 					     const TEE_Attribute *params,
 					     uint32_t paramCount)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
-	uint8_t *buf;
-	size_t blen;
+	uint32_t ret_orig = 0;
+	uint8_t *buf = NULL;
+	size_t blen = 0;
 
 	res = pack_attrs(params, paramCount, &buf, &blen);
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c, res))
@@ -923,9 +923,9 @@ static const struct xtest_hash_case hash_cases[] = {
 
 static void xtest_tee_test_4001(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
@@ -934,10 +934,10 @@ static void xtest_tee_test_4001(ADBG_Case_t *c)
 
 
 	for (n = 0; n < ARRAY_SIZE(hash_cases); n++) {
-		TEE_OperationHandle op1;
-		TEE_OperationHandle op2;
-		uint8_t out[64];
-		size_t out_size;
+		TEE_OperationHandle op1 = TEE_HANDLE_NULL;
+		TEE_OperationHandle op2 = TEE_HANDLE_NULL;
+		uint8_t out[64] = { };
+		size_t out_size = 0;
 
 		Do_ADBG_BeginSubCase(c, "Hash case %d algo 0x%x",
 				     (int)n, (unsigned int)hash_cases[n].algo);
@@ -1580,14 +1580,14 @@ static const struct xtest_mac_case mac_cases[] = {
 
 static void xtest_tee_test_4002(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	TEE_OperationHandle op1;
-	TEE_OperationHandle op2;
-	TEE_ObjectHandle key_handle;
-	uint8_t out[64];
-	size_t out_size;
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	TEE_OperationHandle op1 = TEE_HANDLE_NULL;
+	TEE_OperationHandle op2 = TEE_HANDLE_NULL;
+	TEE_ObjectHandle key_handle = TEE_HANDLE_NULL;
+	uint8_t out[64] = { };
+	size_t out_size = 0;
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
@@ -1595,9 +1595,9 @@ static void xtest_tee_test_4002(ADBG_Case_t *c)
 		return;
 
 	for (n = 0; n < ARRAY_SIZE(mac_cases); n++) {
-		TEE_Attribute key_attr;
-		size_t key_size;
-		size_t offs;
+		TEE_Attribute key_attr = { };
+		size_t key_size = 0;
+		size_t offs = 0;
 
 		Do_ADBG_BeginSubCase(c, "MAC case %d algo 0x%x",
 				     (int)n, (unsigned int)mac_cases[n].algo);
@@ -2317,15 +2317,15 @@ static const struct xtest_ciph_case ciph_cases[] = {
 
 static void xtest_tee_test_4003(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	TEE_OperationHandle op;
+	TEEC_Session session = { };
+	TEE_OperationHandle op = TEE_HANDLE_NULL;
 	TEE_ObjectHandle key1_handle = TEE_HANDLE_NULL;
 	TEE_ObjectHandle key2_handle = TEE_HANDLE_NULL;
-	uint8_t out[2048];
-	size_t out_size;
-	size_t out_offs;
-	uint32_t ret_orig;
-	size_t n;
+	uint8_t out[2048] = { };
+	size_t out_size = 0;
+	size_t out_offs = 0;
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
@@ -2333,10 +2333,9 @@ static void xtest_tee_test_4003(ADBG_Case_t *c)
 		return;
 
 	for (n = 0; n < ARRAY_SIZE(ciph_cases); n++) {
-		TEE_Attribute key_attr;
-		size_t key_size;
-		size_t op_key_size;
-
+		TEE_Attribute key_attr = { };
+		size_t key_size = 0;
+		size_t op_key_size = 0;
 
 		Do_ADBG_BeginSubCase(c, "Cipher case %d algo 0x%x line %d",
 				     (int)n, (unsigned int)ciph_cases[n].algo,
@@ -2461,11 +2460,11 @@ ADBG_CASE_DEFINE(regression, 4003, xtest_tee_test_4003,
 
 static void xtest_tee_test_4004(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	uint8_t buf1[45] = { 0 };
-	uint8_t buf2[45] = { 0 };
-	static const uint8_t zeros[45] = { 0 };
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	uint8_t buf1[45] = { };
+	uint8_t buf2[45] = { };
+	static const uint8_t zeros[45];
 
 	Do_ADBG_BeginSubCase(c, "TEE get random");
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -2585,15 +2584,15 @@ static const struct xtest_ae_case ae_cases[] = {
 
 static void xtest_tee_test_4005(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	TEE_OperationHandle op;
+	TEEC_Session session = { };
+	TEE_OperationHandle op = TEE_HANDLE_NULL;
 	TEE_ObjectHandle key_handle = TEE_HANDLE_NULL;
-	TEE_Attribute key_attr;
-	uint8_t out[512];
-	size_t out_size;
-	size_t out_offs;
-	uint32_t ret_orig;
-	size_t n;
+	TEE_Attribute key_attr = { };
+	uint8_t out[512] = { };
+	size_t out_size = 0;
+	size_t out_offs = 0;
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
@@ -3616,7 +3615,7 @@ static bool create_key(ADBG_Case_t *c, TEEC_Session *s,
 		       TEE_Attribute *attrs, size_t num_attrs,
 		       TEE_ObjectHandle *handle)
 {
-	size_t n;
+	size_t n = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		ta_crypt_cmd_allocate_transient_object(c, s, key_type,
@@ -3629,11 +3628,8 @@ static bool create_key(ADBG_Case_t *c, TEEC_Session *s,
 		return false;
 
 	for (n = 0; n < num_attrs; n++) {
-		uint8_t out[512];
-		size_t out_size;
-
-		out_size = sizeof(out);
-		memset(out, 0, sizeof(out));
+		uint8_t out[512] = { };
+		size_t out_size = sizeof(out);
 
 		if (attrs[n].attributeID == TEE_ATTR_ECC_CURVE)
 			continue;
@@ -3661,25 +3657,25 @@ static bool create_key(ADBG_Case_t *c, TEEC_Session *s,
 
 static void xtest_tee_test_4006(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = { };
 	TEE_OperationHandle op = TEE_HANDLE_NULL;
 	TEE_ObjectHandle priv_key_handle = TEE_HANDLE_NULL;
 	TEE_ObjectHandle pub_key_handle = TEE_HANDLE_NULL;
-	TEE_Attribute key_attrs[8];
-	TEE_Attribute algo_params[1];
-	size_t num_algo_params;
-	uint8_t out[512];
-	size_t out_size;
-	uint8_t out_enc[512];
-	size_t out_enc_size;
-	uint8_t ptx_hash[TEE_MAX_HASH_SIZE];
+	TEE_Attribute key_attrs[8] = { };
+	TEE_Attribute algo_params[1] = { };
+	size_t num_algo_params = 0;
+	uint8_t out[512] = { };
+	size_t out_size = 0;
+	uint8_t out_enc[512] = { };
+	size_t out_enc_size = 0;
+	uint8_t ptx_hash[TEE_MAX_HASH_SIZE] = { };
 	size_t ptx_hash_size = 0;
-	size_t max_key_size;
-	size_t num_key_attrs;
-	uint32_t ret_orig;
-	size_t n;
-	uint32_t curve;
-	uint32_t hash_algo;
+	size_t max_key_size = 0;
+	size_t num_key_attrs = 0;
+	uint32_t ret_orig = 0;
+	size_t n = 0;
+	uint32_t curve = 0;
+	uint32_t hash_algo = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
@@ -4164,10 +4160,10 @@ static bool test_keygen_attributes(ADBG_Case_t *c, TEEC_Session *s,
 				   TEE_ObjectHandle key, uint32_t key_size,
 				   struct key_attrs *attrs, size_t num_attrs)
 {
-	uint8_t out[2048];
-	size_t out_size;
-	size_t n;
-	size_t m;
+	uint8_t out[2048] = { };
+	size_t out_size = 0;
+	size_t n = 0;
+	size_t m = 0;
 
 	for (m = 0; m < num_attrs; m++) {
 		if ((attrs[m].attr & TEE_ATTR_BIT_VALUE) == 0) {
@@ -4192,8 +4188,8 @@ static bool test_keygen_attributes(ADBG_Case_t *c, TEEC_Session *s,
 					return false;
 			}
 		} else {
-			uint32_t a;
-			uint32_t b;
+			uint32_t a = 0;
+			uint32_t b = 0;
 
 			if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 				ta_crypt_cmd_get_object_value_attribute(c, s, key,
@@ -4288,7 +4284,7 @@ static bool generate_and_test_key(ADBG_Case_t *c, TEEC_Session *s,
 				  uint32_t key_size,
 				  TEE_Attribute *params, size_t param_count)
 {
-	TEE_ObjectHandle key;
+	TEE_ObjectHandle key = TEE_HANDLE_NULL;
 	bool ret_val = true;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -4366,8 +4362,8 @@ static void keygen_noparams(ADBG_Case_t *c, TEEC_Session *session,
 			    const struct key_types_noparam *key_types,
 			    size_t num_key_types)
 {
-	size_t n;
-	uint32_t key_size;
+	size_t n = 0;
+	uint32_t key_size = 0;
 
 	for (n = 0; n < num_key_types; n++) {
 		uint32_t min_size = key_types[n].min_size;
@@ -4393,8 +4389,8 @@ static void keygen_noparams(ADBG_Case_t *c, TEEC_Session *session,
 
 static void xtest_tee_test_4007_symmetric(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 	static const struct key_types_noparam key_types[] = {
 		{ 0, "AES", TEE_TYPE_AES, 64, 128,
 		  256 /* valid sizes 128, 192, 256 */ },
@@ -4424,8 +4420,8 @@ ADBG_CASE_DEFINE(regression, 4007_symmetric, xtest_tee_test_4007_symmetric,
 
 static void xtest_tee_test_4007_rsa(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 	static const struct key_types_noparam key_types[] = {
 		{ 0, "RSA-256", TEE_TYPE_RSA_KEYPAIR, 1, 256, 256 },
 		{ 1, "RSA-384", TEE_TYPE_RSA_KEYPAIR, 1, 384, 384 },
@@ -4453,10 +4449,10 @@ ADBG_CASE_DEFINE(regression, 4007_rsa, xtest_tee_test_4007_rsa,
 
 static void xtest_tee_test_4007_dh(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
-	size_t param_count;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
+	size_t param_count = 0;
 	/*
 	 * Note that the key size parameter is not used when creating the keys
 	 * but specifying these sizes make it possible to test the expected size
@@ -4464,7 +4460,7 @@ static void xtest_tee_test_4007_dh(ADBG_Case_t *c)
 	 * size of p or what is specified in private_bits or the equvivalent
 	 * size of the subprime parameter.
 	 */
-	TEE_Attribute params[4];
+	TEE_Attribute params[4] = { };
 
 #define XTEST_DH_GK_DATA(vect) \
 	ARRAY(vect ## _p), \
@@ -4577,11 +4573,11 @@ ADBG_CASE_DEFINE(regression, 4007_dh, xtest_tee_test_4007_dh,
 
 static void xtest_tee_test_4007_dsa(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
-	size_t param_count;
-	TEE_Attribute params[4];
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
+	size_t param_count = 0;
+	TEE_Attribute params[4] = { };
 
 #define XTEST_DSA_GK_DATA(vect) \
 	ARRAY(vect ## _p), \
@@ -4650,11 +4646,11 @@ ADBG_CASE_DEFINE(regression, 4007_dsa, xtest_tee_test_4007_dsa,
 
 static void xtest_tee_test_4007_ecc(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
-	size_t param_count;
-	TEE_Attribute params[4];
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
+	size_t param_count = 0;
+	TEE_Attribute params[4] = { };
 
 	static const struct {
 		unsigned level;
@@ -4719,15 +4715,15 @@ ADBG_CASE_DEFINE(regression, 4007_ecc, xtest_tee_test_4007_ecc,
 
 static void xtest_tee_test_4008(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	TEE_OperationHandle op;
-	TEE_ObjectHandle key_handle;
-	TEE_ObjectHandle sv_handle;
-	TEE_Attribute params[4];
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	TEE_OperationHandle op = TEE_HANDLE_NULL;
+	TEE_ObjectHandle key_handle = TEE_HANDLE_NULL;
+	TEE_ObjectHandle sv_handle = TEE_HANDLE_NULL;
+	TEE_Attribute params[4] = { };
 	size_t param_count = 0;
-	uint8_t out[2048];
-	size_t out_size;
+	uint8_t out[2048] = { };
+	size_t out_size = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
@@ -4818,18 +4814,18 @@ ADBG_CASE_DEFINE(regression, 4008, xtest_tee_test_4008,
 
 static void xtest_tee_test_4009(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	TEE_OperationHandle op;
-	TEE_ObjectHandle key_handle;
-	TEE_ObjectHandle sv_handle;
-	TEE_Attribute params[4];
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	TEE_OperationHandle op = TEE_HANDLE_NULL;
+	TEE_ObjectHandle key_handle = TEE_HANDLE_NULL;
+	TEE_ObjectHandle sv_handle = TEE_HANDLE_NULL;
+	TEE_Attribute params[4] = { };
 	size_t param_count = 0;
-	uint8_t out[2048];
-	size_t out_size;
-	uint32_t size_bytes;
-	uint32_t i;
-	struct derive_key_ecdh_t *pt;
+	uint8_t out[2048] = { };
+	size_t out_size = 0;
+	uint32_t size_bytes = 0;
+	uint32_t i = 0;
+	struct derive_key_ecdh_t *pt = NULL;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
@@ -4949,9 +4945,9 @@ ADBG_CASE_DEFINE(regression, 4009, xtest_tee_test_4009,
 
 static void xtest_tee_test_4010(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	TEE_ObjectHandle o;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	TEE_ObjectHandle o = TEE_HANDLE_NULL;
 	static const uint8_t large_key[1024] = { 1, 2, 3, 4, 5, 6 };
 	static const TEE_Attribute attr = {
 		.attributeID = TEE_ATTR_SECRET_VALUE,
@@ -4981,21 +4977,21 @@ ADBG_CASE_DEFINE(regression, 4010, xtest_tee_test_4010,
 
 static void xtest_tee_test_4011(ADBG_Case_t *c)
 {
-	TEEC_Session s = { 0 };
+	TEEC_Session s = { };
 	size_t key_size = 512;
-	TEE_ObjectHandle key;
-	TEE_OperationHandle ops;
-	TEE_OperationHandle opv;
-	TEE_OperationHandle ope;
-	TEE_OperationHandle opd;
-	uint32_t ret_orig;
-	uint8_t in[TEE_SHA1_HASH_SIZE];
-	uint8_t out[1024];
-	uint8_t tmp[1024];
-	size_t out_size;
-	size_t tmp_size;
-	size_t n;
-	size_t m;
+	TEE_ObjectHandle key = TEE_HANDLE_NULL;
+	TEE_OperationHandle ops = TEE_HANDLE_NULL;
+	TEE_OperationHandle opv = TEE_HANDLE_NULL;
+	TEE_OperationHandle ope = TEE_HANDLE_NULL;
+	TEE_OperationHandle opd = TEE_HANDLE_NULL;
+	uint32_t ret_orig = 0;
+	uint8_t in[TEE_SHA1_HASH_SIZE] = { };
+	uint8_t out[1024] = { };
+	uint8_t tmp[1024] = { };
+	size_t out_size = 0;
+	size_t tmp_size = 0;
+	size_t n = 0;
+	size_t m = 0;
 	size_t i = 0;
 
 	/* Setup session, initialize message to sign, create a keypair */
@@ -5131,13 +5127,13 @@ ADBG_CASE_DEFINE(regression, 4011, xtest_tee_test_4011,
 #ifdef CFG_SYSTEM_PTA
 static void xtest_tee_test_4012(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	/* Fortuna PRNG requires seed <= 32 bytes */
-	uint8_t pool_input[32] = {};
-	time_t t;
-	struct tm tm_local;
+	uint8_t pool_input[32] = { };
+	time_t t = 0;
+	struct tm tm_local = { };
 
 	t = time(NULL);
 	tm_local = *localtime(&t);

--- a/host/xtest/regression_4100.c
+++ b/host/xtest/regression_4100.c
@@ -19,9 +19,9 @@
 static TEEC_Result cmd_new_var(ADBG_Case_t *c, TEEC_Session *s,
 			       uint32_t num_bits, uint32_t *handle)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = num_bits;
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_VALUE_OUTPUT,
@@ -37,9 +37,9 @@ static TEEC_Result cmd_new_var(ADBG_Case_t *c, TEEC_Session *s,
 static TEEC_Result cmd_new_fmm_var(ADBG_Case_t *c, TEEC_Session *s,
 				   uint32_t num_bits, uint32_t *handle)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = num_bits;
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_VALUE_OUTPUT,
@@ -57,9 +57,9 @@ static TEEC_Result cmd_new_fmm_ctx(ADBG_Case_t *c, TEEC_Session *s,
 				   uint32_t num_bits, uint32_t hmodulus,
 				   uint32_t *handle)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = num_bits;
 	op.params[0].value.b = hmodulus;
@@ -80,9 +80,9 @@ static TEEC_Result cmd_free_handle(ADBG_Case_t *c, TEEC_Session *s,
 	if (handle == TA_CRYPT_ARITH_INVALID_HANDLE)
 		return TEEC_SUCCESS;
 
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = handle;
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE,
@@ -98,9 +98,9 @@ static TEEC_Result cmd_from_octet_string(ADBG_Case_t *c, TEEC_Session *s,
 					 uint8_t *buf, uint32_t buf_len,
 					 int32_t sign, uint32_t h)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = h;
 	op.params[0].value.b = sign;
@@ -119,9 +119,9 @@ static TEEC_Result cmd_from_octet_string(ADBG_Case_t *c, TEEC_Session *s,
 static TEEC_Result cmd_from_s32(ADBG_Case_t *c, TEEC_Session *s,
 				uint32_t handle, int32_t v)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = handle;
 	op.params[0].value.b = v;
@@ -137,9 +137,9 @@ static TEEC_Result cmd_from_s32(ADBG_Case_t *c, TEEC_Session *s,
 static TEEC_Result cmd_get_bit(ADBG_Case_t *c, TEEC_Session *s,
 				uint32_t handle, uint32_t bit_num, uint32_t *v)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = handle;
 	op.params[0].value.b = bit_num;
@@ -156,9 +156,9 @@ static TEEC_Result cmd_get_bit(ADBG_Case_t *c, TEEC_Session *s,
 static TEEC_Result cmd_get_bit_count(ADBG_Case_t *c, TEEC_Session *s,
 				uint32_t handle, uint32_t *v)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = handle;
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_VALUE_OUTPUT,
@@ -175,9 +175,9 @@ static TEEC_Result cmd_get_bit_count(ADBG_Case_t *c, TEEC_Session *s,
 static TEEC_Result cmd_binary_cmd(ADBG_Case_t *c, TEEC_Session *s, uint32_t cmd,
 				  uint32_t hop1, uint32_t hop2, uint32_t hres)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hop1;
 	op.params[0].value.b = hop2;
@@ -193,9 +193,9 @@ static TEEC_Result cmd_binary_cmd(ADBG_Case_t *c, TEEC_Session *s, uint32_t cmd,
 static TEEC_Result cmd_unary_cmd(ADBG_Case_t *c, TEEC_Session *s, uint32_t cmd,
 				  uint32_t hop, uint32_t hres)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hop;
 	op.params[0].value.b = hres;
@@ -211,9 +211,9 @@ static TEEC_Result cmd_ternary_cmd(ADBG_Case_t *c, TEEC_Session *s,
 				   uint32_t cmd, uint32_t hop1, uint32_t hop2,
 				   uint32_t hn, uint32_t hres)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hop1;
 	op.params[0].value.b = hop2;
@@ -291,9 +291,9 @@ static TEEC_Result cmd_mulmod(ADBG_Case_t *c, TEEC_Session *s,
 static TEEC_Result cmd_is_prime(ADBG_Case_t *c, TEEC_Session *s, uint32_t hop,
 				uint32_t conf_level, int32_t *pres)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hop;
 	op.params[0].value.b = conf_level;
@@ -311,9 +311,9 @@ static TEEC_Result cmd_is_prime(ADBG_Case_t *c, TEEC_Session *s, uint32_t hop,
 static TEEC_Result cmd_shift_right(ADBG_Case_t *c, TEEC_Session *s,
 				   uint32_t hop, uint32_t bits, uint32_t hres)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hop;
 	op.params[0].value.b = bits;
@@ -330,9 +330,9 @@ static TEEC_Result cmd_shift_right(ADBG_Case_t *c, TEEC_Session *s,
 static TEEC_Result cmd_to_fmm(ADBG_Case_t *c, TEEC_Session *s, uint32_t hsrc,
 			      uint32_t hn, uint32_t hctx, uint32_t hres)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hsrc;
 	op.params[0].value.b = hn;
@@ -349,9 +349,9 @@ static TEEC_Result cmd_to_fmm(ADBG_Case_t *c, TEEC_Session *s, uint32_t hsrc,
 static TEEC_Result cmd_from_fmm(ADBG_Case_t *c, TEEC_Session *s, uint32_t hsrc,
 				uint32_t hn, uint32_t hctx, uint32_t hres)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hsrc;
 	op.params[0].value.b = hn;
@@ -370,9 +370,9 @@ static TEEC_Result cmd_compute_fmm(ADBG_Case_t *c, TEEC_Session *s,
 				   uint32_t hop1, uint32_t hop2, uint32_t hn,
 				   uint32_t hctx, uint32_t hres)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hop1;
 	op.params[0].value.b = hop2;
@@ -392,9 +392,9 @@ static TEEC_Result cmd_compute_egcd(ADBG_Case_t *c, TEEC_Session *s,
 				   uint32_t hop1, uint32_t hop2, uint32_t hu,
 				   uint32_t hv, uint32_t hgcd)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hop1;
 	op.params[0].value.b = hop2;
@@ -440,7 +440,7 @@ static TEEC_Result convert_from_string(ADBG_Case_t *c, TEEC_Session *s,
 	size_t os_len = spos / 2 + 1;
 	uint8_t *os = calloc(1, os_len);
 	int ospos = os_len - 1;
-	int nibble;
+	int nibble = 0;
 
 	if (!os)
 		return TEEC_ERROR_OUT_OF_MEMORY;
@@ -478,9 +478,9 @@ out:
 static TEEC_Result cmd_get_value(ADBG_Case_t *c, TEEC_Session *s, uint8_t *buf,
 				 uint32_t *buf_len, int32_t *sign, uint32_t h)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = h;
 	op.params[2].tmpref.buffer = buf;
@@ -500,7 +500,7 @@ static TEEC_Result cmd_get_value(ADBG_Case_t *c, TEEC_Session *s, uint8_t *buf,
 static TEEC_Result __maybe_unused print_handle(ADBG_Case_t *c, TEEC_Session *s,
 					       const char *name, uint32_t h)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	uint8_t *os = NULL;
 	uint32_t os_len = 0;
 	int32_t sign = 0;
@@ -530,9 +530,9 @@ out:
 static TEEC_Result cmd_get_value_s32(ADBG_Case_t *c, TEEC_Session *s,
 				     uint32_t h, int32_t *val)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = h;
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_VALUE_OUTPUT,
@@ -549,9 +549,9 @@ static TEEC_Result cmd_get_value_s32(ADBG_Case_t *c, TEEC_Session *s,
 static TEEC_Result cmd_cmp(ADBG_Case_t *c, TEEC_Session *s, uint32_t hop1,
 			   uint32_t hop2, int32_t *cmp_res)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hop1;
 	op.params[0].value.b = hop2;
@@ -569,9 +569,9 @@ static TEEC_Result cmd_cmp(ADBG_Case_t *c, TEEC_Session *s, uint32_t hop1,
 static TEEC_Result cmd_cmp_s32(ADBG_Case_t *c, TEEC_Session *s, uint32_t hop,
 			       int32_t s32, int32_t *cmp_res)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hop;
 	op.params[0].value.b = s32;
@@ -589,9 +589,9 @@ static TEEC_Result cmd_cmp_s32(ADBG_Case_t *c, TEEC_Session *s, uint32_t hop,
 static TEEC_Result cmd_div(ADBG_Case_t *c, TEEC_Session *s, uint32_t hop1,
 			   uint32_t hop2, uint32_t hq, uint32_t hr)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = hop1;
 	op.params[0].value.b = hop2;
@@ -607,8 +607,8 @@ static TEEC_Result cmd_div(ADBG_Case_t *c, TEEC_Session *s, uint32_t hop1,
 
 static void test_4101(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 	uint32_t handle = TA_CRYPT_ARITH_INVALID_HANDLE;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -684,11 +684,11 @@ ADBG_CASE_DEFINE(regression, 4101, test_4101,
 
 static void test_4102(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 	uint32_t ha = TA_CRYPT_ARITH_INVALID_HANDLE;
 	uint32_t hb = TA_CRYPT_ARITH_INVALID_HANDLE;
-	size_t n;
+	size_t n = 0;
 	const struct {
 		const uint8_t *os;
 		uint32_t os_len;
@@ -766,15 +766,16 @@ ADBG_CASE_DEFINE(regression, 4102, test_4102,
 
 static void test_4103(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 	uint32_t h = TA_CRYPT_ARITH_INVALID_HANDLE;
 	int32_t v = 0;
 	static const int32_t data[] = {
 		1, -1, 123, -123, 0x7FFFFFFF, (int32_t)0x80000000,
 		(int32_t)0xFFFFFFFF, 0,
 	};
+	static const char *data_str[] = { "1FFFFFFFFF", "-1FFFFFFFFF" };
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 			xtest_teec_open_session(&session, &crypt_user_ta_uuid,
@@ -809,8 +810,6 @@ static void test_4103(ADBG_Case_t *c)
 		Do_ADBG_EndSubCase(c, NULL);
 	}
 
-	static const char *data_str[] = { "1FFFFFFFFF", "-1FFFFFFFFF" };
-
 	for (n = 0; n < ARRAY_SIZE(data_str); n++) {
 		Do_ADBG_BeginSubCase(c, "\"%s\" (overflow)", data_str[n]);
 		if (!ADBG_EXPECT_TEEC_SUCCESS(c, convert_from_string(c,
@@ -832,7 +831,7 @@ static TEEC_Result compare_str(ADBG_Case_t *c, TEEC_Session *s,
 			       const char str1[], const char str2[],
 			       int32_t cmp_res)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	int32_t cres = 0;
 	uint32_t h1 = TA_CRYPT_ARITH_INVALID_HANDLE;
 	uint32_t h2 = TA_CRYPT_ARITH_INVALID_HANDLE;
@@ -866,7 +865,7 @@ static TEEC_Result compare_s32(ADBG_Case_t *c, TEEC_Session *s,
 			       const char str[], int32_t val,
 			       int32_t cmp_res)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	int32_t cres = 0;
 	uint32_t h = TA_CRYPT_ARITH_INVALID_HANDLE;
 
@@ -891,9 +890,9 @@ out:
 
 static void test_4104(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 	const struct {
 		const char *str1;
 		const char *str2;
@@ -1079,9 +1078,9 @@ out:
 
 static void test_4105(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 	static const struct {
 		const char *s;
 		const char *t;
@@ -1158,9 +1157,9 @@ ADBG_CASE_DEFINE(regression, 4105, test_4105,
 
 static void test_4106(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 	uint32_t h1 = TA_CRYPT_ARITH_INVALID_HANDLE;
 	uint32_t h2 = TA_CRYPT_ARITH_INVALID_HANDLE;
 	static const struct {
@@ -1258,9 +1257,9 @@ out:
 
 static void test_4107(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 	static const struct {
 		const char *s;
 		const char *t;
@@ -1398,9 +1397,9 @@ out:
 
 static void test_4108(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 	static const struct {
 		const char *s;
 		const char *t;
@@ -1659,9 +1658,9 @@ out:
 
 static void test_4109(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 			xtest_teec_open_session(&session, &crypt_user_ta_uuid,
@@ -1965,9 +1964,9 @@ out:
 
 static void test_4110(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 			xtest_teec_open_session(&session, &crypt_user_ta_uuid,
@@ -2091,9 +2090,9 @@ out:
 
 static void test_4111(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 			xtest_teec_open_session(&session, &crypt_user_ta_uuid,
@@ -2212,7 +2211,8 @@ static bool test_4112_is_prime(ADBG_Case_t *c, TEEC_Session *s,
 						      &pres)))
 		goto out;
 	if (!ADBG_EXPECT_TRUE(c, pres == res1 || pres == res2)) {
-		Do_ADBG_Log("Unexpected prime clasification %" PRId32 ", expected %" PRId32 " or %" PRId32, pres, res1, res2);
+		Do_ADBG_Log("Unexpected prime clasification %" PRId32 ", expected %" PRId32 " or %" PRId32,
+			    pres, res1, res2);
 		goto out;
 	}
 
@@ -2225,9 +2225,9 @@ out:
 
 static void test_4112(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 			xtest_teec_open_session(&session, &crypt_user_ta_uuid,
@@ -2343,9 +2343,9 @@ out:
 
 static void test_4113(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 			xtest_teec_open_session(&session, &crypt_user_ta_uuid,
@@ -2477,9 +2477,9 @@ out:
 
 static void test_4114(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
-	size_t n;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+	size_t n = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 			xtest_teec_open_session(&session, &crypt_user_ta_uuid,

--- a/host/xtest/regression_5000.c
+++ b/host/xtest/regression_5000.c
@@ -102,7 +102,7 @@ static void Allocate_In(struct xtest_session *cs)
 {
 	Do_ADBG_BeginSubCase(cs->c, "Allocate_In");
 	{
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 		size_t size = 1024;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
@@ -126,7 +126,7 @@ static void Allocate_out_of_memory(struct xtest_session *cs)
 {
 	Do_ADBG_BeginSubCase(cs->c, "Allocate_out_of_memory");
 	{
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 		size_t SIZE_OVER_MEMORY_CAPACITY = SIZE_MAX;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
@@ -150,7 +150,7 @@ static void OpenSession_error_notExistingTA(struct xtest_session *cs)
 		TEEC_UUID NONEXISTING_TA_UUID = { 0x534D1192, 0x6143, 0x234C,
 						  { 0x47, 0x55, 0x53, 0x52,
 						    0x54, 0x4F, 0x4F, 0x59 } };
-		uint32_t ret_orig;
+		uint32_t ret_orig = 0;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -173,7 +173,7 @@ static void Allocate_InOut(struct xtest_session *cs)
 {
 	Do_ADBG_BeginSubCase(cs->c, "Allocate_InOut");
 	{
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 		uint8_t val[] = { 54, 76, 98, 32 };
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
@@ -197,7 +197,7 @@ static void Register_In(struct xtest_session *cs)
 {
 	Do_ADBG_BeginSubCase(cs->c, "Register_In");
 	{
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 		uint8_t val[] = { 32, 65, 43, 21, 98 };
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
@@ -223,7 +223,7 @@ static void Register_notZeroLength_Out(struct xtest_session *cs)
 {
 	Do_ADBG_BeginSubCase(cs->c, "Register_notZeroLength_Out");
 	{
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 		uint8_t val[] = { 56, 67, 78, 99 };
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
@@ -249,7 +249,7 @@ static void Register_InOut(struct xtest_session *cs)
 {
 	Do_ADBG_BeginSubCase(cs->c, "Register_InOut");
 	{
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 		uint8_t val[] = { 54, 76, 23, 98, 255, 23, 86 };
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
@@ -275,7 +275,7 @@ static void Register_zeroLength_Out(struct xtest_session *cs)
 	Do_ADBG_BeginSubCase(cs->c, "Register_zeroLength_Out");
 	{
 		uint8_t val[] = { 65, 76, 98, 32 };
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -299,7 +299,7 @@ static void Allocate_Out(struct xtest_session *cs)
 {
 	Do_ADBG_BeginSubCase(cs->c, "Allocate_Out");
 	{
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -343,7 +343,7 @@ static void AllocateThenRegister_SameMemory(struct xtest_session *cs)
 {
 	Do_ADBG_BeginSubCase(cs->c, "AllocateThenRegister_SameMemory");
 	{
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 		size_t size_allocation = 32;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
@@ -371,7 +371,7 @@ static void AllocateSameMemory_twice(struct xtest_session *cs)
 {
 	Do_ADBG_BeginSubCase(cs->c, "AllocateSameMemory_twice");
 	{
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 		size_t size_allocation = 32;
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
@@ -400,7 +400,7 @@ static void RegisterSameMemory_twice(struct xtest_session *cs)
 	Do_ADBG_BeginSubCase(cs->c, "RegisterSameMemory_twice");
 	{
 		uint8_t val[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 };
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -434,7 +434,7 @@ static void Allocate_sharedMemory_32k(struct xtest_session *cs)
 	{
 		size_t size = MIN(32 * 1024,
 				  TEEC_CONFIG_SHAREDMEM_MAX_SIZE);
-		TEEC_SharedMemory shm;
+		TEEC_SharedMemory shm = { };
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -453,14 +453,14 @@ out:
 	Do_ADBG_EndSubCase(cs->c, "Allocate_sharedMemory_32k");
 }
 
+#define SHM_32K_SIZE	MIN(32 * 1024, TEEC_CONFIG_SHAREDMEM_MAX_SIZE)
+
 static void Register_sharedMemory_32k(struct xtest_session *cs)
 {
 	Do_ADBG_BeginSubCase(cs->c, "Register_sharedMemory_32k");
 	{
-		size_t size = MIN(32 * 1024,
-				  TEEC_CONFIG_SHAREDMEM_MAX_SIZE);
-		uint8_t val[size];
-		TEEC_SharedMemory shm;
+		uint8_t val[SHM_32K_SIZE] = { };
+		TEEC_SharedMemory shm = { };
 
 		if (!ADBG_EXPECT(cs->c, TEEC_SUCCESS,
 			TEEC_InitializeContext(_device, &cs->context)))
@@ -468,7 +468,7 @@ static void Register_sharedMemory_32k(struct xtest_session *cs)
 
 		shm.buffer = val;
 		if (!ADBG_EXPECT_TEEC_SUCCESS(cs->c,
-			RegisterSharedMemory(&cs->context, &shm, size,
+			RegisterSharedMemory(&cs->context, &shm, SHM_32K_SIZE,
 					     TEEC_MEM_INPUT)))
 			goto out_final;
 

--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -113,8 +113,8 @@ static TEEC_Result fs_open(TEEC_Session *sess, void *id, uint32_t id_size,
 			   uint32_t flags, uint32_t *obj, uint32_t storage_id)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	TEEC_Result res;
-	uint32_t org;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t org = 0;
 
 	op.params[0].tmpref.buffer = id;
 	op.params[0].tmpref.size = id_size;
@@ -140,8 +140,8 @@ static TEEC_Result fs_create(TEEC_Session *sess, void *id, uint32_t id_size,
 			     uint32_t storage_id)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	TEEC_Result res;
-	uint32_t org;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t org = 0;
 
 	op.params[0].tmpref.buffer = id;
 	op.params[0].tmpref.size = id_size;
@@ -168,8 +168,8 @@ static TEEC_Result fs_create_overwrite(TEEC_Session *sess, void *id,
 				       uint32_t id_size, uint32_t storage_id)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	TEEC_Result res;
-	uint32_t org;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t org = 0;
 
 	op.params[0].tmpref.buffer = id;
 	op.params[0].tmpref.size = id_size;
@@ -187,7 +187,7 @@ static TEEC_Result fs_create_overwrite(TEEC_Session *sess, void *id,
 static TEEC_Result fs_close(TEEC_Session *sess, uint32_t obj)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.params[0].value.a = obj;
 
@@ -200,9 +200,9 @@ static TEEC_Result fs_close(TEEC_Session *sess, uint32_t obj)
 static TEEC_Result fs_read(TEEC_Session *sess, uint32_t obj, void *data,
 			   uint32_t data_size, uint32_t *count)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.params[0].tmpref.buffer = data;
 	op.params[0].tmpref.size = data_size;
@@ -225,7 +225,7 @@ static TEEC_Result fs_write(TEEC_Session *sess, uint32_t obj, void *data,
 			    uint32_t data_size)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.params[0].tmpref.buffer = data;
 	op.params[0].tmpref.size = data_size;
@@ -243,7 +243,7 @@ static TEEC_Result fs_seek(TEEC_Session *sess, uint32_t obj, int32_t offset,
 			   int32_t whence)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.params[0].value.a = obj;
 	op.params[0].value.b = *(uint32_t *)&offset;
@@ -258,7 +258,7 @@ static TEEC_Result fs_seek(TEEC_Session *sess, uint32_t obj, int32_t offset,
 static TEEC_Result fs_unlink(TEEC_Session *sess, uint32_t obj)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.params[0].value.a = obj;
 
@@ -271,7 +271,7 @@ static TEEC_Result fs_unlink(TEEC_Session *sess, uint32_t obj)
 static TEEC_Result fs_trunc(TEEC_Session *sess, uint32_t obj, uint32_t len)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.params[0].value.a = obj;
 	op.params[0].value.b = len;
@@ -286,7 +286,7 @@ static TEEC_Result fs_rename(TEEC_Session *sess, uint32_t obj, void *id,
 			     uint32_t id_size)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.params[0].value.a = obj;
 	op.params[1].tmpref.buffer = id;
@@ -301,9 +301,9 @@ static TEEC_Result fs_rename(TEEC_Session *sess, uint32_t obj, void *id,
 
 static TEEC_Result fs_alloc_enum(TEEC_Session *sess, uint32_t *e)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_OUTPUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
@@ -318,9 +318,9 @@ static TEEC_Result fs_alloc_enum(TEEC_Session *sess, uint32_t *e)
 
 static TEEC_Result fs_reset_enum(TEEC_Session *sess, uint32_t e)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
@@ -334,7 +334,7 @@ static TEEC_Result fs_reset_enum(TEEC_Session *sess, uint32_t e)
 static TEEC_Result fs_free_enum(TEEC_Session *sess, uint32_t e)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE, TEEC_NONE,
 					 TEEC_NONE);
@@ -348,7 +348,7 @@ static TEEC_Result fs_start_enum(TEEC_Session *sess, uint32_t e,
 				 uint32_t storage_id)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
@@ -363,7 +363,7 @@ static TEEC_Result fs_next_enum(TEEC_Session *sess, uint32_t e, void *obj_info,
 				size_t info_size, void *id, uint32_t id_size)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE,
 					 TEEC_MEMREF_TEMP_OUTPUT, TEEC_NONE);
@@ -383,7 +383,7 @@ static TEEC_Result fs_restrict_usage(TEEC_Session *sess, uint32_t obj,
 				     uint32_t obj_usage)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.params[0].value.a = obj;
 	op.params[0].value.b = obj_usage;
@@ -398,9 +398,9 @@ static TEEC_Result fs_restrict_usage(TEEC_Session *sess, uint32_t obj,
 static TEEC_Result fs_alloc_obj(TEEC_Session *sess, uint32_t obj_type,
 				     uint32_t max_key_size, uint32_t *obj)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.params[0].value.a = obj_type;
 	op.params[0].value.b = max_key_size;
@@ -416,7 +416,7 @@ static TEEC_Result fs_alloc_obj(TEEC_Session *sess, uint32_t obj_type,
 static TEEC_Result fs_free_obj(TEEC_Session *sess, uint32_t obj)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.params[0].value.a = obj;
 
@@ -429,7 +429,7 @@ static TEEC_Result fs_free_obj(TEEC_Session *sess, uint32_t obj)
 static TEEC_Result fs_reset_obj(TEEC_Session *sess, uint32_t obj)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.params[0].value.a = obj;
 
@@ -443,7 +443,7 @@ static TEEC_Result fs_get_obj_info(TEEC_Session *sess, uint32_t obj,
 				void *obj_info, size_t info_size)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t org;
+	uint32_t org = 0;
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT,
 					TEEC_MEMREF_TEMP_OUTPUT,
@@ -459,11 +459,11 @@ static TEEC_Result fs_get_obj_info(TEEC_Session *sess, uint32_t obj,
 /* trunc */
 static void test_truncate_file_length(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
+	TEEC_Session sess = { };
 	uint32_t obj = 0;
-	uint8_t out[10] = { 0 };
+	uint8_t out[10] = { };
 	uint32_t count = 0;
-	uint32_t orig;
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -499,7 +499,7 @@ static void test_truncate_file_length(ADBG_Case_t *c, uint32_t storage_id)
 		goto exit;
 
 	/* open */
-	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_open(&sess,  file_01, sizeof(file_01),
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_open(&sess, file_01, sizeof(file_01),
 			TEE_DATA_FLAG_ACCESS_WRITE |
 			TEE_DATA_FLAG_ACCESS_READ |
 			TEE_DATA_FLAG_ACCESS_WRITE_META, &obj, storage_id)))
@@ -528,12 +528,12 @@ exit:
 /* extend */
 static void test_extend_file_length(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
+	TEEC_Session sess = { };
 	uint32_t obj = 0;
-	uint8_t out[10] = { 0 };
-	uint8_t expect[10] = { 0 };
+	uint8_t out[10] = { };
+	uint8_t expect[10] = { };
 	uint32_t count = 0;
-	uint32_t orig;
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -571,7 +571,7 @@ static void test_extend_file_length(ADBG_Case_t *c, uint32_t storage_id)
 		goto exit;
 
 	/* open */
-	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_open(&sess,  file_01, sizeof(file_01),
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_open(&sess, file_01, sizeof(file_01),
 			TEE_DATA_FLAG_ACCESS_WRITE |
 			TEE_DATA_FLAG_ACCESS_READ |
 			TEE_DATA_FLAG_ACCESS_WRITE_META, &obj, storage_id)))
@@ -602,12 +602,12 @@ exit:
 /* file hole */
 static void test_file_hole(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
+	TEEC_Session sess = { };
 	uint32_t obj = 0;
-	uint8_t out[10] = { 0 };
-	uint8_t expect[10] = { 0 };
+	uint8_t out[10] = { };
+	uint8_t expect[10] = { };
 	uint32_t count = 0;
-	uint32_t orig;
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -653,7 +653,7 @@ static void test_file_hole(ADBG_Case_t *c, uint32_t storage_id)
 		goto exit;
 
 	/* open */
-	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_open(&sess,  file_01, sizeof(file_01),
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_open(&sess, file_01, sizeof(file_01),
 			TEE_DATA_FLAG_ACCESS_WRITE |
 			TEE_DATA_FLAG_ACCESS_READ |
 			TEE_DATA_FLAG_ACCESS_WRITE_META, &obj, storage_id)))
@@ -686,38 +686,38 @@ exit:
 #ifdef WITH_GP_TESTS
 static TEEC_Result ds_seek_obj_inv_handle(TEEC_Session *sess)
 {
-    TEEC_Operation op;
-    uint32_t org;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t org = 0;
 
-    op.paramTypes = TEEC_PARAM_TYPES(
-        TEEC_VALUE_INPUT, TEEC_NONE, TEEC_NONE, TEEC_NONE);
+	op.paramTypes = TEEC_PARAM_TYPES(
+		TEEC_VALUE_INPUT, TEEC_NONE, TEEC_NONE, TEEC_NONE);
 
-    op.params[0].value.a = CASE_DATA_OBJECT_NOT_PERSISTENT;
+	op.params[0].value.a = CASE_DATA_OBJECT_NOT_PERSISTENT;
 
-    return TEEC_InvokeCommand(
-        sess, CMD_SeekObjectData_panic, &op, &org);
+	return TEEC_InvokeCommand(
+		sess, CMD_SeekObjectData_panic, &op, &org);
 }
 
 static TEEC_Result ds_seek_gp(
-    TEEC_Session *sess, TEE_Whence wh, uint32_t wh_off, uint32_t set_off,
-    void *in, size_t in_size, void *out, size_t out_size)
+	TEEC_Session *sess, TEE_Whence wh, uint32_t wh_off, uint32_t set_off,
+	void *in, size_t in_size, void *out, size_t out_size)
 {
-    TEEC_Operation op;
-    uint32_t org;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t org = 0;
 
-    op.paramTypes = TEEC_PARAM_TYPES(
-        TEEC_VALUE_INPUT, TEEC_VALUE_INPUT, TEEC_MEMREF_TEMP_INPUT,
-        TEEC_MEMREF_TEMP_OUTPUT);
+	op.paramTypes = TEEC_PARAM_TYPES(
+		TEEC_VALUE_INPUT, TEEC_VALUE_INPUT, TEEC_MEMREF_TEMP_INPUT,
+		TEEC_MEMREF_TEMP_OUTPUT);
 
-    op.params[0].value.a = wh;
-    op.params[0].value.b = wh_off;
-    op.params[1].value.a = set_off;
-    op.params[2].tmpref.buffer = in;
-    op.params[2].tmpref.size = in_size;
-    op.params[3].tmpref.buffer = out;
-    op.params[3].tmpref.size = out_size;
+	op.params[0].value.a = wh;
+	op.params[0].value.b = wh_off;
+	op.params[1].value.a = set_off;
+	op.params[2].tmpref.buffer = in;
+	op.params[2].tmpref.size = in_size;
+	op.params[3].tmpref.buffer = out;
+	op.params[3].tmpref.size = out_size;
 
-    return TEEC_InvokeCommand(sess, CMD_SeekWriteReadObjectData, &op, &org);
+	return TEEC_InvokeCommand(sess, CMD_SeekWriteReadObjectData, &op, &org);
 }
 
 static TEEC_Result ds_init_object_and_attributes(TEEC_Session *sess,
@@ -725,88 +725,89 @@ static TEEC_Result ds_init_object_and_attributes(TEEC_Session *sess,
             size_t attr_meta_len, const void *attr_data, size_t attr_data_len,
             uint32_t option)
 {
-    TEEC_Operation op;
-    uint32_t org;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t org = 0;
 
-    op.paramTypes = TEEC_PARAM_TYPES(
-        TEEC_VALUE_INPUT, TEEC_MEMREF_TEMP_INPUT,
-        TEEC_MEMREF_TEMP_INPUT, TEEC_VALUE_INPUT);
+	op.paramTypes = TEEC_PARAM_TYPES(
+		TEEC_VALUE_INPUT, TEEC_MEMREF_TEMP_INPUT,
+		TEEC_MEMREF_TEMP_INPUT, TEEC_VALUE_INPUT);
 
-    op.params[0].value.a = obj_type;
-    op.params[0].value.b = obj_size;
-    op.params[1].tmpref.buffer = (void *)attr_meta;
-    op.params[1].tmpref.size = attr_meta_len;
-    op.params[2].tmpref.buffer = (void *)attr_data;
-    op.params[2].tmpref.size = attr_data_len;
-    op.params[3].value.a = option;
+	op.params[0].value.a = obj_type;
+	op.params[0].value.b = obj_size;
+	op.params[1].tmpref.buffer = (void *)attr_meta;
+	op.params[1].tmpref.size = attr_meta_len;
+	op.params[2].tmpref.buffer = (void *)attr_data;
+	op.params[2].tmpref.size = attr_data_len;
+	op.params[3].value.a = option;
 
-    return TEEC_InvokeCommand(sess, CMD_InitObjectAndAttributes, &op, &org);
+	return TEEC_InvokeCommand(sess, CMD_InitObjectAndAttributes, &op, &org);
 }
 
 static TEEC_Result ds_rename_access_conflict(TEEC_Session *sess)
 {
-    TEEC_Operation op;
-    uint32_t org;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t org = 0;
 
-    op.paramTypes = TEEC_PARAM_TYPES(
-        TEEC_NONE, TEEC_NONE, TEEC_NONE, TEEC_NONE);
+	op.paramTypes = TEEC_PARAM_TYPES(
+		TEEC_NONE, TEEC_NONE, TEEC_NONE, TEEC_NONE);
 
-    return TEEC_InvokeCommand(
-        sess, CMD_RenamePersistentObject_AccessConflict, &op, &org);
+	return TEEC_InvokeCommand(
+		sess, CMD_RenamePersistentObject_AccessConflict, &op, &org);
 }
 
 static TEEC_Result ds_start_enum_no_item(TEEC_Session *sess)
 {
-    TEEC_Operation op;
-    uint32_t org;
-    TEEC_Result res;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t org = 0;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 
-    op.paramTypes = TEEC_PARAM_TYPES(
-        TEEC_VALUE_OUTPUT, TEEC_NONE, TEEC_NONE, TEEC_NONE);
+	op.paramTypes = TEEC_PARAM_TYPES(
+		TEEC_VALUE_OUTPUT, TEEC_NONE, TEEC_NONE, TEEC_NONE);
 
-    res = TEEC_InvokeCommand(
-        sess, CMD_StartNGetPersistentObjectEnumerator_itemNotFound, &op, &org);
+	res = TEEC_InvokeCommand(
+		sess, CMD_StartNGetPersistentObjectEnumerator_itemNotFound,
+		&op, &org);
 
-    if (res != TEEC_SUCCESS)
-        return res;
+	if (res != TEEC_SUCCESS)
+		return res;
 
-    if (op.params[0].value.a != 0 || op.params[0].value.b != 0)
-        return TEEC_ERROR_GENERIC;
+	if (op.params[0].value.a != 0 || op.params[0].value.b != 0)
+		return TEEC_ERROR_GENERIC;
 
-    return res;
+	return res;
 }
 
 static TEEC_Result ds_rename_success(TEEC_Session *sess)
 {
-    TEEC_Operation op;
-    uint32_t org;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t org = 0;
 
-    op.paramTypes = TEEC_PARAM_TYPES(
-        TEEC_NONE, TEEC_NONE, TEEC_NONE, TEEC_NONE);
+	op.paramTypes = TEEC_PARAM_TYPES(
+		TEEC_NONE, TEEC_NONE, TEEC_NONE, TEEC_NONE);
 
-    return TEEC_InvokeCommand(
-        sess, CMD_RenamePersistentObject_Success, &op, &org);
+	return TEEC_InvokeCommand(
+		sess, CMD_RenamePersistentObject_Success, &op, &org);
 }
 
 static TEEC_Result ds_null_close_free_reset(TEEC_Session *sess)
 {
-    TEEC_Operation op;
-    uint32_t org;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t org = 0;
 
-    op.paramTypes = TEEC_PARAM_TYPES(
-        TEEC_NONE, TEEC_NONE, TEEC_NONE, TEEC_NONE);
+	op.paramTypes = TEEC_PARAM_TYPES(
+		TEEC_NONE, TEEC_NONE, TEEC_NONE, TEEC_NONE);
 
-    return TEEC_InvokeCommand(
-        sess, CMD_CloseFreeAndResetObjectSuccessHandleNull, &op, &org);
+	return TEEC_InvokeCommand(
+		sess, CMD_CloseFreeAndResetObjectSuccessHandleNull, &op, &org);
 }
 #endif
 
 /* create */
 static void xtest_tee_test_6001_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
+	TEEC_Session sess = { };
 	uint32_t obj = 0;
-	uint32_t orig;
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -833,9 +834,9 @@ ADBG_CASE_DEFINE(regression, 6001, xtest_tee_test_6001,
 /* open */
 static void xtest_tee_test_6002_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
+	TEEC_Session sess = { };
 	uint32_t obj = 0;
-	uint32_t orig;
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -877,11 +878,11 @@ ADBG_CASE_DEFINE(regression, 6002, xtest_tee_test_6002,
 /* read */
 static void xtest_tee_test_6003_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
+	TEEC_Session sess = { };
 	uint32_t obj = 0;
-	uint8_t out[10] = { 0 };
+	uint8_t out[10] = { };
 	uint32_t count = 0;
-	uint32_t orig;
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -921,11 +922,11 @@ ADBG_CASE_DEFINE(regression, 6003, xtest_tee_test_6003,
 /* write */
 static void xtest_tee_test_6004_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
+	TEEC_Session sess = { };
 	uint32_t obj = 0;
-	uint8_t out[10] = { 0 };
+	uint8_t out[10] = { };
 	uint32_t count = 0;
-	uint32_t orig;
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -980,11 +981,11 @@ ADBG_CASE_DEFINE(regression, 6004, xtest_tee_test_6004,
 /* seek */
 static void xtest_tee_test_6005_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
+	TEEC_Session sess = { };
 	uint32_t obj = 0;
-	uint8_t out[10] = { 0 };
+	uint8_t out[10] = { };
 	uint32_t count = 0;
-	uint32_t orig;
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -1024,9 +1025,9 @@ ADBG_CASE_DEFINE(regression, 6005, xtest_tee_test_6005,
 /* unlink */
 static void xtest_tee_test_6006_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
+	TEEC_Session sess = { };
 	uint32_t obj = 0;
-	uint32_t orig;
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -1076,11 +1077,11 @@ ADBG_CASE_DEFINE(regression, 6007, xtest_tee_test_6007,
 
 static void xtest_tee_test_6008_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
+	TEEC_Session sess = { };
 	uint32_t obj = 0;
-	uint8_t out[10] = { 0 };
+	uint8_t out[10] = { };
 	uint32_t count = 0;
-	uint32_t orig;
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -1141,14 +1142,14 @@ ADBG_CASE_DEFINE(regression, 6008, xtest_tee_test_6008,
 
 static void xtest_tee_test_6009_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
-	uint32_t obj0;
-	uint32_t obj1;
-	uint32_t obj2;
+	TEEC_Session sess = { };
+	uint32_t obj0 = 0;
+	uint32_t obj1 = 0;
+	uint32_t obj2 = 0;
 	uint32_t e = 0;
-	uint8_t info[200];
-	uint8_t id[200];
-	uint32_t orig;
+	uint8_t info[200] = { };
+	uint8_t id[200] = { };
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -1248,15 +1249,15 @@ ADBG_CASE_DEFINE(regression, 6009, xtest_tee_test_6009,
 
 static void xtest_tee_test_6010_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
-	uint32_t orig;
-	uint32_t o1;
-	uint32_t o2;
-	uint32_t e;
-	uint32_t f;
-	uint8_t data[1024];
-	uint8_t out[1024];
-	uint32_t n;
+	TEEC_Session sess = { };
+	uint32_t orig = 0;
+	uint32_t o1 = 0;
+	uint32_t o2 = 0;
+	uint32_t e = 0;
+	uint32_t f = 0;
+	uint8_t data[1024] = { };
+	uint8_t out[1024] = { };
+	uint32_t n = 0;
 
 	for (n = 0; n < ARRAY_SIZE(data); n++)
 		data[n] = n;
@@ -1477,37 +1478,38 @@ ADBG_CASE_DEFINE(regression, 6010, xtest_tee_test_6010, "Test Storage");
 #ifdef WITH_GP_TESTS
 static void xtest_tee_test_6011(ADBG_Case_t *c)
 {
-    TEEC_Session sess;
-    uint32_t orig;
-    /*
-     * Test data from
-     * Invoke_InitObjectAndAttributes_TEE_TYPE_AES_success_attribute_
-     * TEE_ATTR_SECRET_VALUE_correct_size (9d-9a-91)
-     */
-    static const uint8_t attr_meta[] = {
+	TEEC_Session sess = { };
+	uint32_t orig = 0;
+	/*
+	 * Test data from
+	 * Invoke_InitObjectAndAttributes_TEE_TYPE_AES_success_attribute_
+	 * TEE_ATTR_SECRET_VALUE_correct_size (9d-9a-91)
+	 */
+	static const uint8_t attr_meta[] = {
 0xc0,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x20,0x00,0x00,0x00,
 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-    };
-    static const uint8_t attr_data[] = {
+	};
+	static const uint8_t attr_data[] = {
 0x60,0x3d,0xeb,0x10,0x15,0xca,0x71,0xbe,0x2b,0x73,0xae,0xf0,0x85,0x7d,0x77,
 0x81,0x1f,0x35,0x2c,0x07,0x3b,0x61,0x08,0xd7,0x2d,0x98,0x10,0xa3,0x09,0x14,
 0xdf,0xf4,
-    };
+	};
 
-    if (!ADBG_EXPECT_TEEC_SUCCESS(
-            c, xtest_teec_open_session(
-                &sess, &gp_tta_ds_uuid, NULL, &orig)))
-        return;
+	if (!ADBG_EXPECT_TEEC_SUCCESS(
+			c, xtest_teec_open_session(&sess, &gp_tta_ds_uuid,
+					NULL, &orig)))
+		return;
 
-    if (!ADBG_EXPECT_TEEC_SUCCESS(c, ds_init_object_and_attributes(&sess,
-            0xa0000010, 0x100, attr_meta, sizeof(attr_meta), attr_data,
-            sizeof(attr_data), 0)))
-        goto exit;
+	if (!ADBG_EXPECT_TEEC_SUCCESS(
+			c, ds_init_object_and_attributes(&sess, 0xa0000010,
+					0x100, attr_meta, sizeof(attr_meta),
+					attr_data, sizeof(attr_data), 0)))
+		goto exit;
 
 exit:
-    TEEC_CloseSession(&sess);
+	TEEC_CloseSession(&sess);
 }
 ADBG_CASE_DEFINE(regression, 6011, xtest_tee_test_6011,
 		 "Test TEE GP TTA DS init objects");
@@ -1515,8 +1517,8 @@ ADBG_CASE_DEFINE(regression, 6011, xtest_tee_test_6011,
 
 static void xtest_tee_test_6012_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
-	uint32_t orig;
+	TEEC_Session sess = { };
+	uint32_t orig = 0;
 	uint32_t obj = 0;
 
 	/*
@@ -1589,8 +1591,8 @@ ADBG_CASE_DEFINE(regression, 6012, xtest_tee_test_6012,
 
 static void xtest_tee_test_6013_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
-	uint32_t orig;
+	TEEC_Session sess = { };
+	uint32_t orig = 0;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -1613,8 +1615,8 @@ ADBG_CASE_DEFINE(regression, 6013, xtest_tee_test_6013,
 
 static void xtest_tee_test_6014_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
-	uint32_t orig;
+	TEEC_Session sess = { };
+	uint32_t orig = 0;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -1636,11 +1638,11 @@ ADBG_CASE_DEFINE(regression, 6014, xtest_tee_test_6014,
 
 static void xtest_tee_test_6015_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
-	TEEC_Session sess2;
-	uint32_t orig;
+	TEEC_Session sess = { };
+	TEEC_Session sess2 = { };
+	uint32_t orig = 0;
 	uint32_t obj = 0;
-	uint32_t obj2;
+	uint32_t obj2 = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -1688,7 +1690,7 @@ static void *test_6016_thread(void *arg)
 	struct test_6016_thread_arg *a = arg;
 	TEEC_Session sess = a->session;
 	uint32_t obj = 0;
-	uint8_t out[10] = { 0 };
+	uint8_t out[10] = { };
 	uint32_t count = 0;
 
 	/* create */
@@ -1739,23 +1741,20 @@ exit:
 #define NUM_THREADS 4
 static void xtest_tee_test_6016_loop(ADBG_Case_t *c, uint32_t storage_id)
 {
-	size_t num_threads = NUM_THREADS;
-	struct test_6016_thread_arg arg[num_threads];
-	pthread_t thr[num_threads];
-	uint32_t orig;
-	size_t i;
+	struct test_6016_thread_arg arg[NUM_THREADS] = { };
+	uint32_t orig = 0;
+	size_t i = 0;
 	size_t n = 0;
-	size_t m;
+	size_t m = 0;
+	pthread_t thr[NUM_THREADS] = { };
 
-	memset(arg, 0, sizeof(arg));
-
-	for (m = 0; m < num_threads; m++)
+	for (m = 0; m < NUM_THREADS; m++)
 		if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 			xtest_teec_open_session(&arg[m].session,
 				&storage_ta_uuid, NULL, &orig)))
 			goto out;
 
-	for (n = 0; n < num_threads; n++) {
+	for (n = 0; n < NUM_THREADS; n++) {
 		arg[n].case_t = c;
 		arg[n].storage_id = storage_id;
 		snprintf(arg[n].file_name, sizeof(arg[n].file_name),
@@ -1775,7 +1774,7 @@ out:
 /* concurency */
 static void xtest_tee_test_6016_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	int i;
+	int i = 0;
 	int loops = 8;
 
 	Do_ADBG_Log("    threads: %d, loops: %d", NUM_THREADS, loops);
@@ -1787,11 +1786,11 @@ ADBG_CASE_DEFINE(regression, 6016, xtest_tee_test_6016, "Storage concurency");
 
 static void xtest_tee_test_6017_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
-	TEE_ObjectInfo obj_info1;
-	TEE_ObjectInfo obj_info2;
+	TEEC_Session sess = { };
+	TEE_ObjectInfo obj_info1 = { };
+	TEE_ObjectInfo obj_info2 = { };
 	uint32_t obj = 0;
-	uint32_t orig;
+	uint32_t orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&sess, &storage_ta_uuid, NULL, &orig)))
@@ -1842,15 +1841,15 @@ ADBG_CASE_DEFINE(regression, 6017, xtest_tee_test_6017,
 
 static void xtest_tee_test_6018_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
-	TEE_ObjectInfo obj_info1;
-	TEE_ObjectInfo obj_info2;
+	TEEC_Session sess = { };
+	TEE_ObjectInfo obj_info1 = { };
+	TEE_ObjectInfo obj_info2 = { };
 	uint32_t obj = 0;
-	uint32_t orig;
-	uint8_t block[32 * 1024];
-	size_t num_blocks;
-	size_t block_size;
-	size_t n;
+	uint32_t orig = 0;
+	uint8_t block[32 * 1024] = { };
+	size_t num_blocks = 0;
+	size_t block_size = 0;
+	size_t n = 0;
 
 	if (storage_is(storage_id, TEE_STORAGE_PRIVATE_RPMB)) {
 		/* RPMB FS is a bit resource constrained */
@@ -1911,6 +1910,7 @@ static void xtest_tee_test_6018_single(ADBG_Case_t *c, uint32_t storage_id)
 		uint8_t br[block_size];
 		uint32_t count = 0;
 
+		memset(br, 0, sizeof(br));
 		memset(block, n, block_size);
 
 		Do_ADBG_Log("reading %zu", n);
@@ -1933,12 +1933,12 @@ ADBG_CASE_DEFINE(regression, 6018, xtest_tee_test_6018, "Large object");
 
 static void xtest_tee_test_6019_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Session sess;
-	TEEC_Session sess2;
-	uint32_t orig;
+	TEEC_Session sess = { };
+	TEEC_Session sess2 = { };
+	uint32_t orig = 0;
 	uint32_t obj = 0;
 	uint32_t obj2 = 0;
-	uint8_t out[10] = { 0 };
+	uint8_t out[10] = { };
 	uint32_t count = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -2031,8 +2031,8 @@ static TEEC_Result fs_access_with_bad_object_id_ref(TEEC_Session *sess,
 						    uint32_t storage_id)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	TEEC_Result res;
-	uint32_t org;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t org = 0;
 
 	switch (command) {
 	case TA_STORAGE_CMD_OPEN_ID_IN_SHM:
@@ -2101,9 +2101,9 @@ static TEEC_Result fs_access_with_bad_object_id_ref(TEEC_Session *sess,
 
 static void xtest_tee_test_6020_single(ADBG_Case_t *c, uint32_t storage_id)
 {
-	TEEC_Result res;
-	TEEC_Session sess;
-	uint32_t orig;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	TEEC_Session sess = { };
+	uint32_t orig = 0;
 	uint32_t obj = 0;
 
 	/*

--- a/host/xtest/regression_8000.c
+++ b/host/xtest/regression_8000.c
@@ -320,7 +320,7 @@ static const uint8_t pbkdf2_6_dkm[] = {
 #ifdef WITH_HKDF
 static void xtest_test_derivation_hkdf(ADBG_Case_t *c, TEEC_Session *session)
 {
-	size_t n;
+	size_t n = 0;
 #define TEST_HKDF_DATA(section, algo, id, oeb /* omit empty bufs */) \
 	{ \
 		section, algo, \
@@ -365,13 +365,13 @@ static void xtest_test_derivation_hkdf(ADBG_Case_t *c, TEEC_Session *session)
 	size_t max_size = 2048;
 
 	for (n = 0; n < sizeof(hkdf_cases) / sizeof(struct hkdf_case); n++) {
-		TEE_OperationHandle op;
-		TEE_ObjectHandle key_handle;
-		TEE_ObjectHandle sv_handle;
-		TEE_Attribute params[4];
+		TEE_OperationHandle op = TEE_HANDLE_NULL;
+		TEE_ObjectHandle key_handle = TEE_HANDLE_NULL;
+		TEE_ObjectHandle sv_handle = TEE_HANDLE_NULL;
+		TEE_Attribute params[4] = { };
 		size_t param_count = 0;
-		uint8_t out[2048];
-		size_t out_size;
+		uint8_t out[2048] = { };
+		size_t out_size = 0;
 		const struct hkdf_case *hc = &hkdf_cases[n];
 
 		Do_ADBG_BeginSubCase(c, "HKDF RFC 5869 %s", hc->subcase_name);
@@ -457,7 +457,7 @@ static void xtest_test_derivation_hkdf(ADBG_Case_t *c, TEEC_Session *session)
 #ifdef WITH_CONCAT_KDF
 static void xtest_test_derivation_concat_kdf(ADBG_Case_t *c, TEEC_Session *session)
 {
-	size_t n;
+	size_t n = 0;
 #define TEST_CONCAT_KDF_DATA(name, algo, id, oeb /* omit empty bufs */) \
 	{ \
 		name, algo, \
@@ -485,13 +485,13 @@ static void xtest_test_derivation_concat_kdf(ADBG_Case_t *c, TEEC_Session *sessi
 	for (n = 0;
 	     n < sizeof(concat_kdf_cases) / sizeof(struct concat_kdf_case);
 	     n++) {
-		TEE_OperationHandle op;
-		TEE_ObjectHandle key_handle;
-		TEE_ObjectHandle sv_handle;
-		TEE_Attribute params[4];
+		TEE_OperationHandle op = TEE_HANDLE_NULL;
+		TEE_ObjectHandle key_handle = TEE_HANDLE_NULL;
+		TEE_ObjectHandle sv_handle = TEE_HANDLE_NULL;
+		TEE_Attribute params[4] = { };
 		size_t param_count = 0;
-		uint8_t out[2048];
-		size_t out_size;
+		uint8_t out[2048] = { };
+		size_t out_size = 0;
 		const struct concat_kdf_case *cc = &concat_kdf_cases[n];
 
 		Do_ADBG_BeginSubCase(c, "Concat KDF %s", cc->subcase_name);
@@ -576,7 +576,7 @@ out:
 #ifdef WITH_PBKDF2
 static void xtest_test_derivation_pbkdf2(ADBG_Case_t *c, TEEC_Session *session)
 {
-	size_t n;
+	size_t n = 0;
 #define TEST_PBKDF2_DATA(level, section, algo, id, oeb /* omit empty bufs */) \
 	{ \
 		level, section, algo, \
@@ -609,13 +609,13 @@ static void xtest_test_derivation_pbkdf2(ADBG_Case_t *c, TEEC_Session *session)
 	size_t max_size = 2048;
 
 	for (n = 0; n < sizeof(pbkdf2_cases) / sizeof(struct pbkdf2_case); n++) {
-		TEE_OperationHandle op;
-		TEE_ObjectHandle key_handle;
-		TEE_ObjectHandle sv_handle;
-		TEE_Attribute params[4];
+		TEE_OperationHandle op = TEE_HANDLE_NULL;
+		TEE_ObjectHandle key_handle = TEE_HANDLE_NULL;
+		TEE_ObjectHandle sv_handle = TEE_HANDLE_NULL;
+		TEE_Attribute params[4] = { };
 		size_t param_count = 0;
-		uint8_t out[2048];
-		size_t out_size;
+		uint8_t out[2048] = { };
+		size_t out_size = 0;
 		const struct pbkdf2_case *pc = &pbkdf2_cases[n];
 
 		if (pc->level > level)
@@ -684,7 +684,8 @@ static void xtest_test_derivation_pbkdf2(ADBG_Case_t *c, TEEC_Session *session)
 		memset(out, 0, sizeof(out));
 		if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 			ta_crypt_cmd_get_object_buffer_attribute(c, session,
-				sv_handle, TEE_ATTR_SECRET_VALUE, out, &out_size)))
+						sv_handle, TEE_ATTR_SECRET_VALUE,
+						out, &out_size)))
 			goto out;
 
 		if (!ADBG_EXPECT_BUFFER(c, pc->dkm, pc->dkm_len, out, out_size))
@@ -706,19 +707,18 @@ out:
 
 static TEEC_Result enc_fs_km_self_test(TEEC_Session *sess)
 {
-	TEEC_Operation op;
-	TEEC_Result res;
-	uint32_t org;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	uint32_t org = 0;
 
-	memset(&op, 0, sizeof(op));
 	res = TEEC_InvokeCommand(sess, CMD_SELF_TESTS, &op, &org);
 	return res;
 }
 
 static void xtest_tee_test_8001(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
@@ -743,9 +743,9 @@ ADBG_CASE_DEFINE(regression, 8001, xtest_tee_test_8001,
 /* secure storage key manager self test */
 static void xtest_tee_test_8002(ADBG_Case_t *c)
 {
-	TEEC_Result res;
-	TEEC_Session sess;
-	uint32_t orig;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	TEEC_Session sess = { };
+	uint32_t orig = 0;
 
 	res = xtest_teec_open_session(&sess,
 			&enc_fs_key_manager_test_ta_uuid,

--- a/host/xtest/regression_8100.c
+++ b/host/xtest/regression_8100.c
@@ -30,8 +30,8 @@
 static void test_8101(ADBG_Case_t *c __maybe_unused)
 {
 #ifdef CFG_TA_MBEDTLS_SELF_TEST
-	TEEC_Session session = { 0 };
-	uint32_t ret_orig;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c, xtest_teec_open_session(
 					      &session, &crypt_user_ta_uuid,
@@ -77,13 +77,13 @@ out:
 
 static void test_8102(ADBG_Case_t *c)
 {
-	TEEC_Session session = { 0 };
+	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 	char *chain = NULL;
 	int clen = 0;
 	char *trust = NULL;
-	int tlen;
+	int tlen = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c, xtest_teec_open_session(
 					      &session, &crypt_user_ta_uuid,
@@ -124,10 +124,10 @@ ADBG_CASE_DEFINE(regression, 8102, test_8102, "TA mbedTLS test cert chain");
 static void osslerr(void)
 {
 	while (true) {
-		unsigned long e;
-		char b[256];
-		const char *f;
-		int l;
+		unsigned long e = 0;
+		char b[256] = { };
+		const char *f = NULL;
+		int l = 0;
 
 		e = ERR_get_error_line(&f, &l);
 		if (!e)
@@ -142,7 +142,7 @@ static bool get_cert(ADBG_Case_t *c, const char *crt_str, X509 **crt)
 	bool ret = false;
 	size_t slen = strlen(crt_str) + 1;
 	BIO *buf = BIO_new(BIO_s_mem());
-	size_t b;
+	size_t b = 0;
 
 	if (!ADBG_EXPECT_NOT_NULL(c, buf))
 		goto out;
@@ -165,7 +165,7 @@ out:
 static bool push_cert(ADBG_Case_t *c, const char *crt_str, STACK_OF(X509) *cs)
 {
 	X509 *crt = NULL;
-	int rc;
+	int rc = 0;
 
 	if (!get_cert(c, crt_str, &crt))
 		return false;
@@ -186,8 +186,8 @@ static bool check(ADBG_Case_t *c, STACK_OF(X509) *trusted,
 	X509_STORE *store = NULL;
 	X509_STORE_CTX *csc = NULL;
 	X509_VERIFY_PARAM *pm = NULL;
-	int i;
-	time_t vfy_time;
+	int i = 0;
+	time_t vfy_time = 0;
 
 	pm = X509_VERIFY_PARAM_new();
 	vfy_time = 1526898005; /* Mon, 21 May 2018 10:20:05 +0000 */
@@ -267,10 +267,10 @@ static bool verify_cert(ADBG_Case_t *c __unused, const char *ca __unused,
 
 static void test_8103(ADBG_Case_t *c)
 {
-	TEEC_Result res;
-	TEEC_Session session = { 0 };
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 	char *csr = NULL;
 	int clen = 0;
 	char cert[2048];

--- a/host/xtest/sdp_basic.c
+++ b/host/xtest/sdp_basic.c
@@ -39,6 +39,7 @@
 
 #include "crypto_common.h"
 #include "sdp_basic.h"
+#include "xtest_helpers.h"
 #include "xtest_test.h"
 
 #include "include/uapi/linux/ion_old.h"
@@ -83,9 +84,9 @@ struct tee_ctx {
  */
 static int allocate_ion_buffer_old_api(size_t size, int heap_type_id, int ion)
 {
-	struct ion0_allocation_data alloc_data;
-	struct ion0_handle_data hdl_data;
-	struct ion0_fd_data fd_data;
+	struct ion0_allocation_data alloc_data = { };
+	struct ion0_handle_data hdl_data = { };
+	struct ion0_fd_data fd_data = { };
 	int fd = -1;
 
 	alloc_data.len = size;
@@ -111,12 +112,12 @@ static int allocate_ion_buffer_old_api(size_t size, int heap_type_id, int ion)
 
 int allocate_ion_buffer(size_t size, int heap_type_id, int verbosity)
 {
-	struct ion_heap_query query_data;
-	struct ion_heap_data heap_data[32];
-	struct ion_allocation_data alloc_data;
-	int ion;
+	struct ion_heap_query query_data = { };
+	struct ion_heap_data heap_data[32] = { };
+	struct ion_allocation_data alloc_data = { };
+	int ion = 0;
 	int fd = -1;
-	unsigned int idx;
+	unsigned int idx = 0;
 
 	ion = open("/dev/ion", O_RDWR);
 	if (ion < 0) {
@@ -131,7 +132,6 @@ int allocate_ion_buffer(size_t size, int heap_type_id, int verbosity)
 	if (heap_type_id < 0)
 		heap_type_id = DEFAULT_ION_HEAP_TYPE;
 
-	memset(&query_data, 0, sizeof(query_data));
 	if (ioctl(ion, ION_IOC_HEAP_QUERY, &query_data) < 0) {
 		fprintf(stderr, "Error: failed to query the number of heaps\n");
 		goto out;
@@ -182,9 +182,9 @@ static void finalize_tee_ctx(struct tee_ctx *ctx)
 
 static int create_tee_ctx(struct tee_ctx *ctx, enum test_target_ta target_ta)
 {
-	TEEC_Result teerc;
-	const TEEC_UUID *uuid;
-	uint32_t err_origin;
+	TEEC_Result teerc = TEEC_ERROR_GENERIC;
+	const TEEC_UUID *uuid = NULL;
+	uint32_t err_origin = 0;
 
 	switch (target_ta) {
 	case TEST_NS_TO_TA:
@@ -217,10 +217,9 @@ static int create_tee_ctx(struct tee_ctx *ctx, enum test_target_ta target_ta)
 
 static int tee_register_buffer(struct tee_ctx *ctx, void **shm_ref, int fd)
 {
-	TEEC_Result teerc;
-	TEEC_SharedMemory *shm;
+	TEEC_Result teerc = TEEC_ERROR_GENERIC;
+	TEEC_SharedMemory *shm = malloc(sizeof(*shm));
 
-	shm = malloc(sizeof(*shm));
 	if (!shm)
 		return 1;
 
@@ -251,10 +250,10 @@ static int inject_sdp_data(struct tee_ctx *ctx,
 		    void *in, size_t offset, size_t len, void *shm_ref, int ind)
 {
 	TEEC_SharedMemory *shm = (TEEC_SharedMemory *)shm_ref;
-	TEEC_Result teerc;
-	TEEC_Operation op;
-	uint32_t err_origin;
-	unsigned cmd;
+	TEEC_Result teerc = TEEC_ERROR_GENERIC;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t err_origin = 0;
+	unsigned int cmd = 0;
 
 	switch (ind) {
 	case TEST_NS_TO_TA:
@@ -273,7 +272,6 @@ static int inject_sdp_data(struct tee_ctx *ctx,
 		return -1;
 	}
 
-	memset(&op, 0, sizeof(op));
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
 					 TEEC_MEMREF_PARTIAL_OUTPUT,
 					 TEEC_NONE, TEEC_NONE);
@@ -297,10 +295,10 @@ static int transform_sdp_data(struct tee_ctx *ctx,
 			size_t offset, size_t len, void *shm_ref, int ind)
 {
 	TEEC_SharedMemory *shm = (TEEC_SharedMemory *)shm_ref;
-	TEEC_Result teerc;
-	TEEC_Operation op;
-	uint32_t err_origin;
-	unsigned cmd;
+	TEEC_Result teerc = TEEC_ERROR_GENERIC;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t err_origin = 0;
+	unsigned int cmd = 0;
 
 	switch (ind) {
 	case TEST_NS_TO_TA:
@@ -319,7 +317,6 @@ static int transform_sdp_data(struct tee_ctx *ctx,
 		return -1;
 	}
 
-	memset(&op, 0, sizeof(op));
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_PARTIAL_INOUT,
 					 TEEC_NONE, TEEC_NONE, TEEC_NONE);
 	op.params[0].memref.parent = shm;
@@ -338,10 +335,10 @@ static int dump_sdp_data(struct tee_ctx *ctx,
 		  void *out, size_t offset, size_t len, void *shm_ref, int ind)
 {
 	TEEC_SharedMemory *shm = (TEEC_SharedMemory *)shm_ref;
-	TEEC_Result teerc;
-	TEEC_Operation op;
-	uint32_t err_origin;
-	unsigned cmd;
+	TEEC_Result teerc = TEEC_ERROR_GENERIC;
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t err_origin = 0;
+	unsigned int cmd = 0;
 
 	switch (ind) {
 	case TEST_NS_TO_TA:
@@ -360,7 +357,6 @@ static int dump_sdp_data(struct tee_ctx *ctx,
 		return -1;
 	}
 
-	memset(&op, 0, sizeof(op));
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_PARTIAL_INPUT,
 					 TEEC_MEMREF_TEMP_OUTPUT,
 					 TEEC_NONE, TEEC_NONE);
@@ -404,11 +400,11 @@ static int get_random_bytes(char *out, size_t len)
 {
 	static char *rand_buf = NULL;
 	static size_t rand_idx = 0;
-	int rc;
+	int rc = 0;
 
 	if (!rand_buf) {
 		const char rand_dev[] = "/dev/urandom";
-		int fd;
+		int fd = 0;
 
 		rand_buf = malloc(RANDOM_BUFFER_SIZE);
 		if (!rand_buf) {
@@ -462,8 +458,8 @@ int sdp_basic_test(enum test_target_ta ta, size_t size, size_t loop,
 	unsigned int err = 1;
 	int fd = -1;
 	size_t sdp_size = size;
-	size_t offset;
-	size_t loop_cnt;
+	size_t offset = 0;
+	size_t loop_cnt = 0;
 
 	if (!loop) {
 		fprintf(stderr, "Error: null loop value\n");
@@ -588,8 +584,8 @@ int sdp_basic_runner_cmd_parser(int argc, char *argv[])
 	int ion_heap = DEFAULT_ION_HEAP_TYPE;
 	int rnd_offset = 1;
 	int verbosity = 1;
-	int err;
-	int i;
+	int err = 0;
+	int i = 0;
 
 	/* Parse command line */
 	for (i = 1; i < argc; i++) {

--- a/host/xtest/sock_server.c
+++ b/host/xtest/sock_server.c
@@ -46,7 +46,7 @@ static bool server_io_cb(struct server_state *srvst, size_t idx)
 	short revents = srvst->fds[idx].revents;
 	short *events = &srvst->fds[idx].events;
 	struct sock_io_cb *cb = srvst->cb;
-	int fd;
+	int fd = 0;
 
 	fd = srvst->fds[idx].fd;
 	if (revents & POLLIN) {
@@ -79,8 +79,8 @@ static bool server_add_state(struct server_state *srvst,
 			     struct sock_server_bind *serv, int fd,
 			     short poll_events)
 {
-	void *p;
-	size_t n;
+	void *p = NULL;
+	size_t n = 0;
 
 	for (n = 0; n < srvst->nfds; n++) {
 		if (srvst->fds[n].fd == -1) {
@@ -115,10 +115,10 @@ static bool server_add_state(struct server_state *srvst,
 static bool tcp_server_accept_cb(struct server_state *srvst, size_t idx)
 {
 	short revents = srvst->fds[idx].revents;
-	struct sockaddr_storage sass;
+	struct sockaddr_storage sass = { };
 	struct sockaddr *sa = (struct sockaddr *)&sass;
 	socklen_t len = sizeof(sass);
-	int fd;
+	int fd = 0;
 	short io_events = POLLIN | POLLOUT;
 
 	if (!(revents & POLLIN))
@@ -164,9 +164,9 @@ static void sock_server(struct sock_server *ts,
 			bool (*cb)(struct server_state *srvst, size_t idx))
 {
 	struct server_state srvst = { .cb = ts->cb };
-	int pres;
-	size_t n;
-	char b;
+	int pres = 0;
+	size_t n = 0;
+	char b = 0;
 
 	sock_server_lock(ts);
 
@@ -237,16 +237,14 @@ static void *sock_server_dgram(void *arg)
 
 static void sock_server_add_fd(struct sock_server *ts, struct addrinfo *ai)
 {
-	struct sock_server_bind serv;
-	struct sockaddr_storage sass;
+	struct sock_server_bind serv = { };
+	struct sockaddr_storage sass = { };
 	struct sockaddr *sa = (struct sockaddr *)&sass;
 	struct sockaddr_in *sain = (struct sockaddr_in *)&sass;
 	struct sockaddr_in6 *sain6 = (struct sockaddr_in6 *)&sass;
-	void *src;
+	void *src = NULL;
 	socklen_t len = sizeof(sass);
-	struct sock_server_bind *p;
-
-	memset(&serv, 0, sizeof(serv));
+	struct sock_server_bind *p = NULL;
 
 	serv.fd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
 	if (serv.fd < 0)
@@ -291,8 +289,8 @@ bad:
 
 void sock_server_uninit(struct sock_server *ts)
 {
-	size_t n;
-	int e;
+	size_t n = 0;
+	int e = 0;
 
 	if (ts->stop_fd != -1) {
 		if (close(ts->stop_fd))
@@ -323,11 +321,11 @@ void sock_server_uninit(struct sock_server *ts)
 static bool sock_server_init(struct sock_server *ts, struct sock_io_cb *cb,
 			     int socktype)
 {
-	struct addrinfo hints;
-	struct addrinfo *ai;
-	struct addrinfo *ai0;
-	int fd_pair[2];
-	int e;
+	struct addrinfo hints = { };
+	struct addrinfo *ai = NULL;
+	struct addrinfo *ai0 = NULL;
+	int fd_pair[2] = { };
+	int e = 0;
 
 	memset(ts, 0, sizeof(*ts));
 	ts->quit_fd = -1;
@@ -339,8 +337,6 @@ static bool sock_server_init(struct sock_server *ts, struct sock_io_cb *cb,
 		warnx("sock_server_init: pthread_mutex_init: %s", strerror(e));
 		return false;
 	}
-
-	memset(&hints, 0, sizeof(hints));
 
 	hints.ai_flags = AI_PASSIVE;
 	hints.ai_family = AF_UNSPEC;

--- a/host/xtest/stats.c
+++ b/host/xtest/stats.c
@@ -82,18 +82,17 @@ static int close_sess(TEEC_Context *ctx, TEEC_Session *sess)
 
 static int stat_pager(int argc, char *argv[] __unused)
 {
-	TEEC_Context ctx;
-	TEEC_Session sess;
+	TEEC_Context ctx = { };
+	TEEC_Session sess = { };
 	TEEC_Result res = TEEC_ERROR_GENERIC;
 	uint32_t eo = 0;
-	TEEC_Operation op;
+	TEEC_Operation op = { };
 
 	if (argc != 1)
 		return usage();
 
 	open_sess(&ctx, &sess);
 
-	memset(&op, 0, sizeof(op));
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_OUTPUT, TEEC_VALUE_OUTPUT,
 					 TEEC_VALUE_OUTPUT, TEEC_NONE);
 
@@ -116,11 +115,11 @@ static int stat_pager(int argc, char *argv[] __unused)
 
 static int stat_alloc(int argc, char *argv[] __unused)
 {
-	TEEC_Context ctx;
-	TEEC_Session sess;
+	TEEC_Context ctx = { };
+	TEEC_Session sess = { };
 	TEEC_Result res = TEEC_ERROR_GENERIC;
 	uint32_t eo = 0;
-	TEEC_Operation op;
+	TEEC_Operation op = { };
 	struct malloc_stats *stats = NULL;
 	size_t stats_size_bytes = 0;
 	size_t n = 0;
@@ -129,8 +128,6 @@ static int stat_alloc(int argc, char *argv[] __unused)
 		return usage();
 
 	open_sess(&ctx, &sess);
-
-	memset(&op, 0, sizeof(op));
 
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT,
 					 TEEC_MEMREF_TEMP_OUTPUT,
@@ -190,8 +187,8 @@ static int stat_alloc(int argc, char *argv[] __unused)
 
 static int stat_memleak(int argc, char *argv[] __unused)
 {
-	TEEC_Context ctx;
-	TEEC_Session sess;
+	TEEC_Context ctx = { };
+	TEEC_Session sess = { };
 	TEEC_Result res = TEEC_ERROR_GENERIC;
 	uint32_t eo = 0;
 

--- a/host/xtest/xml/include/xml_datastorage_api.h
+++ b/host/xtest/xml/include/xml_datastorage_api.h
@@ -395,7 +395,7 @@ static uint8_t TEE_ATTR_DH_PUBLIC_VALUE_VALUE01[] = {
 	0x39, 0xf7, 0x4b, 0x01,
 };
 
-static uint8_t TEE_ATTR_DH_SUBPRIME_VALUE01[] = { 0 };
+static uint8_t TEE_ATTR_DH_SUBPRIME_VALUE01[] = { };
 /* static uint8_t *TEE_ATTR_DH_SUBPRIME_VALUE01=NULL; */
 
 static uint8_t TEE_ATTR_HMAC_MD5_256_VALUE01[] = {

--- a/host/xtest/xml/include/xml_timearithm_api.h
+++ b/host/xtest/xml/include/xml_timearithm_api.h
@@ -556,11 +556,9 @@ static TEEC_Result Invoke_BigIntShiftRight(
 
 	res = TEEC_InvokeCommand(sess, cmdId, &op, &org);
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM02->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM02->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
-
-	memset(tmp1, 0, SHARE_MEM02->size);
 
 	if (!BN_bin2bn(SHARE_MEM01->buffer, SHARE_MEM01->size, a))
 		goto exit;
@@ -653,11 +651,9 @@ static TEEC_Result Invoke_BigIntDiv_Remain(
 
 	res = TEEC_InvokeCommand(sess, cmdId, &op, &org);
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
-
-	memset(tmp1, 0, SHARE_MEM03->size);
 
 	if (!BN_bin2bn((uint8_t *)(SHARE_MEM01->buffer), SHARE_MEM01->size,
 		       a))
@@ -735,11 +731,9 @@ static TEEC_Result Invoke_BigIntDiv_Quotient(
 
 	res = TEEC_InvokeCommand(sess, cmdId, &op, &org);
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)caalloc(SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
-
-	memset(tmp1, 0, SHARE_MEM03->size);
 
 	if (!BN_bin2bn((uint8_t *)(SHARE_MEM01->buffer), SHARE_MEM01->size,
 		       a))
@@ -817,11 +811,9 @@ static TEEC_Result Invoke_BigIntAdd(
 
 	res = TEEC_InvokeCommand(sess, cmdId, &op, &org);
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)caalloc(SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
-
-	memset(tmp1, 0, SHARE_MEM03->size);
 
 	if (!BN_bin2bn((uint8_t *)(SHARE_MEM01->buffer), SHARE_MEM01->size,
 		       a))
@@ -985,11 +977,9 @@ static TEEC_Result Invoke_BigIntAddMod(
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
-
-	memset(tmp1, 0, SHARE_MEM03->size);
 
 	if (!BN_bin2bn((uint8_t *)(SHARE_MEM01->buffer), SHARE_MEM01->size,
 		       a))
@@ -1070,11 +1060,9 @@ static TEEC_Result Invoke_BigIntSubMod(
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
-
-	memset(tmp1, 0, SHARE_MEM03->size);
 
 	if (!BN_bin2bn((uint8_t *)(SHARE_MEM01->buffer), SHARE_MEM01->size,
 		       a))
@@ -1192,11 +1180,9 @@ static TEEC_Result Invoke_BigIntMulMod(
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
-
-	memset(tmp1, 0, SHARE_MEM03->size);
 
 	if (!BN_bin2bn((uint8_t *)(SHARE_MEM01->buffer), SHARE_MEM01->size,
 		       a))
@@ -1368,11 +1354,9 @@ static TEEC_Result Invoke_BigIntSub(
 
 	res = TEEC_InvokeCommand(sess, cmdId, &op, &org);
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
-
-	memset(tmp1, 0, SHARE_MEM03->size);
 
 	if (!BN_bin2bn((uint8_t *)(SHARE_MEM01->buffer), SHARE_MEM01->size,
 		       a))
@@ -1440,17 +1424,13 @@ static TEEC_Result Invoke_BigIntNeg(
 
 	res = TEEC_InvokeCommand(sess, cmdId, &op, &org);
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
 
-	memset(tmp1, 0, SHARE_MEM03->size);
-
-	tmp2 = (uint8_t *)malloc(SHARE_MEM01->size);
+	tmp2 = (uint8_t *)calloc(1, SHARE_MEM01->size);
 	if (tmp2 == NULL)
 		goto tmp2_exit;
-	memset(tmp2, 0, SHARE_MEM01->size);
-
 
 	if (!BN_bin2bn((uint8_t *)(SHARE_MEM01->buffer), SHARE_MEM01->size,
 		       a))
@@ -1607,11 +1587,9 @@ static TEEC_Result Invoke_BigIntMul(
 
 	res = TEEC_InvokeCommand(sess, cmdId, &op, &org);
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
-
-	memset(tmp1, 0, SHARE_MEM03->size);
 
 	if (!BN_bin2bn((uint8_t *)(SHARE_MEM01->buffer), SHARE_MEM01->size,
 		       a))
@@ -1688,17 +1666,14 @@ static TEEC_Result Invoke_BigIntInvMod(
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
 
-	memset(tmp1, 0, SHARE_MEM03->size);
-
-	tmp2 = (uint8_t *)malloc(SHARE_MEM01->size);
+	tmp2 = (uint8_t *)calloc(1, SHARE_MEM01->size);
 	if (tmp2 == NULL)
 		goto tmp2_exit;
 
-	memset(tmp2, 0, SHARE_MEM01->size);
 	tmp2[0] = 1;
 
 	if (!BN_bin2bn((uint8_t *)(SHARE_MEM01->buffer), SHARE_MEM01->size,
@@ -1775,11 +1750,9 @@ static TEEC_Result Invoke_BigIntSquare(
 
 	res = TEEC_InvokeCommand(sess, cmdId, &op, &org);
 
-	tmp1 = (uint8_t *)malloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
-
-	memset(tmp1, 0, SHARE_MEM03->size);
 
 	if (!BN_bin2bn((uint8_t *)(SHARE_MEM01->buffer), SHARE_MEM01->size,
 		       a))

--- a/host/xtest/xtest_helpers.c
+++ b/host/xtest/xtest_helpers.c
@@ -51,9 +51,9 @@ TEEC_Result ta_crypt_cmd_allocate_operation(ADBG_Case_t *c, TEEC_Session *s,
 					    uint32_t algo, uint32_t mode,
 					    uint32_t max_key_size)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = 0;
 	op.params[0].value.b = algo;
@@ -83,9 +83,9 @@ TEEC_Result ta_crypt_cmd_allocate_transient_object(ADBG_Case_t *c,
 						   uint32_t max_obj_size,
 						   TEE_ObjectHandle *o)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = obj_type;
 	op.params[0].value.b = max_obj_size;
@@ -134,10 +134,10 @@ struct tee_attr_packed {
 TEE_Result pack_attrs(const TEE_Attribute *attrs, uint32_t attr_count,
 		      uint8_t **buf, size_t *blen)
 {
-	struct tee_attr_packed *a;
-	uint8_t *b;
-	size_t bl;
-	size_t n;
+	struct tee_attr_packed *a = NULL;
+	uint8_t *b = NULL;
+	size_t bl = 0;
+	size_t n = 0;
 
 	*buf = NULL;
 	*blen = 0;
@@ -202,11 +202,11 @@ TEEC_Result ta_crypt_cmd_populate_transient_object(ADBG_Case_t *c,
 						   const TEE_Attribute *attrs,
 						   uint32_t attr_count)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
-	uint8_t *buf;
-	size_t blen;
+	uint32_t ret_orig = 0;
+	uint8_t *buf = NULL;
+	size_t blen = 0;
 
 	res = pack_attrs(attrs, attr_count, &buf, &blen);
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c, res))
@@ -238,9 +238,9 @@ TEE_Result ta_crypt_cmd_set_operation_key(ADBG_Case_t *c, TEEC_Session *s,
 					  TEE_OperationHandle oph,
 					  TEE_ObjectHandle key)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)oph <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
@@ -265,9 +265,9 @@ TEE_Result ta_crypt_cmd_set_operation_key(ADBG_Case_t *c, TEEC_Session *s,
 TEEC_Result ta_crypt_cmd_free_transient_object(ADBG_Case_t *c, TEEC_Session *s,
 					       TEE_ObjectHandle o)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)o <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)o;
@@ -290,11 +290,11 @@ TEEC_Result ta_crypt_cmd_derive_key(ADBG_Case_t *c, TEEC_Session *s,
 				    const TEE_Attribute *params,
 				    uint32_t paramCount)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
-	uint8_t *buf;
-	size_t blen;
+	uint32_t ret_orig = 0;
+	uint8_t *buf = NULL;
+	size_t blen = 0;
 
 	res = pack_attrs(params, paramCount, &buf, &blen);
 
@@ -331,9 +331,9 @@ TEEC_Result ta_crypt_cmd_get_object_buffer_attribute(ADBG_Case_t *c,
 						     uint32_t attr_id,
 						     void *buf, size_t *blen)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	assert((uintptr_t)o <= UINT32_MAX);
 	op.params[0].value.a = (uint32_t)(uintptr_t)o;
@@ -363,9 +363,9 @@ TEEC_Result ta_crypt_cmd_get_object_buffer_attribute(ADBG_Case_t *c,
 TEEC_Result ta_crypt_cmd_free_operation(ADBG_Case_t *c, TEEC_Session *s,
 					TEE_OperationHandle oph)
 {
-	TEEC_Result res;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	op.params[0].value.a = (uint32_t)(uintptr_t)oph;
 

--- a/host/xtest/xtest_helpers.h
+++ b/host/xtest/xtest_helpers.h
@@ -40,7 +40,7 @@ TEEC_Result xtest_teec_open_static_session(TEEC_Session *session,
 					   TEEC_Operation *op,
 					   uint32_t *ret_orig);
 
-#define TEEC_OPERATION_INITIALIZER { 0 }
+#define TEEC_OPERATION_INITIALIZER	{ }
 
 /* IO access macro */
 #define  IO(addr)  (*((volatile unsigned long *)(addr)))

--- a/host/xtest/xtest_main.c
+++ b/host/xtest/xtest_main.c
@@ -95,15 +95,17 @@ static void init_ossl(void)
 
 int main(int argc, char *argv[])
 {
-	int opt;
-	int index;
-	TEEC_Result tee_res;
-	int ret;
+	int opt = 0;
+	int index = 0;
+	TEEC_Result tee_res = TEEC_ERROR_GENERIC;
+	int ret = 0;
 	char *p = (char *)glevel;
 	char *test_suite = (char *)gsuitename;
-	char *token;
-	ADBG_Suite_Definition_t all = { .SuiteID_p = NULL,
-				.cases = TAILQ_HEAD_INITIALIZER(all.cases), };
+	char *token = NULL;
+	ADBG_Suite_Definition_t all = {
+		.SuiteID_p = NULL,
+		.cases = TAILQ_HEAD_INITIALIZER(all.cases),
+	};
 
 	opterr = 0;
 


### PR DESCRIPTION
This change initializes all local variables to prevent build issues
(warnings and/or errors) in OP-TEE test package. It uses memset()
to initialize structured and typed variables.

This change replaces all TEEC_Session instance initialization from
= { 0 } into use of memset().

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>