### PR TITLE
Disable TLS/C++ tests with some unsupported compilers

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2202,6 +2202,7 @@ ADBG_CASE_DEFINE(regression, 1028, xtest_tee_test_1028,
 
 static void xtest_tee_test_1029(ADBG_Case_t *c)
 {
+	TEEC_Result res = TEEC_SUCCESS;
 	TEEC_Session session = { 0 };
 	uint32_t ret_orig = 0;
 
@@ -2211,15 +2212,23 @@ static void xtest_tee_test_1029(ADBG_Case_t *c)
 		return;
 
 	Do_ADBG_BeginSubCase(c, "TLS variables (main program)");
-	ADBG_EXPECT_TEEC_SUCCESS(c,
-		TEEC_InvokeCommand(&session, TA_OS_TEST_CMD_TLS_TEST_MAIN, NULL,
-				   &ret_orig));
+	res = TEEC_InvokeCommand(&session, TA_OS_TEST_CMD_TLS_TEST_MAIN, NULL,
+				 &ret_orig);
+	if (res == TEEC_ERROR_NOT_SUPPORTED)
+		Do_ADBG_Log(" - 1029 -   skip test, "
+			    "TA returned TEEC_ERROR_NOT_SUPPORTED");
+	else
+		ADBG_EXPECT_TEEC_SUCCESS(c, res);
 	Do_ADBG_EndSubCase(c, "TLS variables (main program)");
 
 	Do_ADBG_BeginSubCase(c, "TLS variables (shared library)");
-	ADBG_EXPECT_TEEC_SUCCESS(c,
-		TEEC_InvokeCommand(&session, TA_OS_TEST_CMD_TLS_TEST_SHLIB,
-				   NULL, &ret_orig));
+	res = TEEC_InvokeCommand(&session, TA_OS_TEST_CMD_TLS_TEST_SHLIB, NULL,
+				 &ret_orig);
+	if (res == TEEC_ERROR_NOT_SUPPORTED)
+		Do_ADBG_Log(" - 1029 -   skip test, "
+			    "TA returned TEEC_ERROR_NOT_SUPPORTED");
+	else
+		ADBG_EXPECT_TEEC_SUCCESS(c, res);
 	Do_ADBG_EndSubCase(c, "TLS variables (shared library)");
 
 	TEEC_CloseSession(&session);

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -1301,6 +1301,7 @@ TEE_Result ta_entry_client_identity(uint32_t param_types, TEE_Param params[4])
 	return res;
 }
 
+#if defined(__clang__) || !defined(__aarch64__) || __GNUC__ >= 8
 __thread int os_test_tls_a;
 __thread int os_test_tls_b = 42;
 
@@ -1332,6 +1333,17 @@ TEE_Result ta_entry_tls_test_shlib(void)
 
 	return TEE_SUCCESS;
 }
+#else
+TEE_Result ta_entry_tls_test_main(void)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+TEE_Result ta_entry_tls_test_shlib(void)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+#endif
 
 static int iterate_hdr_cb(struct dl_phdr_info *info __maybe_unused,
 			  size_t size __unused, void *data)

--- a/ta/os_test/sub.mk
+++ b/ta/os_test/sub.mk
@@ -8,7 +8,9 @@ srcs-y += init.c
 srcs-y += os_test.c
 srcs-y += ta_entry.c
 srcs-$(CFG_TA_FLOAT_SUPPORT) += test_float_subj.c
-ifneq ($(COMPILER),clang)
+# C++ tests don't work with Clang, and for Aarch64 they require GCC >= 8
+c++-supported := $(shell env echo -e '\#if !defined(__clang__) && (!defined(__aarch64__) || __GNUC__ >= 8)\ny\n\#endif' | $(CC$(sm)) -E -P -)
+ifeq ($(c++-supported),y)
 # Profiling (-pg) is disabled for C++ tests because in case it is used for
 # function tracing (CFG_FTRACE_SUPPORT=y) then the exception handling code in
 # the C++ runtime won't be able to unwind the (modified) stack.

--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -121,7 +121,7 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_OS_TEST_CMD_DL_PHDR_DL:
 		return ta_entry_dl_phdr_dl();
 
-#ifdef __clang__
+#if defined(__clang__) || (defined(__aarch64__) && __GNUC__ < 8)
 	case TA_OS_TEST_CMD_CXX_CTOR_MAIN:
 	case TA_OS_TEST_CMD_CXX_CTOR_SHLIB:
 	case TA_OS_TEST_CMD_CXX_CTOR_SHLIB_DL:

--- a/ta/os_test_lib/include/os_test_lib.h
+++ b/ta/os_test_lib/include/os_test_lib.h
@@ -11,8 +11,10 @@
 int os_test_shlib_add(int a, int b);
 void os_test_shlib_panic(void);
 
+#if defined(__clang__) || !defined(__aarch64__) || __GNUC__ >= 8
 extern __thread int os_test_shlib_tls_a;
 extern __thread int os_test_shlib_tls_b;
+#endif
 
 TEE_Result os_test_shlib_cxx_ctor(void);
 

--- a/ta/os_test_lib/os_test_lib.c
+++ b/ta/os_test_lib/os_test_lib.c
@@ -16,8 +16,10 @@ static void __attribute__((constructor)) os_test_shlib_init(void)
 	DMSG("os_test_global=%d", os_test_global);
 }
 
+#if defined(__clang__) || !defined(__aarch64__) || __GNUC__ >= 8
 __thread int os_test_shlib_tls_a;
 __thread int os_test_shlib_tls_b = 123;
+#endif
 
 int os_test_shlib_add(int a, int b)
 {


### PR DESCRIPTION
Addresses https://github.com/OP-TEE/optee_os/pull/4008#issuecomment-675512429.