### PR TITLE
regression 4013: add test for device and TA unique keys

### DIFF
--- a/ta/crypt/derive_key_taf.c
+++ b/ta/crypt/derive_key_taf.c
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2019, Linaro Limited
+ */
+
+#include <pta_system.h>
+#include <string.h>
+#include <tee_internal_api.h>
+
+#include "derive_key_taf.h"
+
+#define TA_DERIVED_KEY_MIN_SIZE		16
+#define TA_DERIVED_KEY_MAX_SIZE		32
+#define TA_DERIVED_EXTRA_DATA_MAX_SIZE	1024
+
+static const TEE_UUID system_uuid = PTA_SYSTEM_UUID;
+
+/*
+ * Helper function that just derives a key.
+ */
+static TEE_Result derive_unique_key(TEE_TASessionHandle session,
+				    uint8_t *key, uint16_t key_size,
+				    uint8_t *extra, uint16_t extra_size)
+{
+	TEE_Param params[TEE_NUM_PARAMS] = { 0 };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t ret_origin = 0;
+	uint32_t param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+					       TEE_PARAM_TYPE_MEMREF_OUTPUT,
+					       TEE_PARAM_TYPE_NONE,
+					       TEE_PARAM_TYPE_NONE);
+	if (extra && extra_size > 0) {
+		params[0].memref.buffer = extra;
+		params[0].memref.size = extra_size;
+	}
+
+	params[1].memref.buffer = key;
+	params[1].memref.size = key_size;
+
+	res = TEE_InvokeTACommand(session, 0, PTA_SYSTEM_DERIVE_TA_UNIQUE_KEY,
+				  param_types, params, &ret_origin);
+	if (res != TEE_SUCCESS)
+		EMSG("Failure when calling PTA_SYSTEM_DERIVE_TA_UNIQUE_KEY");
+
+	return res;
+}
+
+TEE_Result derive_ta_unique_key_test(uint32_t param_types,
+				     TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	size_t i = 0;
+	TEE_Result res_final = TEE_SUCCESS;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_TASessionHandle session = TEE_HANDLE_NULL;
+	uint8_t big_key[64] = { };
+	uint8_t extra_key_data[] = { "My dummy data" };
+	uint8_t key1[32] = { };
+	uint8_t key2[32] = { };
+	uint32_t ret_origin = 0;
+
+	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE,
+					   TEE_PARAM_TYPE_NONE,
+					   TEE_PARAM_TYPE_NONE,
+					   TEE_PARAM_TYPE_NONE))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = TEE_OpenTASession(&system_uuid, 0, 0, NULL, &session,
+				&ret_origin);
+
+	if (res != TEE_SUCCESS)
+		return res;
+
+	/*
+	 * Testing for successful calls to the PTA and that two calls with same
+	 * input data generates the same output data (keys).
+	 */
+	res = derive_unique_key(session, key1, sizeof(key1), NULL, 0);
+	if (res != TEE_SUCCESS)
+		res_final = TEE_ERROR_GENERIC;
+
+	res = derive_unique_key(session, key2, sizeof(key2), NULL, 0);
+	if (res != TEE_SUCCESS)
+		res_final = TEE_ERROR_GENERIC;
+
+	if (TEE_MemCompare(key1, key2, sizeof(key1)) != 0)
+		res_final = TEE_ERROR_GENERIC;
+
+	TEE_MemFill(key1, 0, sizeof(key1));
+	TEE_MemFill(key2, 0, sizeof(key2));
+
+	/*
+	 * Testing for successful calls to the PTA and that two calls with same
+	 * input data generates the same output data (keys). Here we are using
+	 * extra data also.
+	 */
+	res = derive_unique_key(session, key1, sizeof(key1), extra_key_data,
+				sizeof(extra_key_data));
+	if (res != TEE_SUCCESS)
+		res_final = TEE_ERROR_GENERIC;
+
+	res = derive_unique_key(session, key2, sizeof(key2), extra_key_data,
+				sizeof(extra_key_data));
+	if (res != TEE_SUCCESS)
+		res_final = TEE_ERROR_GENERIC;
+
+	if (TEE_MemCompare(key1, key2, sizeof(key1)) != 0)
+		res_final = TEE_ERROR_GENERIC;
+
+	TEE_MemFill(key1, 0, sizeof(key1));
+	TEE_MemFill(key2, 0, sizeof(key2));
+
+	/*
+	 * Testing for successful calls to the PTA and that two calls with
+	 * different input data do not generate the same output data (keys). We
+	 * do that by using one key with and one key without extra data.
+	 */
+	res = derive_unique_key(session, key1, sizeof(key1), extra_key_data,
+				sizeof(extra_key_data));
+	if (res != TEE_SUCCESS)
+		res_final = TEE_ERROR_GENERIC;
+
+	res = derive_unique_key(session, key2, sizeof(key2), NULL, 0);
+	if (res != TEE_SUCCESS)
+		res_final = TEE_ERROR_GENERIC;
+
+	/* They should not be equal */
+	if (TEE_MemCompare(key1, key2, sizeof(key1)) == 0)
+		res_final = TEE_ERROR_GENERIC;
+
+	TEE_MemFill(key1, 0, sizeof(key1));
+	TEE_MemFill(key2, 0, sizeof(key2));
+
+	/*
+	 * Testing limits for extra data size (if this would success, then we
+	 * would overwrite the buffer extra_key_data also).
+	 */
+	res = derive_unique_key(session, key1, sizeof(key1), extra_key_data,
+				TA_DERIVED_EXTRA_DATA_MAX_SIZE + 1);
+	/* This shall fail */
+	if (res == TEE_SUCCESS)
+		res_final = TEE_ERROR_GENERIC;
+
+	TEE_MemFill(key1, 0, sizeof(key1));
+
+	/* Testing limits. */
+	for (i = 0; i < sizeof(big_key); i++) {
+		uint8_t *extra = NULL;
+		uint8_t extra_size = 0;
+
+		TEE_MemFill(big_key, 0, sizeof(big_key));
+
+		/* Alternate between using and not using extra data. */
+		if (i % 2) {
+			extra = extra_key_data;
+			extra_size = sizeof(extra_key_data);
+		}
+
+		res = derive_unique_key(session, big_key, i, extra, extra_size);
+		if (i < TA_DERIVED_KEY_MIN_SIZE) {
+			if (res != TEE_SUCCESS)
+				continue;
+
+			EMSG("Small key test iteration %d failed", i);
+			res_final = TEE_ERROR_GENERIC;
+			break;
+		}
+
+		if (i > TA_DERIVED_KEY_MAX_SIZE) {
+			if (res != TEE_SUCCESS)
+				continue;
+
+			EMSG("Big key test iteration %d failed", i);
+			res_final = TEE_ERROR_GENERIC;
+			break;
+		}
+
+		if (res != TEE_SUCCESS) {
+			res_final = TEE_ERROR_GENERIC;
+			break;
+		}
+	}
+
+	TEE_CloseTASession(session);
+
+	return res_final;
+}
+
+TEE_Result derive_ta_unique_key_test_shm(uint32_t param_types,
+					 TEE_Param params[TEE_NUM_PARAMS])
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	TEE_TASessionHandle session = TEE_HANDLE_NULL;
+	uint32_t ret_origin = 0;
+
+	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+					   TEE_PARAM_TYPE_MEMREF_OUTPUT,
+					   TEE_PARAM_TYPE_NONE,
+					   TEE_PARAM_TYPE_NONE))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = TEE_OpenTASession(&system_uuid, 0, 0, NULL, &session,
+				&ret_origin);
+
+	if (res != TEE_SUCCESS)
+		return res;
+
+	/*
+	 * Testing for unsuccessful calls to the PTA. They should be
+	 * unsuccessful since we are using an out buffer coming from normal
+	 * world.
+	 */
+	res = TEE_InvokeTACommand(session, 0, PTA_SYSTEM_DERIVE_TA_UNIQUE_KEY,
+				  param_types, params, &ret_origin);
+err:
+	TEE_CloseTASession(session);
+
+	return res;
+}

