### PR TITLE
ta: os_test: fix build warning on unused propset

### DIFF
--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -1217,7 +1217,6 @@ TEE_Result ta_entry_get_global_var(uint32_t param_types, TEE_Param params[4])
 
 TEE_Result ta_entry_client_identity(uint32_t param_types, TEE_Param params[4])
 {
-	TEE_PropSetHandle *propset = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	TEE_Identity identity = { };
 


### PR DESCRIPTION
Fix build warning reported with trace below:

os_test.c: In function ‘ta_entry_client_identity’:
os_test.c:1220:21: warning: unused variable ‘propset’ [-Wunused-variable]
  TEE_PropSetHandle *propset = NULL;
                     ^~~~~~~

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
