### PR TITLE
regression_4100.c: convert_from_string(): fix length of output buffer

### DIFF
--- a/host/xtest/regression_4100.c
+++ b/host/xtest/regression_4100.c
@@ -437,7 +437,7 @@ static TEEC_Result convert_from_string(ADBG_Case_t *c, TEEC_Session *s,
 	TEEC_Result res = TEEC_ERROR_BAD_FORMAT;
 	size_t spos = strlen(str);
 	int32_t sign = 1;
-	size_t os_len = spos / 2 + 1;
+	size_t os_len = (spos + 1) / 2;
 	uint8_t *os = calloc(1, os_len);
 	int ospos = os_len - 1;
 	int nibble = 0;


### PR DESCRIPTION
convert_from_string() takes an hexadecimal character string and
converts it to binary. The size of the output buffer is computed from
the length of the input string, but the computation is wrong. Fix it.

Signed-off-by: Jerome Forissier <jerome@forissier.org>