### PR TITLE
xtest: fix unused variable warning

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2046,7 +2046,9 @@ ADBG_CASE_DEFINE(regression, 1025, xtest_tee_test_1025,
  * Value here is random UUID that is allocated as name space identifier for
  * forming Client UUID's for TEE environment using UUIDv5 scheme.
  */
+#ifdef OPENSSL_FOUND
 static const char *client_uuid_linux_ns = "58ac9ca0-2086-4683-a1b8-ec4bc08e01b6";
+#endif
 
 /* TEEC_LOGIN_PUBLIC's Client UUID is NIL UUID */
 static TEEC_UUID client_uuid_public = { };


### PR DESCRIPTION
The client_uuid_linux_ns variable is only used in tests 1027 and 1028,
which are compiled only if OPENSSL_FOUND is defined, so the variable
itself needs to be enclosed too with the OPENSSL_FOUND ifdef to avoid
unused variable warnings.

Reported-by: Dmitry Shmidt <dimitrysh@google.com>
Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
