### PR TITLE
xtest: regression 1027: fix build warning when openssl not used

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2128,6 +2128,7 @@ out:
 	TEEC_CloseSession(&session);
 #else /*!OPENSSL_FOUND*/
 	UNUSED(c);
+	UNUSED(client_uuid_linux_ns);
 	/* xtest_uuid_v5() depends on OpenSSL */
 	Do_ADBG_Log("OpenSSL not available, skipping test 1027");
 #endif


### PR DESCRIPTION
Fix build warning reported with trace message like below:

.../optee-test-custom/host/xtest/regression_1000.c:2049:20: error: ‘client_uuid_linux_ns’ defined but not used [-Werror=unused-variable]
 static const char *client_uuid_linux_ns = "58ac9ca0-2086-4683-a1b8-ec4bc08e01b6";
                    ^~~~~~~~~~~~~~~~~~~~

Fixes: 8e070bc41e1d ("xtest: disable tests 1027 and 1028 if no OpenSSL")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
