### PR TITLE
fix resource leak and error handling in read_ta

### DIFF
--- a/host/xtest/install_ta.c
+++ b/host/xtest/install_ta.c
@@ -30,7 +30,7 @@ static void *read_ta(const char *dname, const char *fname, size_t *size)
 	char nbuf[PATH_MAX];
 	FILE *f = NULL;
 	void *buf = NULL;
-	size_t s = 0;
+	ssize_t s = 0;
 
 	if (dname)
 		snprintf(nbuf, sizeof(nbuf), "%s/%s", dname, fname);
@@ -45,15 +45,20 @@ static void *read_ta(const char *dname, const char *fname, size_t *size)
 		err(1, "fseek");
 
 	s = ftell(f);
+	if (s < 0) {
+		fclose(f);
+		return NULL;
+	}
 	rewind(f);
 
 	buf = malloc(s);
 	if (!buf)
 		err(1, "malloc(%zu)", s);
 
-	if (fread(buf, 1, s, f) != s)
+	if (fread(buf, 1, s, f) != (size_t)s)
 		err(1, "fread");
 
+	fclose(f);
 	*size = s;
 	return buf;
 }


### PR DESCRIPTION
Fix the FILE pointer resource leak and check the error for ftell() call.

Signed-off-by: Rajesh Ravi <rajesh.ravi@broadcom.com>
Signed-off-by: Scott Branden <scott.branden@broadcom.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
