### PR TITLE
regression 1018: out of bounds memref tests ensure TA is not reached

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -1388,7 +1388,7 @@ static void invoke_1byte_out_of_bounds(ADBG_Case_t *c, TEEC_Session *session,
 	ret = TEEC_InvokeCommand(session, TA_OS_TEST_CMD_PARAMS,
 				 &op, &ret_orig);
 
-	ADBG_EXPECT(c, TEEC_ORIGIN_COMMS, ret_orig);
+	ADBG_EXPECT_COMPARE_UNSIGNED(c, ret_orig, !=, TEEC_ORIGIN_TRUSTED_APP);
 	if (ret != TEEC_ERROR_BAD_PARAMETERS && ret != TEEC_ERROR_GENERIC) {
 		ADBG_EXPECT(c, TEEC_ERROR_BAD_PARAMETERS, ret);
 		ADBG_EXPECT(c, TEEC_ERROR_GENERIC, ret);
@@ -1451,7 +1451,7 @@ static void xtest_tee_test_1018(ADBG_Case_t *c)
 	ret = TEEC_InvokeCommand(&session, TA_OS_TEST_CMD_PARAMS, &op,
 				 &ret_orig);
 
-	ADBG_EXPECT(c, TEEC_ORIGIN_COMMS, ret_orig);
+	ADBG_EXPECT_COMPARE_UNSIGNED(c, ret_orig, !=, TEEC_ORIGIN_TRUSTED_APP);
 	if (ret != TEEC_ERROR_BAD_PARAMETERS && ret != TEEC_ERROR_GENERIC) {
 		ADBG_EXPECT(c, TEEC_ERROR_BAD_PARAMETERS, ret);
 		ADBG_EXPECT(c, TEEC_ERROR_GENERIC, ret);


### PR DESCRIPTION
Change regression test 1018 to allow any layer if the TEE invocation
channel to report outbound memory reference as long as it is the the
TA itself since outbound memory reference should be caught before the
TA is invoked by the TEE.

This change makes xtest regression test 1018 more flexible towards
changes in the OP-TEE components that can catch invalid memory reference
in invocation parameters depending on the OP-TEE configuration.

Fixes: 84382b31d3a3 ("regression 1018: add 1byte out of bounds reference test sub cases
")
Reported-by: Sumit Garg <sumit.garg@linaro.org>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
