### PR TITLE
regression 4007_dsa: run all tests at level 0

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -4926,16 +4926,16 @@ static void xtest_tee_test_4007_dsa(ADBG_Case_t *c)
 		const uint8_t *sub_prime;
 		size_t sub_prime_len;
 	} key_types[] = {
-		{ 1, 1024, XTEST_DSA_GK_DATA(keygen_dsa_test1) },
+		{ 0, 1024, XTEST_DSA_GK_DATA(keygen_dsa_test1) },
 		{ 0, 512, XTEST_DSA_GK_DATA(keygen_dsa512) },
-		{ 1, 576, XTEST_DSA_GK_DATA(keygen_dsa576) },
-		{ 1, 640, XTEST_DSA_GK_DATA(keygen_dsa640) },
-		{ 1, 704, XTEST_DSA_GK_DATA(keygen_dsa704) },
-		{ 1, 768, XTEST_DSA_GK_DATA(keygen_dsa768) },
-		{ 1, 832, XTEST_DSA_GK_DATA(keygen_dsa832) },
-		{ 1, 896, XTEST_DSA_GK_DATA(keygen_dsa896) },
-		{ 1, 960, XTEST_DSA_GK_DATA(keygen_dsa960) },
-		{ 1, 1024, XTEST_DSA_GK_DATA(keygen_dsa1024) },
+		{ 0, 576, XTEST_DSA_GK_DATA(keygen_dsa576) },
+		{ 0, 640, XTEST_DSA_GK_DATA(keygen_dsa640) },
+		{ 0, 704, XTEST_DSA_GK_DATA(keygen_dsa704) },
+		{ 0, 768, XTEST_DSA_GK_DATA(keygen_dsa768) },
+		{ 0, 832, XTEST_DSA_GK_DATA(keygen_dsa832) },
+		{ 0, 896, XTEST_DSA_GK_DATA(keygen_dsa896) },
+		{ 0, 960, XTEST_DSA_GK_DATA(keygen_dsa960) },
+		{ 0, 1024, XTEST_DSA_GK_DATA(keygen_dsa1024) },
 	};
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,


### PR DESCRIPTION
Some DSA tests are currently run at level 1 or higher (xtest -l 1).
But, since optee_os commit xxxxx, the DSA key generation is much faster
so there is no reason to exclude test cases from the default level.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
