### PR TITLE
pkcs11 100x: rename tee_test into pkcs1_test

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -69,7 +69,7 @@ bail:
 	return rv;
 }
 
-static void xtest_tee_test_1000(ADBG_Case_t *c)
+static void xtest_pkcs11_test_1000(ADBG_Case_t *c)
 {
 	CK_RV rv;
 
@@ -95,10 +95,10 @@ static void xtest_tee_test_1000(ADBG_Case_t *c)
 	ADBG_EXPECT_CK_RESULT(c, CKR_CRYPTOKI_NOT_INITIALIZED, rv);
 }
 
-ADBG_CASE_DEFINE(pkcs11, 1000, xtest_tee_test_1000,
-		"Initialize and close Cryptoki library");
+ADBG_CASE_DEFINE(pkcs11, 1000, xtest_pkcs11_test_1000,
+		 "Initialize and close Cryptoki library");
 
-static void xtest_tee_test_1001(ADBG_Case_t *c)
+static void xtest_pkcs11_test_1001(ADBG_Case_t *c)
 {
 	CK_RV rv = CKR_GENERAL_ERROR;
 	CK_SLOT_ID_PTR slot_ids = NULL;
@@ -287,7 +287,7 @@ out:
 	ADBG_EXPECT_CK_OK(c, rv);
 }
 
-ADBG_CASE_DEFINE(pkcs11, 1001, xtest_tee_test_1001,
+ADBG_CASE_DEFINE(pkcs11, 1001, xtest_pkcs11_test_1001,
 		 "PKCS11: List PKCS#11 slots and get information from");
 
 static void xtest_pkcs11_test_1002(ADBG_Case_t *c)


### PR DESCRIPTION
Rename xtest_tee_test_100x() into xtest_pkcs11_test_100x() for
consistency.

Fix a coding style alignment in test 1001.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
