### PR TITLE
regression: fix memory leakage in case 1010

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -496,7 +496,7 @@ static void xtest_tee_test_invalid_mem_access2(ADBG_Case_t *c, unsigned int n,
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &os_test_ta_uuid, NULL,
 		                        &ret_orig)))
-		return;
+		goto rel_shm;
 
 	op.params[0].value.a = (uint32_t)n;
 	op.params[1].memref.parent = &shm;
@@ -517,6 +517,8 @@ static void xtest_tee_test_invalid_mem_access2(ADBG_Case_t *c, unsigned int n,
 	(void)ADBG_EXPECT_TEEC_ERROR_ORIGIN(c, TEEC_ORIGIN_TEE, ret_orig);
 
 	TEEC_CloseSession(&session);
+rel_shm:
+	TEEC_ReleaseSharedMemory(&shm);
 }
 
 static void xtest_tee_test_1005(ADBG_Case_t *c)


### PR DESCRIPTION
In regression test case 1010 xtest_tee_test_invalid_mem_access2()
allocates shared memory, but doesn't free it. This can affect other test
cases run after this case.

The shared memory is freed when the context is finalized, but that can
be too late since it normally happens when xtest exits.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>