### PR TITLE
aes-perf, sha-perf: fix build with 64bit time_t on 32bit arches

### DIFF
--- a/host/xtest/aes_perf.c
+++ b/host/xtest/aes_perf.c
@@ -470,8 +470,8 @@ void aes_perf_run_test(int mode, int keysize, int decrypt, size_t size, size_t u
 		perror("clock_getres");
 		return;
 	}
-	vverbose("Clock resolution is %lu ns\n",
-					ts.tv_sec * 1000000000 + ts.tv_nsec);
+	vverbose("Clock resolution is %jd ns\n",
+		 (intmax_t)ts.tv_sec * 1000000000 + ts.tv_nsec);
 
 	vverbose("input test buffer:  %s\n", buf_type_str(input_buffer));
 	vverbose("output test buffer: %s\n", buf_type_str(output_buffer));

--- a/host/xtest/sha_perf.c
+++ b/host/xtest/sha_perf.c
@@ -320,8 +320,8 @@ extern void sha_perf_run_test(int algo, size_t size, unsigned int n,
 		perror("clock_getres");
 		return;
 	}
-	vverbose("Clock resolution is %lu ns\n", ts.tv_sec*1000000000 +
-		ts.tv_nsec);
+	vverbose("Clock resolution is %jd ns\n",
+		 (intmax_t)ts.tv_sec * 1000000000 + ts.tv_nsec);
 
 	open_ta();
 	prepare_op(algo);


### PR DESCRIPTION
| host/xtest/aes_perf.c: In function 'aes_perf_run_test':
| host/xtest/aes_perf.c:473:11: error: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'time_t' {aka 'long long int'} [-Werror=format=]
|   473 |  vverbose("Clock resolution is %lu ns\n",
|       |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|   474 |      ts.tv_sec * 1000000000 + ts.tv_nsec);
|       |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|       |                             |
|       |                             time_t {aka long long int}
| host/xtest/crypto_common.h:56:11: note: in definition of macro '_verbose'
|    56 |    printf(__VA_ARGS__); \
|       |           ^~~~~~~~~~~
| host/xtest/aes_perf.c:473:2: note: in expansion of macro 'vverbose'
|   473 |  vverbose("Clock resolution is %lu ns\n",
|       |  ^~~~~~~~
| host/xtest/aes_perf.c:473:34: note: format string is defined here
|   473 |  vverbose("Clock resolution is %lu ns\n",
|       |                                ~~^
|       |                                  |
|       |                                  long unsigned int
|       |                                %llu

| host/xtest/sha_perf.c: In function 'sha_perf_run_test':
| host/xtest/sha_perf.c:323:11: error: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'time_t' {aka 'long long int'} [-Werror=format=]
|   323 |  vverbose("Clock resolution is %lu ns\n", ts.tv_sec*1000000000 +
|       |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~
|       |                                                                |
|       |                                                                time_t {aka long long int}
|   324 |   ts.tv_nsec);
|       |   ~~~~~~~~~~
| host/xtest/crypto_common.h:56:11: note: in definition of macro '_verbose'
|    56 |    printf(__VA_ARGS__); \
|       |           ^~~~~~~~~~~
| host/xtest/sha_perf.c:323:2: note: in expansion of macro 'vverbose'
|   323 |  vverbose("Clock resolution is %lu ns\n", ts.tv_sec*1000000000 +
|       |  ^~~~~~~~
| host/xtest/sha_perf.c:323:34: note: format string is defined here
|   323 |  vverbose("Clock resolution is %lu ns\n", ts.tv_sec*1000000000 +
|       |                                ~~^
|       |                                  |
|       |                                  long unsigned int
|       |                                %llu
| cc1: all warnings being treated as errors

The code has two problems:
1) it assumes time_t is unsigned
2) it assumes time_t is the same as unsigned long

1) rarely is true
2) is not true on 32bit architectures which have a 64bit time_t

Fix by appropriate casting and an updated printf format specifier.

Signed-off-by: André Draszik <andre.draszik@jci.com>