### PR TITLE
fix resource leak in sock_server_init

### DIFF
--- a/host/xtest/sock_server.c
+++ b/host/xtest/sock_server.c
@@ -348,6 +348,8 @@ static bool sock_server_init(struct sock_server *ts, struct sock_io_cb *cb,
 	for (ai = ai0; ai; ai = ai->ai_next)
 		sock_server_add_fd(ts, ai);
 
+	freeaddrinfo(ai0);
+
 	if (!ts->num_binds)
 		return false;
 


### PR DESCRIPTION
Free addrinfo obtained through getaddrinfo().
Otherwise, it results in resource leak.

Signed-off-by: Rajesh Ravi <rajesh.ravi@broadcom.com>
Signed-off-by: Scott Branden <scott.branden@broadcom.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
