### PR TITLE
GitHub: sync GitHub templates and actions from build.git

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,21 @@
+<!--
+    General guidance when creating issues:
+
+    1. Please try to remember to close the issue when you have
+       got an answer to your question.
+
+    2. It never hurts to state which commit or release tag you are using in case
+       the question is about build issues.
+
+    3. Try to use GitHub markdown formatting to make your issue more readable:
+         https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code
+
+    4. Try to search for the issue before posting the question:
+         -> Issues tab -> Filters
+
+    5. Check the FAQ before posting a question:
+         https://optee.readthedocs.io/faq/faq.html
+
+    NOTE: This comment will not be shown in the issue, so no harm keeping it,
+    but feel free to remove it if you like.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+    If you are new to submitting pull requests to OP-TEE, then please have a
+    look at the list below and tick them off before submitting the pull request.
+
+    1. Read our contribution guidelines:
+         https://optee.readthedocs.io/general/contribute.html
+
+    2. Read the contribution section in Notice.md and pay extra attention to the
+       "Developer Certificate of Origin" in the contribution guidelines.
+
+    3. You should run checkpatch preferably before submitting the pull request.
+
+    4. When everything has been reviewed, you will need to squash, rebase and
+       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
+       about this can also be found on the link provided above.
+
+    NOTE: This comment will not be shown in the pull request, so no harm keeping
+    it, but feel free to remove it if you like.
+-->

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -1,0 +1,17 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "16 00 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been marked as a stale issue because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 5 days. Note, that you can always re-open a closed issue at any time.'
+        stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 5 days. Note, that you can always re-open a closed pull request at any time.'
+        exempt-issue-label: 'bug'
+        days-before-stale: 30
+        days-before-close: 5


### PR DESCRIPTION
Since "optee_os" and "build" both have reached an almost clean and up-to-date state, let's continue with adding templates and actions to the "optee_test" git also.

The GitHub templates and actions are useful to the "optee_test" git
also, therefore recursively sync up (copy) the .github folder from
build.git.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>