### PR TITLE
regression 6020: fix fs_open() flags

### DIFF
--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -2123,8 +2123,7 @@ static void xtest_tee_test_6020_single(ADBG_Case_t *c, uint32_t storage_id)
 				TA_STORAGE_CMD_OPEN_ID_IN_SHM,
 				file_01, sizeof(file_01),
 				TEE_DATA_FLAG_ACCESS_WRITE |
-				TEE_DATA_FLAG_ACCESS_WRITE_META |
-				TEE_DATA_FLAG_OVERWRITE,
+				TEE_DATA_FLAG_ACCESS_WRITE_META,
 				0,
 				NULL, 0,
 				&obj,
@@ -2161,8 +2160,7 @@ static void xtest_tee_test_6020_single(ADBG_Case_t *c, uint32_t storage_id)
 
 	res = fs_open(&sess, file_01, sizeof(file_01),
 				TEE_DATA_FLAG_ACCESS_WRITE |
-				TEE_DATA_FLAG_ACCESS_WRITE_META |
-				TEE_DATA_FLAG_OVERWRITE,
+				TEE_DATA_FLAG_ACCESS_WRITE_META,
 				&obj,
 				storage_id);
 
@@ -2190,8 +2188,7 @@ static void xtest_tee_test_6020_single(ADBG_Case_t *c, uint32_t storage_id)
 
 	res = fs_open(&sess, file_01, sizeof(file_01),
 				TEE_DATA_FLAG_ACCESS_WRITE |
-				TEE_DATA_FLAG_ACCESS_WRITE_META |
-				TEE_DATA_FLAG_OVERWRITE,
+				TEE_DATA_FLAG_ACCESS_WRITE_META,
 				&obj,
 				storage_id);
 


### PR DESCRIPTION
The flag TEE_DATA_FLAG_OVERWRITE is not permitted with the
TEE_OpenPersistentObject() functions. So remove the flag where needed in
the 6020 case.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
