### PR TITLE
[RFC] Kernel version restrictions on xtest test cases

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2095,6 +2095,13 @@ static void xtest_tee_test_1027(ADBG_Case_t *c)
 	TEEC_UUID uuid_ns = { };
 	char uuid_name[TEE_UUID_NS_NAME_SIZE] = { };
 
+	if (!kernel_is_supported(KERNEL_MAJOR_NEXT, KERNEL_MINOR_NEXT)) {
+		Do_ADBG_Log("- Skip the test case, needs a patched Linux kernel.\n"
+			    "  At least up to Linux kernel v5.7, client UUID is\n"
+			    "  not implemented.\n");
+		return;
+	}
+
 	result = xtest_uuid_from_str(&uuid_ns, client_uuid_linux_ns);
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c, result))
@@ -2148,6 +2155,13 @@ static void xtest_tee_test_1028(ADBG_Case_t *c)
 	TEEC_UUID uuid_ns = { };
 	char uuid_name[TEE_UUID_NS_NAME_SIZE] = { };
 	uint32_t group = 0;
+
+	if (!kernel_is_supported(KERNEL_MAJOR_NEXT, KERNEL_MINOR_NEXT)) {
+		Do_ADBG_Log("- Skip the test case, needs a patched Linux kernel.\n"
+			    "  At least up to Linux kernel v5.7, client UUID is\n"
+			    "  not implemented.\n");
+		return;
+	}
 
 	group = getegid();
 

--- a/host/xtest/xtest_helpers.h
+++ b/host/xtest/xtest_helpers.h
@@ -21,6 +21,25 @@
 
 extern unsigned int level;
 
+/* OP-TEE driver is introduced in kernel v4.5 */
+#define KERNEL_MAJOR_MIN	4
+#define KERNEL_MINOR_MIN	5
+/* As of now, v5.8 is the next kernel */
+#define KERNEL_MAJOR_NEXT	5
+#define KERNEL_MINOR_NEXT	8
+
+/* Return a signed +1, 0 or -1 value based on data comparison */
+#define CMP_TRILEAN(a, b) \
+	(__extension__({ \
+		__typeof__(a) _a = (a); \
+		__typeof__(b) _b = (b); \
+		\
+		_a > _b ? 1 : _a < _b ? -1 : 0; \
+	}))
+
+extern unsigned int xtest_kernel_major;
+extern unsigned int xtest_kernel_minor;
+
 /* Global context to use if any context is needed as input to a function */
 extern TEEC_Context xtest_teec_ctx;
 
@@ -39,6 +58,26 @@ TEEC_Result xtest_teec_open_session(TEEC_Session *session,
 TEEC_Result xtest_teec_open_static_session(TEEC_Session *session,
 					   TEEC_Operation *op,
 					   uint32_t *ret_orig);
+
+/* Return true is OS kernel restriction do not comply provided version */
+static inline int cmp_kernel_version(unsigned int a_major, unsigned int a_minor,
+				      unsigned int b_major, unsigned int b_minor)
+{
+	int cmp = CMP_TRILEAN(a_major, b_major);
+
+	if (cmp)
+		return cmp;
+
+	return CMP_TRILEAN(a_minor, b_minor);
+}
+
+/* Return true is OS kernel restriction comply the registered kernel version */
+static inline bool kernel_is_supported(unsigned int major, unsigned int minor)
+{
+	/* Test if registered version is higher or equal to caller arguments */
+	return cmp_kernel_version(xtest_kernel_major, xtest_kernel_minor,
+				  major, minor) >= 0;
+}
 
 #define TEEC_OPERATION_INITIALIZER	{ }
 


### PR DESCRIPTION
Change `xtest` to take a new optional argument `-k` to skip specific tests that mandate mainline Linux patches.
Config switch `CFG_XTEST_KERNEL_RESTRICTIONS=y` enforces `-k` feature at built time.

Apply to regression 1027 and 1028: skipped if kernel restriction enable.

Below are the logs for `xtest 1028` and `xtest -k 1028` on qemu_virt booted on a recent linux-next head (5.7-rc4), which does not implement OPTEE client UUID arguments:
```bach
# xtest 1028
Test ID: 1028
Run test suite with level=0

TEE test application started with device [(null)]
######################################################
#
# regression
#
######################################################
 
* regression_1028 Session: group login for current user's effective group
regression_1000.c:2195: memcmp(&expected_client_uuid, &client_uuid, sizeof(TEEC_UUID)) has an unexpected value: 0x28, expected 0x0
  regression_1028 FAILED
+-----------------------------------------------------
Result of testsuite regression filtered by "1028":
regression_1028 FAILED first error at regression_1000.c:2195
+-----------------------------------------------------
6 subtests of which 1 failed
1 test case of which 1 failed
101 test cases were skipped
TEE test application done!
```
Now with argument `-k`:
```bach
# xtest -k 1028
Test restricted to mainline kernel 5.7           <------ note here the new trace message
Test ID: 1028
Run test suite with level=0

TEE test application started with device [(null)]
######################################################
#
# regression
#
######################################################
 
* regression_1028 Session: group login for current user's effective group
- Skip the test case, needs a patched Linux kernel.          <------  here the new trace message
  At least up to Linux kernel v5.7, client UUID is
  not implemented.

  regression_1028 OK
+-----------------------------------------------------
Result of testsuite regression filtered by "1028":
regression_1028 OK
+-----------------------------------------------------
0 subtests of which 0 failed
1 test case of which 0 failed
101 test cases were skipped
TEE test application done!
# 
```