### PR TITLE
Add regression 1022 to test dlopen()/dlsym()/dlclose()

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -1717,3 +1717,29 @@ static void xtest_tee_test_1021(ADBG_Case_t *c)
 }
 ADBG_CASE_DEFINE(regression, 1021, xtest_tee_test_1021,
 		 "Test panic context release");
+
+static void xtest_tee_test_1022(ADBG_Case_t *c)
+{
+	TEEC_Session session = { 0 };
+	uint32_t ret_orig = 0;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+			xtest_teec_open_session(&session, &os_test_ta_uuid,
+				NULL, &ret_orig)))
+		return;
+
+	(void)ADBG_EXPECT_TEEC_SUCCESS(c,
+		TEEC_InvokeCommand(&session, TA_OS_TEST_CMD_CALL_LIB_DL, NULL,
+				   &ret_orig));
+
+	(void)ADBG_EXPECT_TEEC_RESULT(c,
+		TEEC_ERROR_TARGET_DEAD,
+		TEEC_InvokeCommand(&session, TA_OS_TEST_CMD_CALL_LIB_DL_PANIC,
+				   NULL, &ret_orig));
+
+	(void)ADBG_EXPECT_TEEC_ERROR_ORIGIN(c, TEEC_ORIGIN_TEE, ret_orig);
+
+	TEEC_CloseSession(&session);
+}
+ADBG_CASE_DEFINE(regression, 1022, xtest_tee_test_1022,
+		"Test dlopen()/dlsym()/dlclose() API");

--- a/ta/Makefile
+++ b/ta/Makefile
@@ -21,6 +21,7 @@ endif
 TA_DIRS := create_fail_test \
 	   crypt \
 	   $(OS_TEST_LIB) \
+	   os_test_lib_dl \
 	   os_test \
 	   rpc_test \
 	   sims \

--- a/ta/os_test/Makefile
+++ b/ta/os_test/Makefile
@@ -10,4 +10,6 @@ ifeq ($(CFG_TA_DYNLINK),y)
 LDADD = -L$(subst os_test,os_test_lib,$(abspath $(link-out-dir))) -los_test
 endif
 
+LDADD += -ldl
+
 include ../ta_common.mk

--- a/ta/os_test/include/os_test.h
+++ b/ta/os_test/include/os_test.h
@@ -44,5 +44,7 @@ TEE_Result ta_entry_ta2ta_memref_mix(uint32_t param_types,
 TEE_Result ta_entry_params(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_call_lib(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_call_lib_panic(uint32_t param_types, TEE_Param params[4]);
+TEE_Result ta_entry_call_lib_dl(uint32_t param_types, TEE_Param params[4]);
+TEE_Result ta_entry_call_lib_dl_panic(uint32_t param_types, TEE_Param params[4]);
 
 #endif /*OS_TEST_H */

--- a/ta/os_test/include/ta_os_test.h
+++ b/ta/os_test/include/ta_os_test.h
@@ -46,5 +46,7 @@
 #define TA_OS_TEST_CMD_PARAMS               13
 #define TA_OS_TEST_CMD_CALL_LIB             14
 #define TA_OS_TEST_CMD_CALL_LIB_PANIC       15
+#define TA_OS_TEST_CMD_CALL_LIB_DL          16
+#define TA_OS_TEST_CMD_CALL_LIB_DL_PANIC    17
 
 #endif /*TA_OS_TEST_H */

--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -115,6 +115,12 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_OS_TEST_CMD_CALL_LIB_PANIC:
 		return ta_entry_call_lib_panic(nParamTypes, pParams);
 
+	case TA_OS_TEST_CMD_CALL_LIB_DL:
+		return ta_entry_call_lib_dl(nParamTypes, pParams);
+
+	case TA_OS_TEST_CMD_CALL_LIB_DL_PANIC:
+		return ta_entry_call_lib_dl_panic(nParamTypes, pParams);
+
 	default:
 		return TEE_ERROR_BAD_PARAMETERS;
 	}

--- a/ta/os_test_lib_dl/Android.mk
+++ b/ta/os_test_lib_dl/Android.mk
@@ -1,0 +1,4 @@
+LOCAL_PATH := $(call my-dir)
+
+local_module := b3091a65-9751-4784-abf7-0298a7cc35ba.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/os_test_lib_dl/Makefile
+++ b/ta/os_test_lib_dl/Makefile
@@ -1,0 +1,5 @@
+include $(TA_DEV_KIT_DIR)/mk/conf.mk
+
+SHLIBNAME = libos_test_dl
+SHLIBUUID = b3091a65-9751-4784-abf7-0298a7cc35ba
+include ../ta_common.mk

--- a/ta/os_test_lib_dl/include/os_test_lib_dl.h
+++ b/ta/os_test_lib_dl/include/os_test_lib_dl.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2019, Linaro Limited
+ */
+
+#ifndef _OS_TEST_LIB_DL_H_
+#define _OS_TEST_LIB_DL_H_
+
+int os_test_shlib_dl_add(int a, int b);
+void os_test_shlib_dl_panic(void);
+
+#endif /* _OS_TEST_LIB_DL_H_ */

--- a/ta/os_test_lib_dl/os_test_lib_dl.c
+++ b/ta/os_test_lib_dl/os_test_lib_dl.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2018-2019, Linaro Limited
+ */
+
+#include <os_test_lib_dl.h>
+#include <tee_internal_api.h>
+
+int os_test_shlib_dl_add(int a, int b)
+{
+	return a + b;
+}
+
+void os_test_shlib_dl_panic(void)
+{
+	TEE_Panic(0);
+}

--- a/ta/os_test_lib_dl/sub.mk
+++ b/ta/os_test_lib_dl/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += include
+srcs-y += os_test_lib_dl.c


### PR DESCRIPTION
Adds a new test case for the dynamic link API in libdl.
- A new shared library is added in ta/os_test_lib_dl.
- In xtest 1022, the dl API is used to load the test library and
  retrieve pointers to functions.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>