### PR TITLE
Revert "os_test: arm64: disable C++ and TLS tests depending on compiler"

### DIFF
--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -1301,7 +1301,6 @@ TEE_Result ta_entry_client_identity(uint32_t param_types, TEE_Param params[4])
 	return res;
 }
 
-#if defined(__clang__) || !defined(__aarch64__) || __GNUC__ >= 8
 __thread int os_test_tls_a;
 __thread int os_test_tls_b = 42;
 
@@ -1333,17 +1332,6 @@ TEE_Result ta_entry_tls_test_shlib(void)
 
 	return TEE_SUCCESS;
 }
-#else
-TEE_Result ta_entry_tls_test_main(void)
-{
-	return TEE_ERROR_NOT_SUPPORTED;
-}
-
-TEE_Result ta_entry_tls_test_shlib(void)
-{
-	return TEE_ERROR_NOT_SUPPORTED;
-}
-#endif
 
 static int iterate_hdr_cb(struct dl_phdr_info *info __maybe_unused,
 			  size_t size __unused, void *data)

--- a/ta/os_test/sub.mk
+++ b/ta/os_test/sub.mk
@@ -8,9 +8,7 @@ srcs-y += init.c
 srcs-y += os_test.c
 srcs-y += ta_entry.c
 srcs-$(CFG_TA_FLOAT_SUPPORT) += test_float_subj.c
-# C++ tests don't work with Clang, and for Aarch64 they require GCC >= 8
-c++-supported := $(shell env echo -e '\#if !defined(__clang__) && (!defined(__aarch64__) || __GNUC__ >= 8)\ny\n\#endif' | $(CC$(sm)) -E -P -)
-ifeq ($(c++-supported),y)
+ifneq ($(COMPILER),clang)
 # Profiling (-pg) is disabled for C++ tests because in case it is used for
 # function tracing (CFG_FTRACE_SUPPORT=y) then the exception handling code in
 # the C++ runtime won't be able to unwind the (modified) stack.

--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -121,7 +121,7 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_OS_TEST_CMD_DL_PHDR_DL:
 		return ta_entry_dl_phdr_dl();
 
-#if defined(__clang__) || (defined(__aarch64__) && __GNUC__ < 8)
+#ifdef __clang__
 	case TA_OS_TEST_CMD_CXX_CTOR_MAIN:
 	case TA_OS_TEST_CMD_CXX_CTOR_SHLIB:
 	case TA_OS_TEST_CMD_CXX_CTOR_SHLIB_DL:

--- a/ta/os_test_lib/include/os_test_lib.h
+++ b/ta/os_test_lib/include/os_test_lib.h
@@ -11,10 +11,8 @@
 int os_test_shlib_add(int a, int b);
 void os_test_shlib_panic(void);
 
-#if defined(__clang__) || !defined(__aarch64__) || __GNUC__ >= 8
 extern __thread int os_test_shlib_tls_a;
 extern __thread int os_test_shlib_tls_b;
-#endif
 
 TEE_Result os_test_shlib_cxx_ctor(void);
 

--- a/ta/os_test_lib/os_test_lib.c
+++ b/ta/os_test_lib/os_test_lib.c
@@ -16,10 +16,8 @@ static void __attribute__((constructor)) os_test_shlib_init(void)
 	DMSG("os_test_global=%d", os_test_global);
 }
 
-#if defined(__clang__) || !defined(__aarch64__) || __GNUC__ >= 8
 __thread int os_test_shlib_tls_a;
 __thread int os_test_shlib_tls_b = 123;
-#endif
 
 int os_test_shlib_add(int a, int b)
 {


### PR DESCRIPTION
This reverts commit 30efcbeaf8864d0f2a5c4be593a5411001fab31b.

Now that R_AARCH64_TLSDESC relocations are implemented in OP-TEE [1]
there is no need to make an exception for older GCC versions.

[1] https://github.com/OP-TEE/optee_os/commit/7bc927fa5192f4af4f59072f38822e0082e4bddb
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
