### PR TITLE
regression 1023: workaround Clang optimization issue

### DIFF
--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -1247,7 +1247,7 @@ err:
 
 /* ELF initialization/finalization test */
 
-int os_test_global;
+volatile int os_test_global;
 
 static void __attribute__((constructor)) os_test_init(void)
 {


### PR DESCRIPTION
When using Clang on HiKey (tested with 9.0.1 and 10.0.0), xtest 1023
fails with:

 * regression_1023 Test ELF initialization (.init_array)
 regression_1000.c:1860: Expression "op.params[0].value.a == 21" (12 == 21) is false
 regression_1000.c:1871: Expression "op.params[0].value.a == 213" (123 == 213) is false
   regression_1023 FAILED

The values indicate that the os_test_lib shared library is initialized
after the main application, which is not what we expect. In fact, the
reason for the failure is code elimination performed by Clang [1]. The
validity of this optimization is still unclear, but in any case it does
not concern the main things being tested, which is the invocation of
initialization functions when they exist. Therefore this commit applies
a workaround which effectively disables the proplematic optimization.

Note: the issue can be reproduced on QEMU with CFLAGS_ta_arm32=-Os and
QEMUv8 with CFLAGS_ta_arm64="-Os -fno-common".

[1] http://lists.llvm.org/pipermail/llvm-dev/2020-June/thread.html#142192

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
