### PR TITLE
os_test: enable __noprof attribute for call_longjmp()

### DIFF
--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -660,7 +660,7 @@ static TEE_Result test_float(void)
 }
 #endif /*CFG_TA_FLOAT_SUPPORT*/
 
-static __noinline void call_longjmp(jmp_buf env)
+static __noinline __noprof void call_longjmp(jmp_buf env)
 {
 	DMSG("Calling longjmp");
 	longjmp(env, 1);


### PR DESCRIPTION
longjmp() api called from call_longjmp() intentionally corrupts/discards
stack frame of call_longjmp() api to make a long jump to a location
configured via setjmp(). As most of the profilers (esp. function call
graph) relies on correct stack frames to profile trusted applications
which makes this api non-profilable. So lets enable __noprof attribute
for call_longjmp() api.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>