### PR TITLE
GP: fix compile errors with calloc()

### DIFF
--- a/host/xtest/xml/include/xml_timearithm_api.h
+++ b/host/xtest/xml/include/xml_timearithm_api.h
@@ -731,7 +731,7 @@ static TEEC_Result Invoke_BigIntDiv_Quotient(
 
 	res = TEEC_InvokeCommand(sess, cmdId, &op, &org);
 
-	tmp1 = (uint8_t *)caalloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
 
@@ -811,7 +811,7 @@ static TEEC_Result Invoke_BigIntAdd(
 
 	res = TEEC_InvokeCommand(sess, cmdId, &op, &org);
 
-	tmp1 = (uint8_t *)caalloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
 
@@ -977,7 +977,7 @@ static TEEC_Result Invoke_BigIntAddMod(
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	tmp1 = (uint8_t *)calloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
 
@@ -1060,7 +1060,7 @@ static TEEC_Result Invoke_BigIntSubMod(
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	tmp1 = (uint8_t *)calloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
 
@@ -1180,7 +1180,7 @@ static TEEC_Result Invoke_BigIntMulMod(
 	if (res != TEE_SUCCESS)
 		goto exit;
 
-	tmp1 = (uint8_t *)calloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
 
@@ -1587,7 +1587,7 @@ static TEEC_Result Invoke_BigIntMul(
 
 	res = TEEC_InvokeCommand(sess, cmdId, &op, &org);
 
-	tmp1 = (uint8_t *)calloc(SHARE_MEM03->size);
+	tmp1 = (uint8_t *)calloc(1, SHARE_MEM03->size);
 	if (tmp1 == NULL)
 		goto tmp1_exit;
 


### PR DESCRIPTION
Fixes a few errors when xtest is compiled with GP tests enabled
(CFG_GP_PACKAGE_PATH pointing to the GP Initial Configuration Test
Suite files).

Fixes: e4ec9e4aca08 ("xtest: Explicitly initialize local variables")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>