--- a/ta/crypt/include/derive_key_taf.h
+++ b/ta/crypt/include/derive_key_taf.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019, Linaro Limited
+ */
+
+#ifndef DERIVE_KEY_TAF_H
+#define DERIVE_KEY_TAF_H
+
+#include <tee_internal_api.h>
+
+TEE_Result derive_ta_unique_key_test(uint32_t param_types,
+				     TEE_Param params[4]);
+TEE_Result derive_ta_unique_key_test_shm(uint32_t param_types,
+					 TEE_Param params[4]);
+#endif

--- a/ta/crypt/include/ta_crypt.h
+++ b/ta/crypt/include/ta_crypt.h
@@ -611,4 +611,22 @@
  */
 #define TA_CRYPT_CMD_ARITH_COMPUTE_FMM		76
 
+/*
+ * system PTA is used for deriving device and TA unique keys. This function in
+ * the "crypt" TA is testing the key derivation.
+ */
+#define TA_CRYPT_CMD_DERIVE_TA_UNIQUE_KEY	77
+
+/*
+ * system PTA is used for deriving device and TA unique keys. This function in
+ * the "crypt" TA is testing the key derivation. This function tries to derive
+ * keys by using shared memory buffers (something that shall fail).
+ *
+ * in  params[0].memref.buffer     Buffer for extra data
+ * in  params[0].memref.size       Size of extra data
+ * out params[1].memref.buffer     Buffer for the derived key
+ * out params[1].memref.size       Size of the derived key
+ */
+#define TA_CRYPT_CMD_DERIVE_TA_UNIQUE_KEY_SHM	78
+
 #endif /*TA_CRYPT_H */

