### PR TITLE
xtest regression 1006: add tests on binary block properties

### DIFF
--- a/ta/os_test/include/user_ta_header_defines.h
+++ b/ta/os_test/include/user_ta_header_defines.h
@@ -37,5 +37,11 @@
 	{ "myprop.binaryblock.3byte-ones", USER_TA_PROP_TYPE_BINARY_BLOCK, \
 	   "////" }, \
 	{ "myprop.binaryblock.4byte-ones", USER_TA_PROP_TYPE_BINARY_BLOCK, \
-	   "/////w==" },
+	   "/////w==" }, \
+	{ "myprop.binaryblock.empty1", USER_TA_PROP_TYPE_BINARY_BLOCK, \
+	   "" }, \
+	{ "myprop.binaryblock.empty2", USER_TA_PROP_TYPE_BINARY_BLOCK, \
+	   "====" }, \
+	{ "myprop.binaryblock.empty3", USER_TA_PROP_TYPE_BINARY_BLOCK, \
+	   "-%@&" /* Only invalid code */},
 #endif

--- a/ta/os_test/include/user_ta_header_defines.h
+++ b/ta/os_test/include/user_ta_header_defines.h
@@ -29,5 +29,13 @@
 	{ "myprop.hello", USER_TA_PROP_TYPE_STRING, \
 		"hello property, larger than 80 characters, so that it checks that it is not truncated by anything in the source code which may be wrong" }, \
 	{ "myprop.binaryblock", USER_TA_PROP_TYPE_BINARY_BLOCK, \
-	   "SGVsbG8gd29ybGQh" },
+	   "SGVsbG8gd29ybGQh" }, \
+	{ "myprop.binaryblock.1byte-ones", USER_TA_PROP_TYPE_BINARY_BLOCK, \
+	   "/w==" }, \
+	{ "myprop.binaryblock.2byte-ones", USER_TA_PROP_TYPE_BINARY_BLOCK, \
+	   "//8=" }, \
+	{ "myprop.binaryblock.3byte-ones", USER_TA_PROP_TYPE_BINARY_BLOCK, \
+	   "////" }, \
+	{ "myprop.binaryblock.4byte-ones", USER_TA_PROP_TYPE_BINARY_BLOCK, \
+	   "/////w==" },
 #endif

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -175,12 +175,15 @@ while (true) {
 	}
 
 	/* Get the property with a very small buffer */
-	vblen2 = 1;
-	res = TEE_GetPropertyAsString(prop_set, nbuf, vbuf2, &vblen2);
-	res = check_returned_prop(__LINE__, nbuf, res, TEE_ERROR_SHORT_BUFFER,
-				  vblen2, vblen);
-	if (res != TEE_SUCCESS)
-		return res;
+	if (vblen > 1) {
+		vblen2 = 1;
+		res = TEE_GetPropertyAsString(prop_set, nbuf, vbuf2, &vblen2);
+		res = check_returned_prop(__LINE__, nbuf, res,
+					  TEE_ERROR_SHORT_BUFFER,
+					  vblen2, vblen);
+		if (res != TEE_SUCCESS)
+			return res;
+	}
 
 	/* Get the property with almost the correct buffer */
 	vblen2 = vblen - 1;
@@ -319,6 +322,14 @@ while (true) {
 				res = check_binprop_ones(4, bbuf, bblen);
 				if (res)
 					return res;
+			} else if (!strcmp("myprop.binaryblock.empty1", nbuf) ||
+				   !strcmp("myprop.binaryblock.empty2", nbuf) ||
+				   !strcmp("myprop.binaryblock.empty3", nbuf)) {
+				if (bblen) {
+					EMSG("Property \"%s\": %zu byte(s)",
+					     nbuf, bblen);
+					return TEE_ERROR_GENERIC;
+				}
 			} else {
 				EMSG("Unexpected property \"%s\"", nbuf);
 				TEE_Panic(0);
@@ -395,6 +406,9 @@ static TEE_Result test_properties(void)
 		{"myprop.binaryblock.2byte-ones", P_TYPE_BINARY_BLOCK},
 		{"myprop.binaryblock.3byte-ones", P_TYPE_BINARY_BLOCK},
 		{"myprop.binaryblock.4byte-ones", P_TYPE_BINARY_BLOCK},
+		{"myprop.binaryblock.empty1", P_TYPE_BINARY_BLOCK},
+		{"myprop.binaryblock.empty2", P_TYPE_BINARY_BLOCK},
+		{"myprop.binaryblock.empty3", P_TYPE_BINARY_BLOCK},
 	};
 	const size_t num_p_attrs = sizeof(p_attrs) / sizeof(p_attrs[0]);
 	size_t n = 0;


### PR DESCRIPTION
Added tests related to https://github.com/OP-TEE/optee_os/pull/3886.