### PR TITLE
xtest: fix spelling error in the 'crypt' TA

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -388,7 +388,7 @@ static TEEC_Result ta_crypt_cmd_random_number_generate(ADBG_Case_t *c,
 	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_OUTPUT, TEEC_NONE,
 					 TEEC_NONE, TEEC_NONE);
 
-	res = TEEC_InvokeCommand(s, TA_CRYPT_CMD_RANDOM_NUMBER_GENEREATE, &op,
+	res = TEEC_InvokeCommand(s, TA_CRYPT_CMD_RANDOM_NUMBER_GENERATE, &op,
 				 &ret_orig);
 
 	if (res != TEEC_SUCCESS) {

--- a/ta/crypt/include/ta_crypt.h
+++ b/ta/crypt/include/ta_crypt.h
@@ -262,7 +262,7 @@
  * void TEE_RandomNumberGenerate(void *randomBuffer, size_t randomBufferLen);
  * out      params[0].memref = randomBuffer
  */
-#define TA_CRYPT_CMD_RANDOM_NUMBER_GENEREATE    32
+#define TA_CRYPT_CMD_RANDOM_NUMBER_GENERATE     32
 
 /*
  * TEE_Result TEE_AEInit(TEE_OperationHandle operation,

--- a/ta/crypt/ta_entry.c
+++ b/ta/crypt/ta_entry.c
@@ -172,7 +172,7 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_CRYPT_CMD_DERIVE_KEY:
 		return ta_entry_derive_key(nParamTypes, pParams);
 
-	case TA_CRYPT_CMD_RANDOM_NUMBER_GENEREATE:
+	case TA_CRYPT_CMD_RANDOM_NUMBER_GENERATE:
 		return ta_entry_random_number_generate(nParamTypes, pParams);
 
 	case TA_CRYPT_CMD_AE_INIT:


### PR DESCRIPTION
Fix misspelling of "random number generate" command in the 'crypt' TA.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
