### PR TITLE
pkcs11 1001: get info from slots

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -11,11 +11,12 @@
  * GNU General Public License for more details.
  */
 
-#include <stdio.h>
-#include <string.h>
+#include <ck_debug.h>
 #include <inttypes.h>
-
 #include <pkcs11.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "xtest_test.h"
 #include "xtest_helpers.h"
@@ -48,3 +49,90 @@ static void xtest_tee_test_1000(ADBG_Case_t *c)
 
 ADBG_CASE_DEFINE(pkcs11, 1000, xtest_tee_test_1000,
 		"Initialize and close Cryptoki library");
+
+static void xtest_tee_test_1001(ADBG_Case_t *c)
+{
+	CK_RV rv = CKR_GENERAL_ERROR;
+	CK_SLOT_ID_PTR slot_ids = NULL;
+	CK_ULONG slot_count = 0;
+	CK_ULONG present_slot_count = 0;
+	CK_INFO lib_info = { };
+	CK_SLOT_INFO slot_info = { };
+	CK_FUNCTION_LIST_PTR ckfunc_list = NULL;
+	size_t i = 0;
+	CK_SLOT_ID max_slot_id = 0;
+
+	rv = C_Initialize(NULL);
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		return;
+
+	rv = C_GetFunctionList(&ckfunc_list);
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto out;
+
+	if (!ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_GetInfo) ||
+	    !ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_GetSlotList) ||
+	    !ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_GetSlotInfo))
+		goto out;
+
+	rv = C_GetInfo(&lib_info);
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto out;
+
+	rv = C_GetSlotList(0, NULL, &slot_count);
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto out;
+
+	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, slot_count, !=, 0))
+		goto out;
+
+	rv = C_GetSlotList(1, NULL, &present_slot_count);
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto out;
+
+	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, slot_count, ==,
+					  present_slot_count))
+		goto out;
+
+	slot_ids = calloc(slot_count, sizeof(CK_SLOT_ID));
+	if (!ADBG_EXPECT_NOT_NULL(c, slot_ids))
+		goto out;
+
+	slot_count--;
+	rv = C_GetSlotList(1, slot_ids, &slot_count);
+	if (!ADBG_EXPECT_CK_RESULT(c, CKR_BUFFER_TOO_SMALL, rv))
+		goto out;
+
+	rv = C_GetSlotList(1, slot_ids, &slot_count);
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto out;
+
+	for (i = 0; i < slot_count; i++) {
+		CK_SLOT_ID slot = slot_ids[i];
+
+		rv = C_GetSlotInfo(slot, &slot_info);
+		if (!ADBG_EXPECT_CK_OK(c, rv))
+			goto out;
+
+		if (max_slot_id < slot)
+			max_slot_id = slot;
+	}
+
+	/* Test invalid slot/token IDs */
+	rv = C_GetSlotInfo(max_slot_id + 1, &slot_info);
+	if (!ADBG_EXPECT_CK_RESULT(c, CKR_SLOT_ID_INVALID, rv))
+		goto out;
+
+	rv = C_GetSlotInfo(ULONG_MAX, &slot_info);
+	if (!ADBG_EXPECT_CK_RESULT(c, CKR_SLOT_ID_INVALID, rv))
+		goto out;
+
+out:
+	free(slot_ids);
+
+	rv = C_Finalize(NULL);
+	ADBG_EXPECT_CK_OK(c, rv);
+}
+
+ADBG_CASE_DEFINE(pkcs11, 1001, xtest_tee_test_1001,
+		 "PKCS11: List PKCS#11 slots and get information from");


### PR DESCRIPTION
Add test to list slots implemented by the PKCS11 TA and get information from. This change tests 
 Cryptoki API functions `C_GetFunctionList()`, `C_GetInfo()`, `C_GetSlotList()` and `C_GetSlotInfo()`.

Depends on https://github.com/OP-TEE/optee_client/pull/190 and https://github.com/OP-TEE/optee_os/pull/3644.