### PR TITLE
Set use of a valid public point for ECDSA operation in test 4009

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -4860,15 +4860,16 @@ static void xtest_tee_test_4009(ADBG_Case_t *c)
 			       TEE_ATTR_ECC_PRIVATE_VALUE,
 			       pt->private, size_bytes);
 		/*
-		 * The public value is not used. This is why we provide
-		 * another buffer
+		 * The public value is not used, but we should provide a valid
+		 * one to avoid rejection in case TEE_PopulateTransientObject()
+		 * checks for key validity.
 		 */
 		xtest_add_attr(&param_count, params,
-				TEE_ATTR_ECC_PUBLIC_VALUE_X,
-			       pt->private, size_bytes);
+			       TEE_ATTR_ECC_PUBLIC_VALUE_X,
+			       pt->public_x, size_bytes);
 		xtest_add_attr(&param_count, params,
-				TEE_ATTR_ECC_PUBLIC_VALUE_Y,
-			       pt->private, size_bytes);
+			       TEE_ATTR_ECC_PUBLIC_VALUE_Y,
+			       pt->public_y, size_bytes);
 
 		if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 				ta_crypt_cmd_populate_transient_object(c,


### PR DESCRIPTION
As described in issue #363, this patch is to support a valid key rather than providing incorrect public part.

The comment states something true, X and Y are not used (otherwise the test would fail), but some implementations might check the validity of the point in order to accept populating the key.