### PR TITLE
ta: os_test: fix build warning in binary property tests

### DIFF
--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -51,9 +51,9 @@ static TEE_Result check_returned_prop(
 	return TEE_SUCCESS;
 }
 
-static TEE_Result check_binprop_ones(size_t size, uint8_t *bbuf, size_t bblen)
+static TEE_Result check_binprop_ones(size_t size, char *bbuf, size_t bblen)
 {
-	uint8_t ones[4] = { 0xff, 0xff, 0xff, 0xff };
+	char ones[4] = { 0xff, 0xff, 0xff, 0xff };
 
 	if (size > 4 || bblen != size) {
 		EMSG("Size error (size=%zu, bblen=%zu)", size, bblen);
@@ -68,17 +68,16 @@ static TEE_Result check_binprop_ones(size_t size, uint8_t *bbuf, size_t bblen)
 }
 
 static TEE_Result get_binblock_property(TEE_PropSetHandle h,
-					char *nbuf,
-					uint8_t **bbuf,
-					size_t *bblen)
+					char *nbuf, char **bbuf, size_t *bblen)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t block_len = 0;
 
 	*bbuf = NULL;
 	*bblen = 0;
-	res = TEE_GetPropertyAsBinaryBlock(h, NULL, *bbuf, bblen);
+	res = TEE_GetPropertyAsBinaryBlock(h, NULL, *bbuf, &block_len);
 
-	if (res == TEE_SUCCESS && !*bblen)
+	if (res == TEE_SUCCESS && !block_len)
 		return TEE_SUCCESS;
 
 	if (res != TEE_ERROR_SHORT_BUFFER) {
@@ -87,14 +86,16 @@ static TEE_Result get_binblock_property(TEE_PropSetHandle h,
 		return res ? res : TEE_ERROR_GENERIC;
 	}
 
-	*bbuf = TEE_Malloc(*bblen, TEE_MALLOC_FILL_ZERO);
+	*bbuf = TEE_Malloc(block_len, TEE_MALLOC_FILL_ZERO);
 	if (!bbuf)
 		return TEE_ERROR_OUT_OF_MEMORY;
 
-	res = TEE_GetPropertyAsBinaryBlock(h, NULL, *bbuf, bblen);
+	res = TEE_GetPropertyAsBinaryBlock(h, NULL, *bbuf, &block_len);
 	if (res != TEE_SUCCESS)
 		EMSG("TEE_GetPropertyAsBinaryBlock(\"%s\") returned 0x%x",
 		     nbuf, (unsigned int)res);
+	else
+		*bblen = block_len;
 
 	return res;
 }
@@ -117,7 +118,7 @@ while (true) {
 	uint32_t nblen_small = 0;
 	uint32_t vblen = sizeof(vbuf);
 	uint32_t vblen2 = sizeof(vbuf2);
-	uint8_t *bbuf = NULL;
+	char *bbuf = NULL;
 	size_t bblen = 0;
 
 	res = TEE_GetPropertyName(h, nbuf, &nblen);


### PR DESCRIPTION
Fix build warning reported with trace below:

os_test.c: In function ‘check_binprop_ones’:
os_test.c:62:14: warning: pointer targets in passing argument 1 of ‘strncmp’ differ in signedness [-Wpointer-sign]
  if (strncmp(bbuf, ones, bblen)) {
              ^~~~
In file included from os_test.c:10:
/local/home/frq93142/Projects/linaro-optee-3.9.0/optee_os/out/arm/export-ta_arm32/include/string.h:23:5: note: expected ‘const char *’ but argument is of type ‘uint8_t *’ {aka ‘unsigned char *’}
 int strncmp(const char *s1, const char *s2, size_t n);
     ^~~~~~~
os_test.c:62:20: warning: pointer targets in passing argument 2 of ‘strncmp’ differ in signedness [-Wpointer-sign]
  if (strncmp(bbuf, ones, bblen)) {
                    ^~~~
In file included from os_test.c:10:
/local/home/frq93142/Projects/linaro-optee-3.9.0/optee_os/out/arm/export-ta_arm32/include/string.h:23:5: note: expected ‘const char *’ but argument is of type ‘uint8_t *’ {aka ‘unsigned char *’}
 int strncmp(const char *s1, const char *s2, size_t n);
     ^~~~~~~

os_test.c: In function ‘get_binblock_property’:
os_test.c:79:53: warning: passing argument 4 of ‘TEE_GetPropertyAsBinaryBlock’ from incompatible pointer type [-Wincompatible-pointer-types]
  res = TEE_GetPropertyAsBinaryBlock(h, NULL, *bbuf, bblen);
                                                     ^~~~~
In file included from ./include/os_test.h:10,
                 from os_test.c:15:
/local/home/frq93142/Projects/linaro-optee-qemu_v8/optee_os/out/arm/export-ta_arm64/include/tee_api.h:30:16: note: expected ‘uint32_t *’ {aka ‘unsigned int *’} but argument is of type ‘size_t *’ {aka ‘long unsigned int *’}
      uint32_t *valueBufferLen);
      ~~~~~~~~~~^~~~~~~~~~~~~~
os_test.c:94:53: warning: passing argument 4 of ‘TEE_GetPropertyAsBinaryBlock’ from incompatible pointer type [-Wincompatible-pointer-types]
  res = TEE_GetPropertyAsBinaryBlock(h, NULL, *bbuf, bblen);
                                                     ^~~~~
In file included from ./include/os_test.h:10,
                 from os_test.c:15:
/local/home/frq93142/Projects/linaro-optee-qemu_v8/optee_os/out/arm/export-ta_arm64/include/tee_api.h:30:16: note: expected ‘uint32_t *’ {aka ‘unsigned int *’} but argument is of type ‘size_t *’ {aka ‘long unsigned int *’}
      uint32_t *valueBufferLen);
      ~~~~~~~~~~^~~~~~~~~~~~~~

Fixes: b34caffbb763 ("xtest: regression 1006: enhance tests on binary block property")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
