### PR TITLE
regression 41xx: prevent unsafe-loop-optimizations build error

### DIFF
--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -61,6 +61,10 @@ set (SRC
 	xtest_test.c
 )
 
+set_source_files_properties(
+	regression_4100.c PROPERTIES COMPILE_FLAGS -Wno-unsafe-loop-optimizations
+)
+
 if (CFG_GP_SOCKETS)
 	list (APPEND SRC
 		regression_2000.c

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -155,6 +155,7 @@ CFLAGS += -Wall -Wcast-align -Werror \
 	  -Wshadow -Wstrict-prototypes -Wswitch-default \
 	  -Wwrite-strings \
 	  -Wno-declaration-after-statement \
+	  -Wno-unsafe-loop-optimizations \
 	  -Wno-missing-field-initializers -Wno-format-zero-length
 endif
 


### PR DESCRIPTION
Add -Wno-unsafe-loop-optimizations directive since regression_4100.c
fails to build on some recent toolchains as GCC 8.2 with a error
trace like:

/path/to/optee_test/host/xtest/regression_4100.c: In function ‘convert_from_string’:
/path/to/optee_test/host/xtest/regression_4100.c:448:8: error: missed loop optimization, the loop counter may overflow [-Werror=unsafe-loop-optimizations]
  while (spos) {
        ^
/path/to/optee_test/host/xtest/regression_4100.c:455:6: error: missed loop optimization, the loop counter may overflow [-Werror=unsafe-loop-optimizations]
   if (!spos)
      ^

The GNU Makefile build sequence defines -Wno-unsafe-loop-optimizations
for the whole xtest sources while CMake build sequence defines it
specifically for regression_4100.c among xtest source files.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>