### PR TITLE
regression 4000: prevent array overrun in xtest_tee_test_4011

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -5436,6 +5436,9 @@ static void xtest_tee_test_4011(ADBG_Case_t *c)
 
 		/* 4.3 */
 		n = n + i + tmp_size - m;
+		if (n >= tmp_size)
+			goto out;
+
 		memset(tmp + n, 0, tmp_size - n);
 
 		/* 5 */


### PR DESCRIPTION
Add check of array boundaries in xtest_tee_test_4011()
to prevent any overrun.

Signed-off-by: Rajesh Ravi <rajesh.ravi@broadcom.com>
Signed-off-by: Scott Branden <scott.branden@broadcom.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
