### PR TITLE
regression 1025: skip test if memref null capability not supported

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -1917,6 +1917,11 @@ static void xtest_tee_test_1025(ADBG_Case_t *c)
 	uint32_t ret_orig = 0;
 	uint8_t *empty_buf = NULL;
 
+	if (!xtest_teec_ctx.memref_null) {
+		Do_ADBG_Log("Skip test: MEMREF_NULL capability not supported");
+		return;
+	}
+
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 				      xtest_teec_open_session(&session,
 							      &os_test_ta_uuid,


### PR DESCRIPTION
Skip regression test 1025 when TEE context reports that memref null
capability is not supported by the OP-TEE ecosystem. This change
prevents xtest suite to fail on regression 1025 when one tests
the latest optee_os/optee_client/optee_test that supports this recent
capability with a mainline or older Linux kernel that does not yet
support this feature.

Reported-by: Masami Hiramatsu <masami.hiramatsu@linaro.org>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
