### PR TITLE
os_test: C++: disable profiling (-pg)

### DIFF
--- a/ta/os_test/sub.mk
+++ b/ta/os_test/sub.mk
@@ -9,6 +9,12 @@ srcs-y += os_test.c
 srcs-y += ta_entry.c
 srcs-$(CFG_TA_FLOAT_SUPPORT) += test_float_subj.c
 ifneq ($(COMPILER),clang)
+# Profiling (-pg) is disabled for C++ tests because in case it is used for
+# function tracing (CFG_FTRACE_SUPPORT=y) then the exception handling code in
+# the C++ runtime won't be able to unwind the (modified) stack.
+# https://github.com/OP-TEE/optee_os/issues/4022
 srcs-y += cxx_tests.cpp
+cxxflags-remove-cxx_tests.cpp-y += -pg
 srcs-y += cxx_tests_c.c
+cflags-remove-cxx_tests_c.c-y += -pg
 endif


### PR DESCRIPTION
os_test includes C++ exception tests which are incompatible with ftrace
by design [1]. This commit makes sure the C++ tests are not compiled
with the profiling flag (-pg), which is the flag that one would use to
enable function tracing in TAs.

Link: [1] https://github.com/OP-TEE/optee_os/issues/4022
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
