### PR TITLE
xtest: Makefile: create flag to enable OpenSSL

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -33,8 +33,12 @@ define cc-bits
 $(if $(filter arm, $(1)),32,$(if $(filter aarch64, $(1)),64,unknown-arch))
 endef
 
-# OpenSSL is used by GP tests series 8500 and Mbed TLS test 8103
-ifneq ($(CFG_GP_PACKAGE_PATH)$(filter y,$(CFG_TA_MBEDTLS)),)
+# OpenSSL is used by:
+# - GP tests series 8500
+# - Mbed TLS test 8103
+# - User/group login tests 1027 and 1028
+WITH_OPENSSL ?= y
+ifeq ($(WITH_OPENSSL),y)
 CFLAGS += -DOPENSSL_FOUND=1
 ifneq ($(OPTEE_OPENSSL_EXPORT),)
 LDFLAGS += -lcrypto


### PR DESCRIPTION
As more tests use or depend on OpenSSL, it does not make sense anymore
to enable OpenSSL, i.e. define OPENSSL_FOUND, based on one or several or
all of the 'imported' CFG* flags. Instead, decouple the definition of
OPENSSL_FOUND from CFG* flags and use a local WITH_OPENSSL flag instead.
This will allow CI testing of builds without OPENSSL_FOUND.

Suggested-by: Jerome Forissier <jerome@forissier.org>
Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
