### PR TITLE
ta/os_test.c: update expected "myprop.binaryblock" value

### DIFF
--- a/ta/os_test/include/user_ta_header_defines.h
+++ b/ta/os_test/include/user_ta_header_defines.h
@@ -30,18 +30,6 @@
 		"hello property, larger than 80 characters, so that it checks that it is not truncated by anything in the source code which may be wrong" }, \
 	{ "myprop.binaryblock", USER_TA_PROP_TYPE_BINARY_BLOCK, \
 	   "SGVsbG8gd29ybGQh" }, \
-	{ "myprop.binaryblock.1byte-ones", USER_TA_PROP_TYPE_BINARY_BLOCK, \
-	   "/w==" }, \
-	{ "myprop.binaryblock.2byte-ones", USER_TA_PROP_TYPE_BINARY_BLOCK, \
-	   "//8=" }, \
-	{ "myprop.binaryblock.3byte-ones", USER_TA_PROP_TYPE_BINARY_BLOCK, \
-	   "////" }, \
-	{ "myprop.binaryblock.4byte-ones", USER_TA_PROP_TYPE_BINARY_BLOCK, \
-	   "/////w==" }, \
-	{ "myprop.binaryblock.empty1", USER_TA_PROP_TYPE_BINARY_BLOCK, \
-	   "" }, \
-	{ "myprop.binaryblock.empty2", USER_TA_PROP_TYPE_BINARY_BLOCK, \
-	   "====" }, \
-	{ "myprop.binaryblock.empty3", USER_TA_PROP_TYPE_BINARY_BLOCK, \
-	   "-%@&" /* Only invalid code */},
+	{ "myprop.binaryblock.empty", USER_TA_PROP_TYPE_BINARY_BLOCK, \
+	   "" },
 #endif

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -52,22 +52,6 @@ static TEE_Result check_returned_prop(
 	return TEE_SUCCESS;
 }
 
-static TEE_Result check_binprop_ones(size_t size, char *bbuf, size_t bblen)
-{
-	char ones[4] = { 0xff, 0xff, 0xff, 0xff };
-
-	if (size > 4 || bblen != size) {
-		EMSG("Size error (size=%zu, bblen=%zu)", size, bblen);
-		return TEE_ERROR_GENERIC;
-	}
-	if (strncmp(bbuf, ones, bblen)) {
-		EMSG("Unexpected content");
-		DHEXDUMP(bbuf, bblen);
-		return TEE_ERROR_GENERIC;
-	}
-	return TEE_SUCCESS;
-}
-
 static TEE_Result get_binblock_property(TEE_PropSetHandle h,
 					char *nbuf, char **bbuf, size_t *bblen)
 {
@@ -294,9 +278,9 @@ while (true) {
 				return res;
 
 			if (!strcmp("myprop.binaryblock", nbuf)) {
-				const char exp_bin_value[] = "Hello world!";
+				const char exp_bin_value[] = "SGVsbG8gd29ybGQh";
 
-				if (bblen != strlen(exp_bin_value) ||
+				if (bblen != sizeof(exp_bin_value) ||
 				    TEE_MemCompare(exp_bin_value, bbuf,
 						   bblen)) {
 					EMSG("Binary buffer of \"%s\" differs from \"%s\"",
@@ -304,32 +288,15 @@ while (true) {
 					EMSG("Got \"%s\"", bbuf);
 					return TEE_ERROR_GENERIC;
 				}
-			} else if (!strcmp("myprop.binaryblock.1byte-ones",
-					   nbuf)) {
-				res = check_binprop_ones(1, bbuf, bblen);
-				if (res)
-					return res;
-			} else if (!strcmp("myprop.binaryblock.2byte-ones",
-					   nbuf)) {
-				res = check_binprop_ones(2, bbuf, bblen);
-				if (res)
-					return res;
-			} else if (!strcmp("myprop.binaryblock.3byte-ones",
-					   nbuf)) {
-				res = check_binprop_ones(3, bbuf, bblen);
-				if (res)
-					return res;
-			} else if (!strcmp("myprop.binaryblock.4byte-ones",
-					   nbuf)) {
-				res = check_binprop_ones(4, bbuf, bblen);
-				if (res)
-					return res;
-			} else if (!strcmp("myprop.binaryblock.empty1", nbuf) ||
-				   !strcmp("myprop.binaryblock.empty2", nbuf) ||
-				   !strcmp("myprop.binaryblock.empty3", nbuf)) {
-				if (bblen) {
-					EMSG("Property \"%s\": %zu byte(s)",
-					     nbuf, bblen);
+			} else if (!strcmp("myprop.binaryblock.empty", nbuf)) {
+				const char exp_bin_value[] = "";
+
+				if (bblen != sizeof(exp_bin_value) ||
+				    TEE_MemCompare(exp_bin_value, bbuf,
+						   bblen)) {
+					EMSG("Binary buffer of \"%s\" differs from \"%s\"",
+					     nbuf, exp_bin_value);
+					EMSG("Got \"%s\"", bbuf);
 					return TEE_ERROR_GENERIC;
 				}
 			} else {
@@ -404,13 +371,7 @@ static TEE_Result test_properties(void)
 		{"myprop.1234", P_TYPE_IDENTITY},
 		{"myprop.hello", P_TYPE_STRING},
 		{"myprop.binaryblock", P_TYPE_BINARY_BLOCK},
-		{"myprop.binaryblock.1byte-ones", P_TYPE_BINARY_BLOCK},
-		{"myprop.binaryblock.2byte-ones", P_TYPE_BINARY_BLOCK},
-		{"myprop.binaryblock.3byte-ones", P_TYPE_BINARY_BLOCK},
-		{"myprop.binaryblock.4byte-ones", P_TYPE_BINARY_BLOCK},
-		{"myprop.binaryblock.empty1", P_TYPE_BINARY_BLOCK},
-		{"myprop.binaryblock.empty2", P_TYPE_BINARY_BLOCK},
-		{"myprop.binaryblock.empty3", P_TYPE_BINARY_BLOCK},
+		{"myprop.binaryblock.empty", P_TYPE_BINARY_BLOCK},
 	};
 	const size_t num_p_attrs = sizeof(p_attrs) / sizeof(p_attrs[0]);
 	size_t n = 0;


### PR DESCRIPTION
TEE_GetPropertyAsBinaryBlock() is supposed to return a binary block
base64 encoded. Drop the TA specific test properties:
- myprop.binaryblock.1byte-ones
- myprop.binaryblock.2byte-ones
- myprop.binaryblock.3byte-ones
- myprop.binaryblock.4byte-ones
- myprop.binaryblock.empty1
- myprop.binaryblock.empty2
- myprop.binaryblock.empty3
since they don't help verifying this implementation any longer.

Add a the new TA specific test proptery "myprop.binaryblock.empty"
which is just empty.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
