### PR TITLE
use python3 instead of python

### DIFF
--- a/scripts/file_to_c.py
+++ b/scripts/file_to_c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # SPDX-License-Identifier: BSD-2-Clause
 #
 # Copyright (c) 2018, Linaro Limited
@@ -29,7 +29,7 @@ def main():
 
     f.write("const uint8_t " + args.name + "[] = {\n")
     i = 0
-    for x in array.array("B", inf.read()):
+    for x in array.array("B", map(ord, (inf.read()))):
         f.write("0x" + '{0:02x}'.format(x) + ",")
         i = i + 1
         if i % 8 == 0:

--- a/scripts/rsp_to_gcm_test.py
+++ b/scripts/rsp_to_gcm_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 modes = {'encrypt': 0, 'decrypt': 1}
 


### PR DESCRIPTION
use python3 instead of python as python2 is EOL January 2020.

Signed-off-by: Scott Branden <scott.branden@broadcom.com>