### PR TITLE
xtest/Makefile: drop COMPILE_NS_USER and detect arch automatically

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -24,6 +24,15 @@ OBJCOPY		?= $(CROSS_COMPILE)objcopy
 OBJDUMP		?= $(CROSS_COMPILE)objdump
 READELF		?= $(CROSS_COMPILE)readelf
 
+# Macros to detect the targeted architecture (e.g., arm-linux-gnueabihf or
+# aarch64-linux-gnu) and the corresponding bit size (32 or 64).
+define cc-arch
+$(shell $(1) -v 2>&1 | grep Target | sed 's/Target: \([^-]*\).*/\1/')
+endef
+define cc-bits
+$(if $(filter arm, $(1)),32,$(if $(filter aarch64, $(1)),64,unknown-arch))
+endef
+
 # OpenSSL is used by GP tests series 8500 and Mbed TLS test 8103
 ifneq ($(CFG_GP_PACKAGE_PATH)$(filter y,$(CFG_TA_MBEDTLS)),)
 CFLAGS += -DOPENSSL_FOUND=1
@@ -32,7 +41,7 @@ LDFLAGS += -lcrypto
 CFLAGS += -I$(OPTEE_OPENSSL_EXPORT)
 else #OPTEE_OPENSSL_EXPORT
 CFLAGS += -I../openssl/include
-ifeq ($(COMPILE_NS_USER),32)
+ifeq ($(call cc-bits, $(call cc-arch, $(CC))),32)
 LDFLAGS += ../openssl/lib/arm/libcrypto.a -ldl
 else
 LDFLAGS += ../openssl/lib/aarch64/libcrypto.a -ldl
@@ -131,13 +140,6 @@ CFLAGS += -I../../ta/GP_TTA_answerSuccessTo_OpenSession_Invoke
 CFLAGS += -I../../ta/GP_TTA_check_OpenSession_with_4_parameters
 CFLAGS += -I../../ta/GP_TTA_testingClientAPI
 
-
-# by default, the client application is compiled as the kernel of optee-os
-ifeq ($(CFG_ARM32_core),y)
-COMPILE_NS_USER ?= 32
-else
-COMPILE_NS_USER ?= 64
-endif
 
 endif
 


### PR DESCRIPTION
COMPILE_NS_USER is used by the xtest Makefile to link against either
the 32-bit or 64-bit version of OpenSSL (libcrypto.a). Historically,
the top level Makefile of the OP-TEE build project would take
COMPILE_NS_USER as an input, with value 32 or 64, and derive the path
to the appropriate cross-compiler. But given that the cross-compiler
may also be customized via CROSS_COMPILE/CROSS_COMPILE_HOST,
inconsistencies can happen.

There is no reason to keep COMPILE_NS_USER, since its value can be
derived from the compiler itself. This commit adds macros to do just
that and uses them to select the proper libcrypto library.

Signed-off-by: Jerome Forissier <jerome@forissier.org>
Reported-by: Denys Dmytriyenko <denys@ti.com>