### PR TITLE
cmake: support OpenSSL in non-standard locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.2)
+cmake_minimum_required (VERSION 3.4)
 project (optee_test C)
 
 # Default cross compile settings

--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 find_package(OpenSSL)
 if(OPENSSL_FOUND)
 	add_compile_options(-DOPENSSL_FOUND=1)
-	set (OPENSSL_PRIVATE_LINK crypto)
+	set (OPENSSL_PRIVATE_LINK OpenSSL::Crypto)
 endif()
 
 include(GNUInstallDirs)


### PR DESCRIPTION
When OpenSSL exists in a non-standard location, compilation
fails:
```bash
    export OPENSSL_ROOT_DIR=/usr/local/openssl
    cmake ...
    make ...
    | gcc  -Ihost/xtest/. -Ihost/xtest/adbg/include -Ihost/xtest/xml/include \
           -I<user-ta>/host_include -Ihost/xtest -Ita/include \
           -Ita/aes_perf/include -Ita/concurrent/include \
           -Ita/concurrent_large/include -Ita/create_fail_test/include \
           -Ita/crypt/include -Ita/enc_fs/include -Ita/os_test/include \
           -Ita/rpc_test/include -Ita/sdp_basic/include -Ita/sha_perf/include \
           -Ita/sims/include -Ita/miss/include -Ita/sims_keepalive/include \
           -Ita/socket/include -Ita/storage_benchmark/include ... \
           -DOPENSSL_FOUND=1 ... \
           -MD -MT host/xtest/CMakeFiles/xtest.dir/regression_8100.c.o \
           -MF host/xtest/CMakeFiles/xtest.dir/regression_8100.c.o.d \
           -o host/xtest/CMakeFiles/xtest.dir/regression_8100.c.o \
           -c host/xtest/regression_8100.c
    | host/xtest/regression_8100.c:17:10: fatal error: openssl/x509_vfy.h: No such file or directory
    |  #include <openssl/x509_vfy.h>
    |           ^~~~~~~~~~~~~~~~~~~~
    | compilation terminated.
```
The reason is that while CMake will find OpenSSL using above export,
and also populate various variables to access the result, those
variables aren't being used in here.

In particular, CMake adds 'Imported Targets' variables that are
meant to be used, OpenSSL::Crypto in this case. They serve multiple
purposes:
   * library (file names) are abstracted away
   * specific include paths are added automatically to the compiler
     command line where needed

So this here needs to switch over to using those.

Note that support for OpenSSL imported targets was added in CMake
v3.4 only and hence we also have to bump the minimum required
version to reflect that fact. Given v3.4 was releasd in 2015,
this is not deemed to be an issue.

Signed-off-by: André Draszik <andre.draszik@jci.com>