### PR TITLE
github: update actions/workflow file

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -1,4 +1,4 @@
-name: "Close stale issues"
+name: 'Close stale issues and pull requests with no recent activity'
 on:
   schedule:
   - cron: "16 00 * * *"
@@ -7,11 +7,16 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v3.0.10
+
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has been marked as a stale issue because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this issue will automatically be closed in 5 days. Note, that you can always re-open a closed issue at any time.'
-        stale-pr-message: 'This pull request has been marked as stale because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment saying that you would like to have the label removed otherwise this pull request will automatically be closed in 5 days. Note, that you can always re-open a closed pull request at any time.'
-        exempt-issue-label: 'bug'
+        stale-issue-message: 'This issue has been marked as a stale issue because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment, otherwise this issue will automatically be closed in 5 days. Note that you can always re-open a closed issue at any time.'
+        stale-pr-message: 'This pull request has been marked as a stale pull request because it has been open (more than) 30 days with no activity. Remove the stale label or add a comment, otherwise this pull request will automatically be closed in 5 days. Note that you can always re-open a closed pull request at any time.'
+        stale-issue-label: Stale
+        stale-pr-label: Stale
+        exempt-issue-labels: bug,enhancement
+        exempt-pr-labels: bug,enhancement
         days-before-stale: 30
         days-before-close: 5
+        remove-stale-when-updated: true


### PR DESCRIPTION
Sync the GitHub workflow file with the recent changes in optee_os as
described in [1] with the difference that we use a more recent version
of the "actions/stale" workflow (v3.0.10). In short, this updates the
version and add "bug" and "enhancement" as the labels where the GitHub
bot shouldn't mark an issue or pull request as stale ticket.

Link: [1] https://github.com/OP-TEE/optee_os/commit/50bbda3dd3

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