--- a/ta/crypt/sub.mk
+++ b/ta/crypt/sub.mk
@@ -2,6 +2,7 @@ global-incdirs-y += include
 srcs-y += aes_impl.c
 srcs-y += aes_taf.c
 srcs-y += cryp_taf.c
+srcs-y += derive_key_taf.c
 srcs-y += sha2_impl.c
 srcs-y += sha2_taf.c
 srcs-$(CFG_SYSTEM_PTA) += seed_rng_taf.c

--- a/ta/crypt/ta_entry.c
+++ b/ta/crypt/ta_entry.c
@@ -28,6 +28,7 @@
 #include <aes_taf.h>
 #include <arith_taf.h>
 #include <cryp_taf.h>
+#include <derive_key_taf.h>
 #include <mbedtls_taf.h>
 #include <seed_rng_taf.h>
 #include <sha2_taf.h>
@@ -233,6 +234,10 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 #ifdef CFG_SYSTEM_PTA
 	case TA_CRYPT_CMD_SEED_RNG_POOL:
 		return seed_rng_pool(nParamTypes, pParams);
+	case TA_CRYPT_CMD_DERIVE_TA_UNIQUE_KEY:
+		return derive_ta_unique_key_test(nParamTypes, pParams);
+	case TA_CRYPT_CMD_DERIVE_TA_UNIQUE_KEY_SHM:
+		return derive_ta_unique_key_test_shm(nParamTypes, pParams);
 #endif
 	case TA_CRYPT_CMD_ARITH_NEW_VAR:
 		return ta_entry_arith_new_var(nParamTypes, pParams);


### PR DESCRIPTION
Adds test cases that tests the system pTA that derives device and TA unique keys.

This depends on https://github.com/OP-TEE/optee_os/pull/3053, which means that IBART will fail as long as optee_os:3053 hasn't been merged.

Note that I've only added two calls from xtest and do most testing in the ta_crypt TA function(s) itself. That makes it easy to write tests, but makes it less clear to understand what failed when something goes wrong. Having that said, I can split up `derive_ta_unique_key_test(...)` into a few more functions that will be called one by one from xtest separately if you think that is better. It'll be a bit more boiler plate code, but it's probably cleaner and would generate better output from xtest. Let me know what you think.