### PR TITLE
ta/miss/Android.mk: fix typo

### DIFF
--- a/ta/miss/Android.mk
+++ b/ta/miss/Android.mk
@@ -1,4 +1,4 @@
 LOCAL_PATH := $(call my-dir)
 
-local_module := 528938ce-fc59-11e8-8eb2-f2801f1b9fd1
+local_module := 528938ce-fc59-11e8-8eb2-f2801f1b9fd1.ta
 include $(BUILD_OPTEE_MK)


### PR DESCRIPTION
insert missing ".ta" at the end of filename

Fixes: 15cecff0 ("regression: add tests for panic events handling")
Signed-off-by: Victor Chong <victor.chong@linaro.org>