### PR TITLE
Add regression 1023 (ELF initialization via .init_array)

### DIFF
--- a/ta/os_test/include/os_test.h
+++ b/ta/os_test/include/os_test.h
@@ -46,5 +46,6 @@ TEE_Result ta_entry_call_lib(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_call_lib_panic(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_call_lib_dl(uint32_t param_types, TEE_Param params[4]);
 TEE_Result ta_entry_call_lib_dl_panic(uint32_t param_types, TEE_Param params[4]);
+TEE_Result ta_entry_get_global_var(uint32_t param_types, TEE_Param params[4]);
 
 #endif /*OS_TEST_H */

--- a/ta/os_test/include/ta_os_test.h
+++ b/ta/os_test/include/ta_os_test.h
@@ -48,5 +48,6 @@
 #define TA_OS_TEST_CMD_CALL_LIB_PANIC       15
 #define TA_OS_TEST_CMD_CALL_LIB_DL          16
 #define TA_OS_TEST_CMD_CALL_LIB_DL_PANIC    17
+#define TA_OS_TEST_CMD_GET_GLOBAL_VAR       18
 
 #endif /*TA_OS_TEST_H */

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -1166,3 +1166,27 @@ err:
 	dlclose(handle);
 	return res;
 }
+
+/* ELF initialization/finalization test */
+
+int os_test_global;
+
+static void __attribute__((constructor)) os_test_init(void)
+{
+	os_test_global *= 10;
+	os_test_global += 1;
+	DMSG("os_test_global=%d", os_test_global);
+}
+
+TEE_Result ta_entry_get_global_var(uint32_t param_types, TEE_Param params[4])
+{
+	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+					   TEE_PARAM_TYPE_NONE,
+					   TEE_PARAM_TYPE_NONE,
+					   TEE_PARAM_TYPE_NONE))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	params[0].value.a = os_test_global;
+
+	return TEE_SUCCESS;
+}

--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -121,6 +121,9 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_OS_TEST_CMD_CALL_LIB_DL_PANIC:
 		return ta_entry_call_lib_dl_panic(nParamTypes, pParams);
 
+	case TA_OS_TEST_CMD_GET_GLOBAL_VAR:
+		return ta_entry_get_global_var(nParamTypes, pParams);
+
 	default:
 		return TEE_ERROR_BAD_PARAMETERS;
 	}

--- a/ta/os_test_lib/os_test_lib.c
+++ b/ta/os_test_lib/os_test_lib.c
@@ -5,6 +5,16 @@
 
 #include "os_test_lib.h"
 #include <tee_internal_api.h>
+#include <trace.h>
+
+extern int os_test_global;
+
+static void __attribute__((constructor)) os_test_shlib_init(void)
+{
+	os_test_global *= 10;
+	os_test_global += 2;
+	DMSG("os_test_global=%d", os_test_global);
+}
 
 int os_test_shlib_add(int a, int b)
 {

--- a/ta/os_test_lib_dl/os_test_lib_dl.c
+++ b/ta/os_test_lib_dl/os_test_lib_dl.c
@@ -5,6 +5,16 @@
 
 #include <os_test_lib_dl.h>
 #include <tee_internal_api.h>
+#include <trace.h>
+
+extern int os_test_global;
+
+static void __attribute__((constructor)) os_test_shlib_dl_init(void)
+{
+	os_test_global *= 10;
+	os_test_global += 3;
+	DMSG("os_test_global=%d", os_test_global);
+}
 
 int os_test_shlib_dl_add(int a, int b)
 {


### PR DESCRIPTION
Adds a test case for the ELF initialization functions (.init_array
section).

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
