### PR TITLE
TAs: explicitly initialize local variables

### DIFF
--- a/ta/aes_perf/ta_aes_perf.c
+++ b/ta/aes_perf/ta_aes_perf.c
@@ -52,7 +52,7 @@ static uint32_t algo;
 
 static bool is_inbuf_a_secure_memref(TEE_Param *param)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	/*
 	 * Check secure attribute for the referenced buffer
@@ -69,7 +69,7 @@ static bool is_inbuf_a_secure_memref(TEE_Param *param)
 
 static bool is_outbuf_a_secure_memref(TEE_Param *param)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	/*
 	 * Check secure attribute for the referenced buffer
@@ -87,7 +87,7 @@ static bool is_outbuf_a_secure_memref(TEE_Param *param)
 #if defined(CFG_CACHE_API)
 static TEE_Result flush_memref_buffer(TEE_Param *param)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	res = TEE_CacheFlush(param->memref.buffer,
 			     param->memref.size);
@@ -105,20 +105,21 @@ TEE_Result cmd_process(uint32_t param_types,
 		       TEE_Param params[TEE_NUM_PARAMS],
 		       bool use_sdp)
 {
-	TEE_Result res;
-	int n;
-	int unit;
-	void *in, *out;
-	uint32_t insz;
-	uint32_t outsz;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	int n = 0;
+	int unit = 0;
+	void *in = NULL;
+	void *out = NULL;
+	uint32_t insz = 0;
+	uint32_t outsz = 0;
 	uint32_t exp_param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
 						   TEE_PARAM_TYPE_MEMREF_INOUT,
 						   TEE_PARAM_TYPE_VALUE_INPUT,
 						   TEE_PARAM_TYPE_NONE);
-	bool secure_in;
+	bool secure_in = false;
 	bool secure_out = false;
 	TEE_Result (*do_update)(TEE_OperationHandle, const void *, uint32_t,
-				void *, uint32_t *);
+				void *, uint32_t *) = NULL;
 
 	if (param_types != exp_param_types)
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -165,7 +166,7 @@ TEE_Result cmd_process(uint32_t param_types,
 		do_update = TEE_CipherUpdate;
 
 	while (n--) {
-		uint32_t i;
+		uint32_t i = 0;
 		for (i = 0; i < insz / unit; i++) {
 			res = do_update(crypto_op, in, unit, out, &outsz);
 			CHECK(res, "TEE_CipherUpdate/TEE_AEUpdate", return res;);
@@ -189,15 +190,15 @@ TEE_Result cmd_process(uint32_t param_types,
 
 TEE_Result cmd_prepare_key(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
-	TEE_ObjectHandle hkey;
-	TEE_ObjectHandle hkey2;
-	TEE_Attribute attr;
-	uint32_t mode;
-	uint32_t op_keysize;
-	uint32_t keysize;
-	const uint8_t *ivp;
-	size_t ivlen;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_ObjectHandle hkey = TEE_HANDLE_NULL;
+	TEE_ObjectHandle hkey2 = TEE_HANDLE_NULL;
+	TEE_Attribute attr = { };
+	uint32_t mode = 0;
+	uint32_t op_keysize = 0;
+	uint32_t keysize = 0;
+	const uint8_t *ivp = NULL;
+	size_t ivlen = 0;
 	static uint8_t aes_key[] = { 0x00, 0x01, 0x02, 0x03,
 				     0x04, 0x05, 0x06, 0x07,
 				     0x08, 0x09, 0x0A, 0x0B,
@@ -214,11 +215,11 @@ TEE_Result cmd_prepare_key(uint32_t param_types, TEE_Param params[4])
 				      0x34, 0x35, 0x36, 0x37,
 				      0x38, 0x39, 0x3A, 0x3B,
 				      0x3C, 0x3D, 0x3E, 0x3F };
-
 	uint32_t exp_param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 						   TEE_PARAM_TYPE_VALUE_INPUT,
 						   TEE_PARAM_TYPE_NONE,
 						   TEE_PARAM_TYPE_NONE);
+
 	if (param_types != exp_param_types)
 		return TEE_ERROR_BAD_PARAMETERS;
 

--- a/ta/concurrent/ta_entry.c
+++ b/ta/concurrent/ta_entry.c
@@ -66,10 +66,9 @@ static uint32_t dec_active_count(struct ta_concurrent_shm *shm)
 	return atomic_dec32(&shm->active_count);
 }
 
-
 static TEE_Result ta_entry_busy_loop(uint32_t param_types, TEE_Param params[4])
 {
-	size_t num_rounds;
+	size_t num_rounds = 0;
 	uint32_t req_param_types =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
 				TEE_PARAM_TYPE_VALUE_INOUT,
@@ -102,11 +101,11 @@ static TEE_Result ta_entry_busy_loop(uint32_t param_types, TEE_Param params[4])
 
 static TEE_Result ta_entry_sha256(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEE_OperationHandle op = TEE_HANDLE_NULL;
-	void *out;
-	uint32_t out_len;
-	size_t num_rounds;
+	void *out = NULL;
+	uint32_t out_len = 0;
+	size_t num_rounds = 0;
 	uint32_t req_param_types =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
 				TEE_PARAM_TYPE_VALUE_INOUT,

--- a/ta/concurrent_large/ta_entry.c
+++ b/ta/concurrent_large/ta_entry.c
@@ -66,10 +66,9 @@ static uint32_t dec_active_count(struct ta_concurrent_shm *shm)
 	return atomic_dec32(&shm->active_count);
 }
 
-
 static TEE_Result ta_entry_busy_loop(uint32_t param_types, TEE_Param params[4])
 {
-	size_t num_rounds;
+	size_t num_rounds = 0;
 	uint32_t req_param_types =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
 				TEE_PARAM_TYPE_VALUE_INOUT,
@@ -102,11 +101,11 @@ static TEE_Result ta_entry_busy_loop(uint32_t param_types, TEE_Param params[4])
 
 static TEE_Result ta_entry_sha256(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEE_OperationHandle op = TEE_HANDLE_NULL;
-	void *out;
-	uint32_t out_len;
-	size_t num_rounds;
+	void *out = NULL;
+	uint32_t out_len = 0;
+	size_t num_rounds = 0;
 	uint32_t req_param_types =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
 				TEE_PARAM_TYPE_VALUE_INOUT,

--- a/ta/crypt/aes_impl.c
+++ b/ta/crypt/aes_impl.c
@@ -727,7 +727,7 @@ static const u32 rcon[] = {
 int rijndaelSetupEncrypt(u32 *rk, const u8 *key, int keybits)
 {
 	int i = 0;
-	u32 temp;
+	u32 temp = 0;
 
 	rk[0] = GETU32(key);
 	rk[1] = GETU32(key + 4);
@@ -806,8 +806,10 @@ int rijndaelSetupEncrypt(u32 *rk, const u8 *key, int keybits)
  */
 int rijndaelSetupDecrypt(u32 *rk, const u8 *key, int keybits)
 {
-	int nrounds, i, j;
-	u32 temp;
+	int nrounds = 0;
+	int i = 0;
+	int j = 0;
+	u32 temp = 0;
 
 /* expand the cipher key: */
 	nrounds = rijndaelSetupEncrypt(rk, key, keybits);
@@ -857,9 +859,16 @@ int rijndaelSetupDecrypt(u32 *rk, const u8 *key, int keybits)
 void rijndaelEncrypt(const u32 *rk, int nrounds, const u8 plaintext[16],
 		     u8 ciphertext[16])
 {
-	u32 s0, s1, s2, s3, t0, t1, t2, t3;
+	u32 s0 = 0;
+	u32 s1 = 0;
+	u32 s2 = 0;
+	u32 s3 = 0;
+	u32 t0 = 0;
+	u32 t1 = 0;
+	u32 t2 = 0;
+	u32 t3 = 0;
 #ifndef FULL_UNROLL
-	int r;
+	int r = 0;
 #endif /* ?FULL_UNROLL */
 /*
  * map byte array block to cipher state
@@ -1056,9 +1065,16 @@ void rijndaelEncrypt(const u32 *rk, int nrounds, const u8 plaintext[16],
 void rijndaelDecrypt(const u32 *rk, int nrounds, const u8 ciphertext[16],
 		     u8 plaintext[16])
 {
-	u32 s0, s1, s2, s3, t0, t1, t2, t3;
+	u32 s0 = 0;
+	u32 s1 = 0;
+	u32 s2 = 0;
+	u32 s3 = 0;
+	u32 t0 = 0;
+	u32 t1 = 0;
+	u32 t2 = 0;
+	u32 t3 = 0;
 #ifndef FULL_UNROLL
-	int r;
+	int r = 0;
 #endif /* ?FULL_UNROLL */
 
 /*

--- a/ta/crypt/aes_taf.c
+++ b/ta/crypt/aes_taf.c
@@ -41,13 +41,13 @@ unsigned long rk[RKLENGTH(AES_256)];
 
 TEE_Result ta_entry_aes256ecb_encrypt(uint32_t param_types, TEE_Param params[4])
 {
-	size_t n_input_blocks;
-	size_t i;
+	size_t n_input_blocks = 0;
+	size_t i = 0;
 
-/*
- * It is expected that memRef[0] is input buffer and memRef[1] is
- * output buffer.
- */
+	/*
+	 * It is expected that memRef[0] is input buffer and memRef[1] is
+	 * output buffer.
+	 */
 	if (param_types !=
 	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 			    TEE_PARAM_TYPE_MEMREF_OUTPUT, TEE_PARAM_TYPE_NONE,
@@ -55,15 +55,15 @@ TEE_Result ta_entry_aes256ecb_encrypt(uint32_t param_types, TEE_Param params[4])
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-/* Check that input buffer is whole mult. of block size, in bits */
+	/* Check that input buffer is whole mult. of block size, in bits */
 	if ((params[0].memref.size << 8) % AES_BLOCK_SIZE != 0)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-/* Check that output buffer is whole mult. of block size, in bits */
+	/* Check that output buffer is whole mult. of block size, in bits */
 	if ((params[1].memref.size << 8) % AES_BLOCK_SIZE != 0)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-/* Set up for encryption */
+	/* Set up for encryption */
 	(void)rijndaelSetupEncrypt(rk, key, AES_256);
 
 	n_input_blocks = params[0].memref.size / (AES_BLOCK_SIZE / 8);
@@ -82,13 +82,13 @@ TEE_Result ta_entry_aes256ecb_encrypt(uint32_t param_types, TEE_Param params[4])
 
 TEE_Result ta_entry_aes256ecb_decrypt(uint32_t param_types, TEE_Param params[4])
 {
-	size_t n_input_blocks;
-	size_t i;
+	size_t n_input_blocks = 0;
+	size_t i = 0;
 
-/*
- * It is expected that memRef[0] is input buffer and memRef[1] is
- * output buffer.
- */
+	/*
+	 * It is expected that memRef[0] is input buffer and memRef[1] is
+	 * output buffer.
+	 */
 	if (param_types !=
 	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 			    TEE_PARAM_TYPE_MEMREF_OUTPUT, TEE_PARAM_TYPE_NONE,
@@ -96,15 +96,15 @@ TEE_Result ta_entry_aes256ecb_decrypt(uint32_t param_types, TEE_Param params[4])
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
-/* Check that input buffer is whole mult. of block size, in bits */
+	/* Check that input buffer is whole mult. of block size, in bits */
 	if ((params[0].memref.size << 8) % AES_BLOCK_SIZE != 0)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-/* Check that output buffer is whole mult. of block size, in bits */
+	/* Check that output buffer is whole mult. of block size, in bits */
 	if ((params[1].memref.size << 8) % AES_BLOCK_SIZE != 0)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-/* Set up for decryption */
+	/* Set up for decryption */
 	(void)rijndaelSetupDecrypt(rk, key, AES_256);
 
 	n_input_blocks = params[0].memref.size / (AES_BLOCK_SIZE / 8);

--- a/ta/crypt/cryp_taf.c
+++ b/ta/crypt/cryp_taf.c
@@ -41,8 +41,8 @@ extern const void *ta_head;
 
 TEE_Result ta_entry_allocate_operation(uint32_t param_type, TEE_Param params[4])
 {
-	TEE_Result res;
-	TEE_OperationHandle op;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_OperationHandle op = TEE_HANDLE_NULL;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INOUT,
@@ -167,8 +167,8 @@ TEE_Result ta_entry_digest_do_final(uint32_t param_type, TEE_Param params[4])
 TEE_Result ta_entry_cipher_init(uint32_t param_type, TEE_Param params[4])
 {
 	TEE_OperationHandle op = VAL2HANDLE(params[0].value.a);
-	void *buffer;
-	size_t size;
+	void *buffer = NULL;
+	size_t size = 0;
 
 	if (param_type == TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 					  TEE_PARAM_TYPE_NONE,
@@ -220,8 +220,8 @@ TEE_Result ta_entry_cipher_do_final(uint32_t param_type, TEE_Param params[4])
 TEE_Result ta_entry_mac_init(uint32_t param_type, TEE_Param params[4])
 {
 	TEE_OperationHandle op = VAL2HANDLE(params[0].value.a);
-	void *buffer;
-	size_t size;
+	void *buffer = NULL;
+	size_t size = 0;
 
 	if (param_type == TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 					  TEE_PARAM_TYPE_NONE,
@@ -286,8 +286,8 @@ TEE_Result ta_entry_mac_final_compare(uint32_t param_type, TEE_Param params[4])
 TEE_Result ta_entry_allocate_transient_object(uint32_t param_type,
 					      TEE_Param params[4])
 {
-	TEE_Result res;
-	TEE_ObjectHandle o;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_ObjectHandle o = TEE_HANDLE_NULL;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,
@@ -338,7 +338,7 @@ static TEE_Result unpack_attrs(const uint8_t *buf, size_t blen,
 {
 	TEE_Result res = TEE_SUCCESS;
 	TEE_Attribute *a = NULL;
-	const struct attr_packed *ap;
+	const struct attr_packed *ap = NULL;
 	size_t num_attrs = 0;
 	const size_t num_attrs_size = sizeof(uint32_t);
 
@@ -396,9 +396,9 @@ out:
 TEE_Result ta_entry_populate_transient_object(uint32_t param_type,
 					      TEE_Param params[4])
 {
-	TEE_Result res;
-	TEE_Attribute *attrs;
-	uint32_t attr_count;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_Attribute *attrs = NULL;
+	uint32_t attr_count = 0;
 	TEE_ObjectHandle o = VAL2HANDLE(params[0].value.a);
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
@@ -432,9 +432,9 @@ TEE_Result ta_entry_copy_object_attributes(uint32_t param_type,
 TEE_Result ta_entry_generate_key(uint32_t param_type, TEE_Param params[4])
 {
 	TEE_ObjectHandle o = VAL2HANDLE(params[0].value.a);
-	TEE_Result res;
-	TEE_Attribute *attrs;
-	uint32_t attr_count;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_Attribute *attrs = NULL;
+	uint32_t attr_count = 0;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,
@@ -454,9 +454,9 @@ TEE_Result ta_entry_generate_key(uint32_t param_type, TEE_Param params[4])
 TEE_Result ta_entry_asymmetric_encrypt(uint32_t param_type, TEE_Param params[4])
 {
 	TEE_OperationHandle op = VAL2HANDLE(params[0].value.a);
-	TEE_Result res;
-	TEE_Attribute *attrs;
-	uint32_t attr_count;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_Attribute *attrs = NULL;
+	uint32_t attr_count = 0;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,
@@ -479,9 +479,9 @@ TEE_Result ta_entry_asymmetric_encrypt(uint32_t param_type, TEE_Param params[4])
 TEE_Result ta_entry_asymmetric_decrypt(uint32_t param_type, TEE_Param params[4])
 {
 	TEE_OperationHandle op = VAL2HANDLE(params[0].value.a);
-	TEE_Result res;
-	TEE_Attribute *attrs;
-	uint32_t attr_count;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_Attribute *attrs = NULL;
+	uint32_t attr_count = 0;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,
@@ -505,9 +505,9 @@ TEE_Result ta_entry_asymmetric_sign_digest(uint32_t param_type,
 					   TEE_Param params[4])
 {
 	TEE_OperationHandle op = VAL2HANDLE(params[0].value.a);
-	TEE_Result res;
-	TEE_Attribute *attrs;
-	uint32_t attr_count;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_Attribute *attrs = NULL;
+	uint32_t attr_count = 0;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,
@@ -531,9 +531,9 @@ TEE_Result ta_entry_asymmetric_verify_digest(uint32_t param_type,
 					     TEE_Param params[4])
 {
 	TEE_OperationHandle op = VAL2HANDLE(params[0].value.a);
-	TEE_Result res;
-	TEE_Attribute *attrs;
-	uint32_t attr_count;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_Attribute *attrs = NULL;
+	uint32_t attr_count = 0;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,
@@ -557,9 +557,9 @@ TEE_Result ta_entry_derive_key(uint32_t param_type, TEE_Param params[4])
 {
 	TEE_OperationHandle op = VAL2HANDLE(params[0].value.a);
 	TEE_ObjectHandle key = VAL2HANDLE(params[0].value.b);
-	TEE_Result res;
-	TEE_Attribute *attrs;
-	uint32_t attr_count;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_Attribute *attrs = NULL;
+	uint32_t attr_count = 0;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,
@@ -630,7 +630,7 @@ TEE_Result ta_entry_ae_update(uint32_t param_type, TEE_Param params[4])
 TEE_Result ta_entry_ae_encrypt_final(uint32_t param_type, TEE_Param params[4])
 {
 	TEE_OperationHandle op = VAL2HANDLE(params[0].value.a);
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,

--- a/ta/crypt/handle.c
+++ b/ta/crypt/handle.c
@@ -25,9 +25,9 @@ void handle_db_destroy(struct handle_db *db)
 
 int handle_get(struct handle_db *db, void *ptr)
 {
-	size_t n;
-	void *p;
-	size_t new_max_ptrs;
+	size_t n = 0;
+	void *p = NULL;
+	size_t new_max_ptrs = 0;
 
 	if (!db || !ptr)
 		return -1;
@@ -60,7 +60,7 @@ int handle_get(struct handle_db *db, void *ptr)
 
 void *handle_put(struct handle_db *db, int handle)
 {
-	void *p;
+	void *p = NULL;
 
 	if (!db || handle < 0 || (size_t)handle >= db->max_ptrs)
 		return NULL;

--- a/ta/crypt/mbedtls_taf.c
+++ b/ta/crypt/mbedtls_taf.c
@@ -35,6 +35,7 @@ ta_entry_mbedtls_self_tests(uint32_t param_type,
 						TEE_PARAM_TYPE_NONE,
 						TEE_PARAM_TYPE_NONE,
 						TEE_PARAM_TYPE_NONE);
+
 	if (param_type != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
 
@@ -70,10 +71,10 @@ TEE_Result ta_entry_mbedtls_check_cert(uint32_t param_type,
 						TEE_PARAM_TYPE_MEMREF_INPUT,
 						TEE_PARAM_TYPE_NONE,
 						TEE_PARAM_TYPE_NONE);
-	int ret;
-	uint32_t flags;
-	mbedtls_x509_crt crt;
-	mbedtls_x509_crt trust_crt;
+	int ret = 0;
+	uint32_t flags = 0;
+	mbedtls_x509_crt crt = { };
+	mbedtls_x509_crt trust_crt = { };
 
 	if (param_type != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -109,7 +110,6 @@ out:
 	mbedtls_x509_crt_free(&crt);
 
 	return res;
-
 }
 
 static int f_rng(void *rng __unused, unsigned char *output, size_t output_len)
@@ -121,8 +121,8 @@ static int f_rng(void *rng __unused, unsigned char *output, size_t output_len)
 static TEE_Result write_cert(mbedtls_x509write_cert *crt, void *buf,
 			     size_t *blen)
 {
-	int ret;
-	void *b;
+	int ret = 0;
+	void *b = NULL;
 	size_t bl = 1024;
 
 	ret = mbedtls_x509write_crt_pem(crt, buf, *blen, f_rng, NULL);
@@ -159,8 +159,8 @@ static TEE_Result write_cert(mbedtls_x509write_cert *crt, void *buf,
 
 static TEE_Result parse_issuer_cert(mbedtls_x509_crt *crt)
 {
-	int ret;
-	unsigned char *buf;
+	int ret = 0;
+	unsigned char *buf = NULL;
 
 	buf = TEE_Malloc(mid_crt_size + 1, TEE_MALLOC_FILL_ZERO);
 	if (!buf)
@@ -179,8 +179,8 @@ static TEE_Result parse_issuer_cert(mbedtls_x509_crt *crt)
 
 static TEE_Result parse_issuer_key(mbedtls_pk_context *pk)
 {
-	int ret;
-	unsigned char *buf;
+	int ret = 0;
+	unsigned char *buf = NULL;
 
 	buf = TEE_Malloc(mid_key_size + 1, TEE_MALLOC_FILL_ZERO);
 	if (!buf)
@@ -205,14 +205,14 @@ TEE_Result ta_entry_mbedtls_sign_cert(uint32_t param_type,
 						TEE_PARAM_TYPE_MEMREF_OUTPUT,
 						TEE_PARAM_TYPE_MEMREF_OUTPUT,
 						TEE_PARAM_TYPE_NONE);
-	char name[256];
-	mbedtls_mpi serial;
-	mbedtls_x509_crt issuer_crt;
-	mbedtls_pk_context issuer_key;
-	mbedtls_x509write_cert crt;
-	mbedtls_x509_csr csr;
-	int ret;
-	size_t sz;
+	char name[256] = { 0 };
+	mbedtls_mpi serial = { };
+	mbedtls_x509_crt issuer_crt = { };
+	mbedtls_pk_context issuer_key = { };
+	mbedtls_x509write_cert crt = { };
+	mbedtls_x509_csr csr = { };
+	int ret = 0;
+	size_t sz = 0;
 
 	if (param_type != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;

--- a/ta/crypt/seed_rng_taf.c
+++ b/ta/crypt/seed_rng_taf.c
@@ -11,8 +11,8 @@ TEE_Result seed_rng_pool(uint32_t param_types, TEE_Param params[4])
 {
 	static const TEE_UUID system_uuid = PTA_SYSTEM_UUID;
 	TEE_TASessionHandle sess = TEE_HANDLE_NULL;
-	TEE_Result res;
-	uint32_t ret_orig;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t ret_orig = 0;
 
 	if (param_types !=
 	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
@@ -37,7 +37,6 @@ TEE_Result seed_rng_pool(uint32_t param_types, TEE_Param params[4])
 		EMSG("TEE_InvokeTACommand failed");
 		goto cleanup_return;
 	}
-
 
 cleanup_return:
 	TEE_CloseTASession(sess);

--- a/ta/crypt/sha2_impl.c
+++ b/ta/crypt/sha2_impl.c
@@ -57,7 +57,10 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-#include "stdint.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api.h>
+
 #include "sha2_impl.h"
 
 #define SHFR(x, n)    (x >> n)
@@ -136,14 +139,14 @@ uint32_t sha256_k[64] = {
 void sha256_transf(struct sha256_ctx *ctx, const unsigned char *message,
 		   unsigned int block_nb)
 {
-	uint32_t w[64];
-	uint32_t wv[8];
-	uint32_t t1, t2;
-	const unsigned char *sub_block;
-	int i;
-
+	uint32_t w[64] = { };
+	uint32_t wv[8] = { };
+	uint32_t t1 = 0;
+	uint32_t t2 = 0;
+	const unsigned char *sub_block = NULL;
+	int i = 0;
 #ifndef UNROLL_LOOPS
-	int j;
+	int j = 0;
 #endif
 
 	for (i = 0; i < (int)block_nb; i++) {
@@ -331,7 +334,7 @@ void sha256_transf(struct sha256_ctx *ctx, const unsigned char *message,
 void sha256(const unsigned char *message,
 	    unsigned int len, unsigned char *digest)
 {
-	struct sha256_ctx ctx;
+	struct sha256_ctx ctx = { };
 
 	sha256_init(&ctx);
 	sha256_update(&ctx, message, len);
@@ -341,7 +344,7 @@ void sha256(const unsigned char *message,
 void sha256_init(struct sha256_ctx *ctx)
 {
 #ifndef UNROLL_LOOPS
-	int i;
+	int i = 0;
 
 	for (i = 0; i < 8; i++)
 		ctx->h[i] = sha256_h0[i];
@@ -363,10 +366,12 @@ void sha256_init(struct sha256_ctx *ctx)
 void sha256_update(struct sha256_ctx *ctx, const unsigned char *message,
 		   unsigned int len)
 {
-	unsigned int block_nb;
-	unsigned int new_len, rem_len, tmp_len;
-	const unsigned char *shifted_message;
-	unsigned long int i;
+	unsigned int block_nb = 0;
+	unsigned int new_len = 0;
+	unsigned int rem_len = 0;
+	unsigned int tmp_len = 0;
+	const unsigned char *shifted_message = NULL;
+	unsigned long int i = 0;
 
 	tmp_len = SHA256_BLOCK_SIZE - ctx->len;
 	rem_len = len < tmp_len ? len : tmp_len;
@@ -398,17 +403,17 @@ void sha256_update(struct sha256_ctx *ctx, const unsigned char *message,
 
 void sha256_final(struct sha256_ctx *ctx, unsigned char *digest)
 {
-	unsigned int block_nb;
-	unsigned int pm_len;
-	unsigned int len_b;
-	unsigned long int i_m;
-
+	unsigned int block_nb = 0;
+	unsigned int pm_len = 0;
+	unsigned int len_b = 0;
+	unsigned long int i_m = 0;
 #ifndef UNROLL_LOOPS
-	int i;
+	int i = 0;
 #endif
 
-	block_nb = (1 + ((SHA256_BLOCK_SIZE - 9)
-			 < (ctx->len % SHA256_BLOCK_SIZE)));
+	block_nb = 1;
+	if ((SHA256_BLOCK_SIZE - 9) < (ctx->len % SHA256_BLOCK_SIZE))
+		block_nb++;
 
 	len_b = (ctx->tot_len + ctx->len) << 3;
 	pm_len = block_nb << 6;
@@ -440,7 +445,7 @@ void sha256_final(struct sha256_ctx *ctx, unsigned char *digest)
 void sha224(const unsigned char *message, unsigned int len,
 	    unsigned char *digest)
 {
-	struct sha224_ctx ctx;
+	struct sha224_ctx ctx = { };
 
 	sha224_init(&ctx);
 	sha224_update(&ctx, message, len);
@@ -450,7 +455,7 @@ void sha224(const unsigned char *message, unsigned int len,
 void sha224_init(struct sha224_ctx *ctx)
 {
 #ifndef UNROLL_LOOPS
-	int i;
+	int i = 0;
 
 	for (i = 0; i < 8; i++)
 		ctx->h[i] = sha224_h0[i];
@@ -472,10 +477,12 @@ void sha224_init(struct sha224_ctx *ctx)
 void sha224_update(struct sha224_ctx *ctx, const unsigned char *message,
 		   unsigned int len)
 {
-	unsigned int block_nb;
-	unsigned int new_len, rem_len, tmp_len;
-	const unsigned char *shifted_message;
-	unsigned long int i;
+	unsigned int block_nb = 0;
+	unsigned int new_len = 0;
+	unsigned int rem_len = 0;
+	unsigned int tmp_len = 0;
+	const unsigned char *shifted_message = NULL;
+	unsigned long int i = 0;
 
 	tmp_len = SHA224_BLOCK_SIZE - ctx->len;
 	rem_len = len < tmp_len ? len : tmp_len;
@@ -507,17 +514,17 @@ void sha224_update(struct sha224_ctx *ctx, const unsigned char *message,
 
 void sha224_final(struct sha224_ctx *ctx, unsigned char *digest)
 {
-	unsigned int block_nb;
-	unsigned int pm_len;
-	unsigned int len_b;
-	unsigned long int i_m;
-
+	unsigned int block_nb = 0;
+	unsigned int pm_len = 0;
+	unsigned int len_b = 0;
+	unsigned long int i_m = 0;
 #ifndef UNROLL_LOOPS
-	int i;
+	int i = 0;
 #endif
 
-	block_nb = (1 + ((SHA224_BLOCK_SIZE - 9)
-			 < (ctx->len % SHA224_BLOCK_SIZE)));
+	block_nb = 1;
+	if ((SHA224_BLOCK_SIZE - 9) < (ctx->len % SHA224_BLOCK_SIZE))
+		block_nb++;
 
 	len_b = (ctx->tot_len + ctx->len) << 3;
 	pm_len = block_nb << 6;

--- a/ta/crypt/sha2_taf.c
+++ b/ta/crypt/sha2_taf.c
@@ -30,10 +30,10 @@
 
 TEE_Result ta_entry_sha224(uint32_t param_types, TEE_Param params[4])
 {
-/*
- * It is expected that memRef[0] is input buffer and memRef[1] is
- * output buffer.
- */
+	/*
+	 * It is expected that memRef[0] is input buffer and memRef[1] is
+	 * output buffer.
+	 */
 	if (param_types !=
 	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 			    TEE_PARAM_TYPE_MEMREF_OUTPUT, TEE_PARAM_TYPE_NONE,
@@ -53,10 +53,10 @@ TEE_Result ta_entry_sha224(uint32_t param_types, TEE_Param params[4])
 
 TEE_Result ta_entry_sha256(uint32_t param_types, TEE_Param params[4])
 {
-/*
- * It is expected that memRef[0] is input buffer and memRef[1] is
- * output buffer.
- */
+	/*
+	 * It is expected that memRef[0] is input buffer and memRef[1] is
+	 * output buffer.
+	 */
 	if (param_types !=
 	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 			    TEE_PARAM_TYPE_MEMREF_OUTPUT, TEE_PARAM_TYPE_NONE,

--- a/ta/crypt/ta_entry.c
+++ b/ta/crypt/ta_entry.c
@@ -90,7 +90,6 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 
 	(void)pSessionContext;
 
-
 	switch (nCommandID) {
 	case TA_CRYPT_CMD_SHA224:
 		use_fptr = !use_fptr;
@@ -305,7 +304,7 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 
 static TEE_Result set_global(uint32_t param_types, TEE_Param params[4])
 {
-	int i;
+	int i = 0;
 
 	/* Param 0 is a memref, input/output */
 	if (TEE_PARAM_TYPE_VALUE_INPUT != TEE_PARAM_TYPE_GET(param_types, 0))
@@ -323,7 +322,7 @@ static TEE_Result set_global(uint32_t param_types, TEE_Param params[4])
 
 static TEE_Result get_global(uint32_t param_types, TEE_Param params[4])
 {
-	int i;
+	int i = 0;
 
 	/* Param 0 is a memref, input/output */
 	if (TEE_PARAM_TYPE_VALUE_OUTPUT != TEE_PARAM_TYPE_GET(param_types, 0))

--- a/ta/os_test/include/testframework.h
+++ b/ta/os_test/include/testframework.h
@@ -34,7 +34,6 @@
 
 #include "tb_macros.h"
 #include "tb_asserts.h"
-#include "mpa.h"
 
 /* define the max size of generated numbers */
 /* this is number of hex chars in the number */
@@ -61,8 +60,6 @@ void tb_gcd(void);
 void tb_modulus(void);
 void tb_fmm(void);
 void tb_prime(void);
-
-extern mpa_scratch_mem mempool;
 
 int TEE_BigIntConvertFromString(TEE_BigInt *dest, const char *src);
 char *TEE_BigIntConvertToString(char *dest, int mode, const TEE_BigInt *src);

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -75,18 +75,18 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 				   TEE_PropSetHandle prop_set,
 				   struct p_attr *p_attrs, size_t num_p_attrs)
 {
-TEE_Result res;
-size_t n;
+TEE_Result res = TEE_ERROR_GENERIC;
+size_t n = 0;
 
 TEE_StartPropertyEnumerator(h, prop_set);
 
 while (true) {
-	char nbuf[256];
-	char nbuf_small[256];
-	char vbuf[256];
-	char vbuf2[256];
+	char nbuf[256] = { };
+	char nbuf_small[256] = { };
+	char vbuf[256] = { };
+	char vbuf2[256] = { };
 	uint32_t nblen = sizeof(nbuf);
-	uint32_t nblen_small;
+	uint32_t nblen_small = 0;
 	uint32_t vblen = sizeof(vbuf);
 	uint32_t vblen2 = sizeof(vbuf2);
 
@@ -191,7 +191,7 @@ while (true) {
 		switch (p_attrs[n].type) {
 		case P_TYPE_BOOL:
 			{
-				bool v;
+				bool v = false;
 
 				res =
 				    TEE_GetPropertyAsBool(h, NULL, &v);
@@ -206,7 +206,7 @@ while (true) {
 
 		case P_TYPE_INT:
 			{
-				uint32_t v;
+				uint32_t v = 0;
 
 				res = TEE_GetPropertyAsU32(h, NULL, &v);
 				if (res != TEE_SUCCESS) {
@@ -220,7 +220,7 @@ while (true) {
 
 		case P_TYPE_UUID:
 			{
-				TEE_UUID v;
+				TEE_UUID v = { };
 
 				res =
 				    TEE_GetPropertyAsUUID(h, NULL, &v);
@@ -235,7 +235,7 @@ while (true) {
 
 		case P_TYPE_IDENTITY:
 			{
-				TEE_Identity v;
+				TEE_Identity v = { };
 
 				res =
 				    TEE_GetPropertyAsIdentity(h, NULL,
@@ -255,7 +255,7 @@ while (true) {
 
 		case P_TYPE_BINARY_BLOCK:
 			{
-				char bbuf[80];
+				char bbuf[80] = { };
 				uint32_t bblen = sizeof(bbuf);
 
 				res =
@@ -273,11 +273,9 @@ while (true) {
 					const char exp_bin_value[] =
 					    "Hello world!";
 
-					if (bblen != strlen(exp_bin_value)
-					    ||
-					    TEE_MemCompare
-					    (exp_bin_value, bbuf,
-					     bblen) != 0) {
+					if (bblen != strlen(exp_bin_value) ||
+					    TEE_MemCompare(exp_bin_value, bbuf,
+							   bblen) != 0) {
 						EMSG(
 						"Binary buffer of \"%s\" differs from \"%s\"\n",
 							nbuf, exp_bin_value);
@@ -325,7 +323,7 @@ static TEE_Result test_malloc(void)
 static TEE_Result test_properties(void)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
-	TEE_PropSetHandle h;
+	TEE_PropSetHandle h = TEE_HANDLE_NULL;
 	struct p_attr p_attrs[] = {
 		{"gpd.ta.appID", P_TYPE_UUID},
 		{"gpd.ta.singleInstance", P_TYPE_BOOL},
@@ -358,7 +356,7 @@ static TEE_Result test_properties(void)
 		{"myprop.binaryblock", P_TYPE_BINARY_BLOCK},
 	};
 	const size_t num_p_attrs = sizeof(p_attrs) / sizeof(p_attrs[0]);
-	size_t n;
+	size_t n = 0;
 
 	res = TEE_AllocatePropertyEnumerator(&h);
 	if (res != TEE_SUCCESS) {
@@ -401,13 +399,13 @@ static TEE_Result test_mem_access_right(uint32_t param_types,
 					TEE_Param params[4])
 {
 	static const TEE_UUID test_uuid = TA_OS_TEST_UUID;
-	TEE_Result res;
-	uint32_t ret_orig;
-	uint32_t l_pts;
-	TEE_Param l_params[4] = { { {0} } };
-	uint8_t buf[32];
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t ret_orig = 0;
+	uint32_t l_pts = 0;
+	TEE_Param l_params[4] = { };
+	uint8_t buf[32] = { };
 	TEE_TASessionHandle sess = TEE_HANDLE_NULL;
-	TEE_UUID *uuid;
+	TEE_UUID *uuid = NULL;
 
 	if (param_types !=
 	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT, 0, 0, 0))
@@ -492,10 +490,9 @@ cleanup_return:
 
 static TEE_Result test_time(void)
 {
-	TEE_Result res;
-	TEE_Time t;
-	TEE_Time sys_t;
-
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_Time t = { };
+	TEE_Time sys_t = { };
 	static const TEE_Time null_time = { 0, 0 };
 	static const TEE_Time wrap_time = { UINT32_MAX, 999 };
 
@@ -672,7 +669,7 @@ static __noinline void call_longjmp(jmp_buf env)
 
 static TEE_Result test_setjmp(void)
 {
-	jmp_buf env;
+	jmp_buf env = { };
 
 	if (setjmp(env)) {
 		IMSG("Returned via longjmp");
@@ -741,9 +738,9 @@ TEE_Result ta_entry_client_with_timeout(uint32_t param_types,
 					TEE_Param params[4])
 {
 	static const TEE_UUID os_test_uuid = TA_OS_TEST_UUID;
-	TEE_Result res;
-	TEE_TASessionHandle sess;
-	uint32_t ret_orig;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_TASessionHandle sess = TEE_HANDLE_NULL;
+	uint32_t ret_orig = 0;
 
 	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 					   TEE_PARAM_TYPE_NONE,
@@ -781,11 +778,11 @@ TEE_Result ta_entry_client_with_timeout(uint32_t param_types,
 TEE_Result ta_entry_client(uint32_t param_types, TEE_Param params[4])
 {
 	static const TEE_UUID crypt_uuid = TA_CRYPT_UUID;
-	TEE_Result res;
-	uint32_t l_pts;
-	TEE_Param l_params[4] = { { {0} } };
-	TEE_TASessionHandle sess;
-	uint32_t ret_orig;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t l_pts = 0;
+	TEE_Param l_params[4] = { };
+	TEE_TASessionHandle sess = TEE_HANDLE_NULL;
+	uint32_t ret_orig = 0;
 	static const uint8_t sha256_in[] = { 'a', 'b', 'c' };
 	static const uint8_t sha256_out[] = {
 		0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
@@ -840,7 +837,7 @@ cleanup_return:
 
 TEE_Result ta_entry_params_access_rights(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (param_types !=
 	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
@@ -890,8 +887,8 @@ static void undef_instr(void)
 
 TEE_Result ta_entry_bad_mem_access(uint32_t param_types, TEE_Param params[4])
 {
-	long stack;
-	long stack_addr = (long)&stack;
+	long int stack = 0;
+	long int stack_addr = (long int)&stack;
 
 	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT, 0, 0, 0) &&
 	    param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
@@ -923,26 +920,27 @@ TEE_Result ta_entry_bad_mem_access(uint32_t param_types, TEE_Param params[4])
 
 static void incr_values(size_t bufsize, uint8_t *a, uint8_t *b, uint8_t *c)
 {
-	size_t i;
+	size_t i = 0;
 
 	for (i = 0; i < bufsize; i++) {
 		a[i]++; b[i]++; c[i]++;
 	}
 }
 
+#define TA2TA_BUF_SIZE		(2 * 1024)
 TEE_Result ta_entry_ta2ta_memref(uint32_t param_types, TEE_Param params[4])
 {
 	static const TEE_UUID test_uuid = TA_OS_TEST_UUID;
 	TEE_TASessionHandle sess = TEE_HANDLE_NULL;
-	TEE_Param l_params[4] = { { {0} } };
-	size_t bufsize = 2 * 1024;
-	uint8_t in[bufsize];
-	uint8_t inout[bufsize];
-	uint8_t out[bufsize];
-	TEE_Result res;
-	uint32_t ret_orig;
-	uint32_t l_pts;
-	size_t i;
+	TEE_Param l_params[4] = { };
+	uint8_t in[TA2TA_BUF_SIZE] = { };
+	uint8_t inout[TA2TA_BUF_SIZE] = { };
+	uint8_t out[TA2TA_BUF_SIZE] = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t ret_orig = 0;
+	uint32_t l_pts = 0;
+	size_t i = 0;
+
 	(void)params;
 
 	if (param_types != TEE_PARAM_TYPES(0, 0, 0, 0))
@@ -958,14 +956,14 @@ TEE_Result ta_entry_ta2ta_memref(uint32_t param_types, TEE_Param params[4])
 				TEE_PARAM_TYPE_MEMREF_INOUT,
 				TEE_PARAM_TYPE_MEMREF_OUTPUT, 0);
 	l_params[0].memref.buffer = in;
-	l_params[0].memref.size = bufsize;
+	l_params[0].memref.size = TA2TA_BUF_SIZE;
 	l_params[1].memref.buffer = inout;
-	l_params[1].memref.size = bufsize;
+	l_params[1].memref.size = TA2TA_BUF_SIZE;
 	l_params[2].memref.buffer = out;
-	l_params[2].memref.size = bufsize;
+	l_params[2].memref.size = TA2TA_BUF_SIZE;
 
 	/* Initialize buffers */
-	for (i = 0; i < bufsize; i++) {
+	for (i = 0; i < TA2TA_BUF_SIZE; i++) {
 		in[i] = 5;
 		inout[i] = 10;
 		out[i] = 0;
@@ -981,12 +979,12 @@ TEE_Result ta_entry_ta2ta_memref(uint32_t param_types, TEE_Param params[4])
 		EMSG("TEE_InvokeTACommand failed");
 		goto cleanup_return;
 	}
-	
+
 	/*
 	 * Increment all values by one.
 	 * Expected values after this step: in: 6, inout: 12, out: 17
 	 */
-	incr_values(bufsize, in, inout, out);
+	incr_values(TA2TA_BUF_SIZE, in, inout, out);
 
 	/*
 	 * TA will compute: out = ++inout + in
@@ -1000,12 +998,12 @@ TEE_Result ta_entry_ta2ta_memref(uint32_t param_types, TEE_Param params[4])
 	}
 
 	/* Check the actual values */
-	for (i = 0; i < bufsize; i++) {
+	for (i = 0; i < TA2TA_BUF_SIZE; i++) {
 		if (in[i] != 6 || inout[i] != 13 || out[i] != 19) {
 			EMSG("Unexpected value in buffer(s)");
-			DHEXDUMP(in, bufsize);
-			DHEXDUMP(inout, bufsize);
-			DHEXDUMP(out, bufsize);
+			DHEXDUMP(in, TA2TA_BUF_SIZE);
+			DHEXDUMP(inout, TA2TA_BUF_SIZE);
+			DHEXDUMP(out, TA2TA_BUF_SIZE);
 			return TEE_ERROR_GENERIC;
 		}
 	}
@@ -1017,11 +1015,11 @@ cleanup_return:
 
 TEE_Result ta_entry_ta2ta_memref_mix(uint32_t param_types, TEE_Param params[4])
 {
-	uint8_t *in;
-	uint8_t *inout;
-	uint8_t *out;
-	size_t bufsize;
-	size_t i;
+	uint8_t *in = NULL;
+	uint8_t *inout = NULL;
+	uint8_t *out = NULL;
+	size_t bufsize = 0;
+	size_t i = 0;
 
 	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 					   TEE_PARAM_TYPE_MEMREF_INOUT,
@@ -1045,7 +1043,7 @@ TEE_Result ta_entry_ta2ta_memref_mix(uint32_t param_types, TEE_Param params[4])
 
 TEE_Result ta_entry_params(uint32_t param_types, TEE_Param params[4])
 {
-	size_t n;
+	size_t n = 0;
 
 	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 					   TEE_PARAM_TYPE_MEMREF_INPUT,

--- a/ta/rpc_test/ta_rpc.c
+++ b/ta/rpc_test/ta_rpc.c
@@ -37,17 +37,14 @@ static TEE_UUID cryp_uuid = TA_CRYPT_UUID;
 static TEE_Result rpc_call_cryp(bool sec_mem, uint32_t nParamTypes,
 				TEE_Param pParams[4], uint32_t cmd)
 {
-	TEE_TASessionHandle cryp_session;
-	TEE_Result res;
-	uint32_t origin;
-	TEE_Param params[4];
-	size_t n;
-
+	TEE_TASessionHandle cryp_session = TEE_HANDLE_NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t origin = 0;
+	TEE_Param params[4] = { };
+	size_t n = 0;
 	uint32_t types =
 	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE,
 			    TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
-
-	TEE_MemFill(params, 0, sizeof(TEE_Param) * 4);
 
 	res = TEE_OpenTASession(&cryp_uuid, 0, types, params, &cryp_session,
 				&origin);
@@ -156,14 +153,14 @@ TEE_Result rpc_aes256ecb_decrypt(bool sec_mem, uint32_t nParamTypes,
 TEE_Result rpc_open(void *session_context, uint32_t param_types,
 		    TEE_Param params[4])
 {
-	TEE_TASessionHandle session;
-	uint32_t orig;
-	TEE_Result res;
+	TEE_TASessionHandle session = TEE_HANDLE_NULL;
+	uint32_t orig = 0;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEE_UUID uuid = TA_SIMS_TEST_UUID;
 	uint32_t types =
 	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT, TEE_PARAM_TYPE_NONE,
 			    TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
-	TEE_Param par[4];
+	TEE_Param par[4] = { };
 
 	(void)session_context;
 	(void)param_types;

--- a/ta/sdp_basic/ta_sdp_basic.c
+++ b/ta/sdp_basic/ta_sdp_basic.c
@@ -45,7 +45,7 @@
 static TEE_Result cmd_inject(uint32_t types,
 			     TEE_Param params[TEE_NUM_PARAMS])
 {
-	TEE_Result rc;
+	TEE_Result rc = TEE_ERROR_GENERIC;
 	const int sec_idx = 1;		/* highlight secure buffer index */
 	const int ns_idx = 0;		/* highlight nonsecure buffer index */
 
@@ -128,9 +128,9 @@ static TEE_Result cmd_inject(uint32_t types,
 static TEE_Result cmd_transform(uint32_t types,
 				TEE_Param params[TEE_NUM_PARAMS])
 {
-	TEE_Result rc;
-	unsigned char *p;
-	size_t sz;
+	TEE_Result rc = TEE_ERROR_GENERIC;
+	unsigned char *p = NULL;
+	size_t sz = 0;
 
 	if (types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
 				     TEE_PARAM_TYPE_NONE,
@@ -198,7 +198,7 @@ static TEE_Result cmd_transform(uint32_t types,
 static TEE_Result cmd_dump(uint32_t types,
 			   TEE_Param params[TEE_NUM_PARAMS])
 {
-	TEE_Result rc;
+	TEE_Result rc = TEE_ERROR_GENERIC;
 	const int sec_idx = 0;		/* highlight secure buffer index */
 	const int ns_idx = 1;		/* highlight nonsecure buffer index */
 
@@ -270,8 +270,8 @@ static TEE_Result cmd_invoke(uint32_t nParamTypes,
 {
         const TEE_UUID uuid = TA_SDP_BASIC_UUID;
         static TEE_TASessionHandle sess = TEE_HANDLE_NULL;
-        uint32_t ret_orig;
-        TEE_Result res;
+        uint32_t ret_orig = 0;
+        TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (sess == TEE_HANDLE_NULL) {
 	        res = TEE_OpenTASession(&uuid, 0, 0, NULL, &sess, &ret_orig);
@@ -302,8 +302,8 @@ static TEE_Result cmd_invoke_pta(uint32_t nParamTypes,
 {
         const TEE_UUID uuid = PTA_INVOKE_TESTS_UUID;
         static TEE_TASessionHandle sess = TEE_HANDLE_NULL;
-        uint32_t ret_orig;
-        TEE_Result res;
+        uint32_t ret_orig = 0;
+        TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (sess == TEE_HANDLE_NULL) {
 	        res = TEE_OpenTASession(&uuid, 0, 0, NULL, &sess, &ret_orig);

--- a/ta/sha_perf/ta_sha_perf.c
+++ b/ta/sha_perf/ta_sha_perf.c
@@ -44,12 +44,13 @@ static TEE_OperationHandle digest_op = NULL;
 
 TEE_Result cmd_process(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
-	int n;
-	void *in, *out;
-	uint32_t insz;
-	uint32_t outsz;
-	uint32_t offset;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	int n = 0;
+	void *in = NULL;
+	void *out = NULL;
+	uint32_t insz = 0;
+	uint32_t outsz = 0;
+	uint32_t offset = 0;
 	uint32_t exp_param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 						   TEE_PARAM_TYPE_MEMREF_OUTPUT,
 						   TEE_PARAM_TYPE_VALUE_INPUT,
@@ -74,13 +75,13 @@ TEE_Result cmd_process(uint32_t param_types, TEE_Param params[4])
 
 TEE_Result cmd_prepare_op(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
-	uint32_t algo;
-
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t algo = 0;
 	uint32_t exp_param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 						   TEE_PARAM_TYPE_NONE,
 						   TEE_PARAM_TYPE_NONE,
 						   TEE_PARAM_TYPE_NONE);
+
 	if (param_types != exp_param_types)
 		return TEE_ERROR_BAD_PARAMETERS;
 

--- a/ta/sims/ta_sims.c
+++ b/ta/sims/ta_sims.c
@@ -48,6 +48,7 @@ TEE_Result sims_open_session(void **ctx)
 {
 	struct sims_session *context =
 	    TEE_Malloc(sizeof(struct sims_session), 0);
+
 	if (context == NULL)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
@@ -66,8 +67,8 @@ void sims_close_session(void *ctx)
 
 TEE_Result sims_read(uint32_t param_types, TEE_Param params[4])
 {
-	uint32_t index;
-	void *p;
+	uint32_t index = 0;
+	void *p = NULL;
 
 	if (param_types !=
 	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
@@ -95,7 +96,7 @@ TEE_Result sims_read(uint32_t param_types, TEE_Param params[4])
 
 TEE_Result sims_write(uint32_t param_types, TEE_Param params[4])
 {
-	uint32_t index;
+	uint32_t index = 0;
 
 	if (param_types !=
 	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,

--- a/ta/socket/ta_entry.c
+++ b/ta/socket/ta_entry.c
@@ -65,9 +65,9 @@ struct sock_handle {
 
 static TEE_Result ta_entry_tcp_open(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
-	struct sock_handle h;
-	TEE_tcpSocket_Setup setup;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct sock_handle h = { };
+	TEE_tcpSocket_Setup setup = { };
 	uint32_t req_param_types =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 				TEE_PARAM_TYPE_MEMREF_INPUT,
@@ -104,9 +104,9 @@ static TEE_Result ta_entry_tcp_open(uint32_t param_types, TEE_Param params[4])
 
 static TEE_Result ta_entry_udp_open(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
-	struct sock_handle h;
-	TEE_udpSocket_Setup setup;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct sock_handle h = { };
+	TEE_udpSocket_Setup setup = { };
 	uint32_t req_param_types =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 				TEE_PARAM_TYPE_MEMREF_INPUT,
@@ -143,7 +143,7 @@ static TEE_Result ta_entry_udp_open(uint32_t param_types, TEE_Param params[4])
 
 static TEE_Result ta_entry_close(uint32_t param_types, TEE_Param params[4])
 {
-	struct sock_handle *h;
+	struct sock_handle *h = NULL;
 	uint32_t req_param_types =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 				TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE,
@@ -164,7 +164,7 @@ static TEE_Result ta_entry_close(uint32_t param_types, TEE_Param params[4])
 
 static TEE_Result ta_entry_send(uint32_t param_types, TEE_Param params[4])
 {
-	struct sock_handle *h;
+	struct sock_handle *h = NULL;
 	uint32_t req_param_types =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 				TEE_PARAM_TYPE_MEMREF_INPUT,
@@ -188,7 +188,7 @@ static TEE_Result ta_entry_send(uint32_t param_types, TEE_Param params[4])
 
 static TEE_Result ta_entry_recv(uint32_t param_types, TEE_Param params[4])
 {
-	struct sock_handle *h;
+	struct sock_handle *h = NULL;
 	uint32_t req_param_types =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 				TEE_PARAM_TYPE_MEMREF_OUTPUT,
@@ -211,7 +211,7 @@ static TEE_Result ta_entry_recv(uint32_t param_types, TEE_Param params[4])
 
 static TEE_Result ta_entry_error(uint32_t param_types, TEE_Param params[4])
 {
-	struct sock_handle *h;
+	struct sock_handle *h = NULL;
 	uint32_t req_param_types =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 				TEE_PARAM_TYPE_VALUE_OUTPUT,
@@ -234,7 +234,7 @@ static TEE_Result ta_entry_error(uint32_t param_types, TEE_Param params[4])
 
 static TEE_Result ta_entry_ioctl(uint32_t param_types, TEE_Param params[4])
 {
-	struct sock_handle *h;
+	struct sock_handle *h = NULL;
 	uint32_t req_param_types =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 				TEE_PARAM_TYPE_MEMREF_INOUT,

--- a/ta/storage/storage.c
+++ b/ta/storage/storage.c
@@ -42,9 +42,9 @@ do { \
 TEE_Result ta_storage_cmd_open(uint32_t command,
 				uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
-	TEE_ObjectHandle o;
-	void *object_id;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_ObjectHandle o = TEE_HANDLE_NULL;
+	void *object_id = NULL;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_MEMREF_INPUT,
@@ -83,10 +83,10 @@ TEE_Result ta_storage_cmd_open(uint32_t command,
 TEE_Result ta_storage_cmd_create(uint32_t command,
 				 uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
-	TEE_ObjectHandle o;
-	void *object_id;
-	TEE_ObjectHandle ref_handle;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_ObjectHandle o = TEE_HANDLE_NULL;
+	void *object_id = NULL;
+	TEE_ObjectHandle ref_handle = TEE_HANDLE_NULL;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_MEMREF_INPUT,
@@ -130,8 +130,8 @@ TEE_Result ta_storage_cmd_create_overwrite(uint32_t command,
 					   uint32_t param_types,
 					   TEE_Param params[4])
 {
-	TEE_Result res;
-	void *object_id;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	void *object_id = NULL;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_MEMREF_INPUT,
@@ -205,10 +205,10 @@ TEE_Result ta_storage_cmd_write(uint32_t param_types, TEE_Param params[4])
 
 TEE_Result ta_storage_cmd_seek(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEE_ObjectInfo info;
 	TEE_ObjectHandle o = VAL2HANDLE(params[0].value.a);
-	int32_t offs;
+	int32_t offs = 0;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,
@@ -243,8 +243,8 @@ TEE_Result ta_storage_cmd_rename(uint32_t command, uint32_t param_types,
 				 TEE_Param params[4])
 {
 	TEE_ObjectHandle o = VAL2HANDLE(params[0].value.a);
-	void *object_id;
-	TEE_Result res;
+	void *object_id = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,
@@ -288,8 +288,8 @@ TEE_Result ta_storage_cmd_trunc(uint32_t param_types, TEE_Param params[4])
 
 TEE_Result ta_storage_cmd_alloc_enum(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
-	TEE_ObjectEnumHandle oe;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_ObjectEnumHandle oe = TEE_HANDLE_NULL;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_OUTPUT, TEE_PARAM_TYPE_NONE,
@@ -338,7 +338,7 @@ TEE_Result ta_storage_cmd_start_enum(uint32_t param_types, TEE_Param params[4])
 TEE_Result ta_storage_cmd_next_enum(uint32_t param_types, TEE_Param params[4])
 {
 	TEE_ObjectEnumHandle oe = VAL2HANDLE(params[0].value.a);
-	TEE_ObjectInfo *obj;
+	TEE_ObjectInfo *obj = NULL;
 
 	if (TEE_PARAM_TYPE_GET(param_types, 0) != TEE_PARAM_TYPE_VALUE_INPUT)
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -382,10 +382,10 @@ TEE_Result ta_storage_cmd_key_in_persistent(uint32_t param_types,
 					    TEE_Param params[4])
 {
 	TEE_Result result = TEE_SUCCESS;
-	TEE_ObjectHandle transient_key = (TEE_ObjectHandle)NULL;
-	TEE_ObjectHandle persistent_key = (TEE_ObjectHandle)NULL;
-	TEE_ObjectHandle key = (TEE_ObjectHandle)NULL;
-	TEE_OperationHandle encrypt_op = (TEE_OperationHandle)NULL;
+	TEE_ObjectHandle transient_key = TEE_HANDLE_NULL;
+	TEE_ObjectHandle persistent_key = TEE_HANDLE_NULL;
+	TEE_ObjectHandle key = TEE_HANDLE_NULL;
+	TEE_OperationHandle encrypt_op = TEE_HANDLE_NULL;
 	TEE_ObjectInfo keyInfo;
 	TEE_ObjectInfo keyInfo2;
 	TEE_ObjectInfo keyInfo3;
@@ -399,6 +399,10 @@ TEE_Result ta_storage_cmd_key_in_persistent(uint32_t param_types,
 			 TEE_DATA_FLAG_ACCESS_WRITE_META |
 			 TEE_DATA_FLAG_SHARE_READ |
 			 TEE_DATA_FLAG_SHARE_WRITE;
+
+	TEE_MemFill(&keyInfo, 0, sizeof(keyInfo));
+	TEE_MemFill(&keyInfo2, 0, sizeof(keyInfo2));
+	TEE_MemFill(&keyInfo3, 0, sizeof(keyInfo3));
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE,
@@ -488,7 +492,7 @@ cleanup1:
 TEE_Result ta_storage_cmd_loop(uint32_t param_types, TEE_Param params[4])
 {
 	TEE_ObjectHandle object = TEE_HANDLE_NULL;
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	int object_id = 0;
 	uint32_t flags =  TEE_DATA_FLAG_OVERWRITE |
 			  TEE_DATA_FLAG_ACCESS_WRITE_META;
@@ -526,7 +530,7 @@ TEE_Result ta_storage_cmd_loop(uint32_t param_types, TEE_Param params[4])
 TEE_Result ta_storage_cmd_restrict_usage(uint32_t param_types,
 					 TEE_Param params[4])
 {
-	TEE_ObjectHandle o;
+	TEE_ObjectHandle o = TEE_HANDLE_NULL;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE,
@@ -539,8 +543,8 @@ TEE_Result ta_storage_cmd_restrict_usage(uint32_t param_types,
 
 TEE_Result ta_storage_cmd_alloc_obj(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
-	TEE_ObjectHandle o;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_ObjectHandle o = TEE_HANDLE_NULL;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT,
@@ -555,7 +559,7 @@ TEE_Result ta_storage_cmd_alloc_obj(uint32_t param_types, TEE_Param params[4])
 
 TEE_Result ta_storage_cmd_free_obj(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_ObjectHandle o;
+	TEE_ObjectHandle o = TEE_HANDLE_NULL;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE,
@@ -568,7 +572,7 @@ TEE_Result ta_storage_cmd_free_obj(uint32_t param_types, TEE_Param params[4])
 
 TEE_Result ta_storage_cmd_reset_obj(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_ObjectHandle o;
+	TEE_ObjectHandle o = TEE_HANDLE_NULL;
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES
 			  (TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE,
@@ -582,8 +586,8 @@ TEE_Result ta_storage_cmd_reset_obj(uint32_t param_types, TEE_Param params[4])
 TEE_Result ta_storage_cmd_get_obj_info(uint32_t param_types,
 					    TEE_Param params[4])
 {
-	TEE_Result res;
-	TEE_ObjectInfo *info;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_ObjectInfo *info = NULL;
 	TEE_ObjectHandle o = VAL2HANDLE(params[0].value.a);
 
 	ASSERT_PARAM_TYPE(TEE_PARAM_TYPES

--- a/ta/storage_benchmark/benchmark.c
+++ b/ta/storage_benchmark/benchmark.c
@@ -45,7 +45,7 @@ static uint8_t filename[] = "BenchmarkTestFile";
 
 static void fill_buffer(uint8_t *buf, size_t size)
 {
-	size_t i;
+	size_t i = 0;
 
 	if (!buf)
 		return;
@@ -56,7 +56,7 @@ static void fill_buffer(uint8_t *buf, size_t size)
 
 static TEE_Result verify_buffer(uint8_t *buf, size_t size)
 {
-	size_t i;
+	size_t i = 0;
 
 	if (!buf)
 		return TEE_ERROR_BAD_PARAMETERS;
@@ -87,7 +87,7 @@ static TEE_Result prepare_test_file(size_t data_size, uint8_t *chunk_buf,
 {
 	size_t remain_bytes = data_size;
 	TEE_Result res = TEE_SUCCESS;
-	TEE_ObjectHandle object;
+	TEE_ObjectHandle object = TEE_HANDLE_NULL;
 
 	res = TEE_CreatePersistentObject(TEE_STORAGE_PRIVATE,
 			filename, sizeof(filename),
@@ -103,7 +103,7 @@ static TEE_Result prepare_test_file(size_t data_size, uint8_t *chunk_buf,
 	}
 
 	while (remain_bytes) {
-		size_t write_size;
+		size_t write_size = 0;
 
 		if (remain_bytes < chunk_size)
 			write_size = remain_bytes;
@@ -126,14 +126,15 @@ static TEE_Result test_write(TEE_ObjectHandle object, size_t data_size,
 		uint8_t *chunk_buf, size_t chunk_size,
 		uint32_t *spent_time_in_ms)
 {
-	TEE_Time start_time, stop_time;
+	TEE_Time start_time = { };
+	TEE_Time stop_time = { };
 	size_t remain_bytes = data_size;
 	TEE_Result res = TEE_SUCCESS;
 
 	TEE_GetSystemTime(&start_time);
 
 	while (remain_bytes) {
-		size_t write_size;
+		size_t write_size = 0;
 
 		DMSG("Write data, remain bytes: %zu", remain_bytes);
 		if (chunk_size > remain_bytes)
@@ -165,7 +166,8 @@ static TEE_Result test_read(TEE_ObjectHandle object, size_t data_size,
 		uint8_t *chunk_buf, size_t chunk_size,
 		uint32_t *spent_time_in_ms)
 {
-	TEE_Time start_time, stop_time;
+	TEE_Time start_time = { };
+	TEE_Time stop_time = { };
 	size_t remain_bytes = data_size;
 	TEE_Result res = TEE_SUCCESS;
 	uint32_t read_bytes = 0;
@@ -173,7 +175,7 @@ static TEE_Result test_read(TEE_ObjectHandle object, size_t data_size,
 	TEE_GetSystemTime(&start_time);
 
 	while (remain_bytes) {
-		size_t read_size;
+		size_t read_size = 0;
 
 		DMSG("Read data, remain bytes: %zu", remain_bytes);
 		if (remain_bytes < chunk_size)
@@ -207,7 +209,8 @@ static TEE_Result test_rewrite(TEE_ObjectHandle object, size_t data_size,
 		uint8_t *chunk_buf, size_t chunk_size,
 		uint32_t *spent_time_in_ms)
 {
-	TEE_Time start_time, stop_time;
+	TEE_Time start_time = { };
+	TEE_Time stop_time = { };
 	size_t remain_bytes = data_size;
 	TEE_Result res = TEE_SUCCESS;
 	uint32_t read_bytes = 0;
@@ -215,8 +218,8 @@ static TEE_Result test_rewrite(TEE_ObjectHandle object, size_t data_size,
 	TEE_GetSystemTime(&start_time);
 
 	while (remain_bytes) {
-		size_t write_size;
-		int32_t negative_chunk_size;
+		size_t write_size = 0;
+		int32_t negative_chunk_size = 0;
 
 		if (remain_bytes < chunk_size)
 			write_size = remain_bytes;
@@ -272,7 +275,7 @@ exit:
 static TEE_Result verify_file_data(TEE_ObjectHandle object, size_t data_size,
 		uint8_t *chunk_buf, size_t chunk_size)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	size_t tmp_data_size = data_size;
 
 	res = TEE_SeekObjectData(object, 0, TEE_DATA_SEEK_SET);
@@ -316,13 +319,13 @@ exit:
 static TEE_Result ta_stroage_benchmark_chunk_access_test(uint32_t nCommandID,
 		uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
-	size_t data_size;
-	size_t chunk_size;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	size_t data_size = 0;
+	size_t chunk_size = 0;
 	TEE_ObjectHandle object = TEE_HANDLE_NULL;
-	uint8_t *chunk_buf;
+	uint8_t *chunk_buf = NULL;
 	uint32_t *spent_time_in_ms = &params[2].value.a;
-	bool do_verify;
+	bool do_verify = false;
 
 	ASSERT_PARAM_TYPE(param_types, TEE_PARAM_TYPES(
 					TEE_PARAM_TYPE_VALUE_INPUT,
@@ -411,7 +414,7 @@ exit:
 TEE_Result ta_storage_benchmark_cmd_handler(uint32_t nCommandID,
 		uint32_t param_types, TEE_Param params[4])
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	switch (nCommandID) {
 	case TA_STORAGE_BENCHMARK_CMD_TEST_READ:


### PR DESCRIPTION
This change initializes all local variables to prevent build issues
(warnings and/or errors) in OP-TEE test package. It uses TEE_MemFill()
to initialize structured and typed variables.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>