### PR TITLE
os_test: call_longjmp(): add __noreturn attribute

### DIFF
--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -663,7 +663,7 @@ static TEE_Result test_float(void)
 }
 #endif /*CFG_TA_FLOAT_SUPPORT*/
 
-static __noinline void call_longjmp(jmp_buf env)
+static __noinline __noreturn void call_longjmp(jmp_buf env)
 {
 	DMSG("Calling longjmp");
 	longjmp(env, 1);


### PR DESCRIPTION
call_longjmp() does not return so it should have a __noreturn attribute.
Fixes a Clang warning:

 $ make COMPILER=clang
 ...
   CC      out/os_test.o
 os_test.c:667:1: warning: function 'call_longjmp' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
 {
 ^

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
