### PR TITLE
ta/crypt: fix warning in unpack_attrs()

### DIFF
--- a/ta/crypt/cryp_taf.c
+++ b/ta/crypt/cryp_taf.c
@@ -341,8 +341,7 @@ static TEE_Result unpack_attrs(const uint8_t *buf, size_t blen,
 			uintptr_t p;
 
 			a[n].attributeID = ap[n].id;
-#define TEE_ATTR_BIT_VALUE		  (1 << 29)
-			if (ap[n].id & TEE_ATTR_BIT_VALUE) {
+			if (ap[n].id & TEE_ATTR_FLAG_VALUE) {
 				a[n].content.value.a = ap[n].a;
 				a[n].content.value.b = ap[n].b;
 				continue;


### PR DESCRIPTION
Prior to this patch there was a warning in unpack_attrs():
cryp_taf.c: In function ‘unpack_attrs’:
cryp_taf.c:344: warning: "TEE_ATTR_BIT_VALUE" redefined
 #define TEE_ATTR_BIT_VALUE    (1 << 29)

In file included from /home/jens/work/op-tee/out-os-qemu/export-ta_arm32/include/tee_api.h:12,
                 from /home/jens/work/op-tee/out-os-qemu/export-ta_arm32/include/tee_internal_api.h:10,
                 from cryp_taf.c:7:
/home/jens/work/op-tee/out-os-qemu/export-ta_arm32/include/tee_api_defines.h:282: note: this is the location of the previous definition
 #define TEE_ATTR_BIT_VALUE  TEE_ATTR_FLAG_VALUE

Fix this by removing the now deprecated TEE_ATTR_BIT_VALUE define.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
