### PR TITLE
xtest: disable tests 1027 and 1028 if no OpenSSL

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2085,6 +2085,7 @@ ADBG_CASE_DEFINE(regression, 1026, xtest_tee_test_1026,
 
 static void xtest_tee_test_1027(ADBG_Case_t *c)
 {
+#ifdef OPENSSL_FOUND
 	TEEC_Result result = TEEC_ERROR_GENERIC;
 	uint32_t ret_orig = 0;
 	TEEC_Session session = { };
@@ -2125,6 +2126,11 @@ static void xtest_tee_test_1027(ADBG_Case_t *c)
 
 out:
 	TEEC_CloseSession(&session);
+#else /*!OPENSSL_FOUND*/
+	UNUSED(c);
+	/* xtest_uuid_v5() depends on OpenSSL */
+	Do_ADBG_Log("OpenSSL not available, skipping test 1027");
+#endif
 }
 
 ADBG_CASE_DEFINE(regression, 1027, xtest_tee_test_1027,
@@ -2132,6 +2138,7 @@ ADBG_CASE_DEFINE(regression, 1027, xtest_tee_test_1027,
 
 static void xtest_tee_test_1028(ADBG_Case_t *c)
 {
+#ifdef OPENSSL_FOUND
 	TEEC_Result result = TEEC_ERROR_GENERIC;
 	uint32_t ret_orig = 0;
 	TEEC_Session session = { };
@@ -2175,6 +2182,11 @@ static void xtest_tee_test_1028(ADBG_Case_t *c)
 
 out:
 	TEEC_CloseSession(&session);
+#else /*!OPENSSL_FOUND*/
+	UNUSED(c);
+	/* xtest_uuid_v5() depends on OpenSSL */
+	Do_ADBG_Log("OpenSSL not available, skipping test 1028");
+#endif
 }
 
 ADBG_CASE_DEFINE(regression, 1028, xtest_tee_test_1028,

--- a/host/xtest/xtest_uuid_helpers.c
+++ b/host/xtest/xtest_uuid_helpers.c
@@ -5,7 +5,9 @@
 
 #include <ctype.h>
 #include <endian.h>
+#ifdef OPENSSL_FOUND
 #include <openssl/evp.h>
+#endif
 #include <stdint.h>
 #include <string.h>
 #include <tee_api_types.h>
@@ -80,6 +82,7 @@ out:
 	return res;
 }
 
+#ifdef OPENSSL_FOUND
 TEEC_Result xtest_uuid_v5(TEEC_UUID *uuid, const TEEC_UUID *ns,
 			  const void *name, size_t size)
 {
@@ -147,3 +150,4 @@ out:
 	EVP_MD_CTX_destroy(mdctx);
 	return res;
 }
+#endif /*OPENSSL_FOUND*/

--- a/host/xtest/xtest_uuid_helpers.h
+++ b/host/xtest/xtest_uuid_helpers.h
@@ -15,9 +15,11 @@
  */
 TEEC_Result xtest_uuid_from_str(TEEC_UUID *uuid, const char *s);
 
+#ifdef OPENSSL_FOUND
 /*
  * Form UUIDv5 from given name space and name.
  */
 TEEC_Result xtest_uuid_v5(TEEC_UUID *uuid, const TEEC_UUID *ns,
 			  const void *name, size_t size);
+#endif /*OPENSSL_FOUND*/
 #endif


### PR DESCRIPTION
Tests 1027 and 1028 depend on xtest_uuid_v5() which in turn depends on OpenSSL
APIs so they should just return if OPENSSL_FOUND is not defined.

Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
