### PR TITLE
pkcs11: test C_GetTokenInfo()

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -66,6 +66,8 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		return;
 
+	Do_ADBG_BeginSubCase(c, "Test C_GetFunctionList()");
+
 	rv = C_GetFunctionList(&ckfunc_list);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto out;
@@ -75,9 +77,15 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 	    !ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_GetSlotInfo))
 		goto out;
 
+	Do_ADBG_EndSubCase(c, "Test C_GetFunctionList()");
+	Do_ADBG_BeginSubCase(c, "Test C_GetInfo()");
+
 	rv = C_GetInfo(&lib_info);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto out;
+
+	Do_ADBG_EndSubCase(c, "Test C_GetInfo()");
+	Do_ADBG_BeginSubCase(c, "Test C_GetSlotList()");
 
 	rv = C_GetSlotList(0, NULL, &slot_count);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
@@ -107,6 +115,9 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto out;
 
+	Do_ADBG_EndSubCase(c, "Test C_GetSlotList()");
+	Do_ADBG_BeginSubCase(c, "Test C_GetSlotInfo()");
+
 	for (i = 0; i < slot_count; i++) {
 		CK_SLOT_ID slot = slot_ids[i];
 
@@ -118,7 +129,9 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 			max_slot_id = slot;
 	}
 
-	/* Test invalid slot/token IDs */
+	Do_ADBG_EndSubCase(c, "Test C_GetSlotInfo()");
+	Do_ADBG_BeginSubCase(c, "Test C_Get*Info() with invalid reference");
+
 	rv = C_GetSlotInfo(max_slot_id + 1, &slot_info);
 	if (!ADBG_EXPECT_CK_RESULT(c, CKR_SLOT_ID_INVALID, rv))
 		goto out;
@@ -128,6 +141,7 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 		goto out;
 
 out:
+	Do_ADBG_EndSubCase(c, NULL);
 	free(slot_ids);
 
 	rv = C_Finalize(NULL);

--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -58,6 +58,7 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 	CK_ULONG present_slot_count = 0;
 	CK_INFO lib_info = { };
 	CK_SLOT_INFO slot_info = { };
+	CK_TOKEN_INFO token_info = { };
 	CK_FUNCTION_LIST_PTR ckfunc_list = NULL;
 	size_t i = 0;
 	CK_SLOT_ID max_slot_id = 0;
@@ -74,7 +75,8 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 
 	if (!ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_GetInfo) ||
 	    !ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_GetSlotList) ||
-	    !ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_GetSlotInfo))
+	    !ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_GetSlotInfo) ||
+	    !ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_GetTokenInfo))
 		goto out;
 
 	Do_ADBG_EndSubCase(c, "Test C_GetFunctionList()");
@@ -116,7 +118,7 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 		goto out;
 
 	Do_ADBG_EndSubCase(c, "Test C_GetSlotList()");
-	Do_ADBG_BeginSubCase(c, "Test C_GetSlotInfo()");
+	Do_ADBG_BeginSubCase(c, "Test C_Get{Slot|Token}Info()");
 
 	for (i = 0; i < slot_count; i++) {
 		CK_SLOT_ID slot = slot_ids[i];
@@ -125,18 +127,30 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 		if (!ADBG_EXPECT_CK_OK(c, rv))
 			goto out;
 
+		rv = C_GetTokenInfo(slot, &token_info);
+		if (!ADBG_EXPECT_CK_OK(c, rv))
+			goto out;
+
 		if (max_slot_id < slot)
 			max_slot_id = slot;
 	}
 
-	Do_ADBG_EndSubCase(c, "Test C_GetSlotInfo()");
+	Do_ADBG_EndSubCase(c, "Test C_Get{Slot|Token}Info()");
 	Do_ADBG_BeginSubCase(c, "Test C_Get*Info() with invalid reference");
 
 	rv = C_GetSlotInfo(max_slot_id + 1, &slot_info);
 	if (!ADBG_EXPECT_CK_RESULT(c, CKR_SLOT_ID_INVALID, rv))
 		goto out;
 
+	rv = C_GetTokenInfo(max_slot_id + 1, &token_info);
+	if (!ADBG_EXPECT_CK_RESULT(c, CKR_SLOT_ID_INVALID, rv))
+		goto out;
+
 	rv = C_GetSlotInfo(ULONG_MAX, &slot_info);
+	if (!ADBG_EXPECT_CK_RESULT(c, CKR_SLOT_ID_INVALID, rv))
+		goto out;
+
+	rv = C_GetTokenInfo(ULONG_MAX, &token_info);
 	if (!ADBG_EXPECT_CK_RESULT(c, CKR_SLOT_ID_INVALID, rv))
 		goto out;
 


### PR DESCRIPTION
* pkcs11 1001: split in sub tests
Define ADBG sub tests per tested API for the friendly traces generated by xtest.

* pkcs11 1001: get info from tokens
Get information from tokens implemented by the PKCS11 TA. This change tests Cryptoki API function C_GetTokenInfo().

Depends on https://github.com/OP-TEE/optee_os/pull/3656 and https://github.com/OP-TEE/optee_client/pull/192.