### PR TITLE
xtest: remove __unused and do not include <compiler.h>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ add_compile_options (
 	-Wswitch-default -Wunsafe-loop-optimizations
 	-Wwrite-strings -Werror -fPIC
  	-Wno-missing-field-initializers
+	-Wno-unused-parameter
 )
 
 find_program(CCACHE_FOUND ccache)

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -170,7 +170,7 @@ CFLAGS += -Wall -Wcast-align -Werror \
 	  -Wmissing-include-dirs -Wmissing-noreturn \
 	  -Wmissing-prototypes -Wnested-externs -Wpointer-arith \
 	  -Wshadow -Wstrict-prototypes -Wswitch-default \
-	  -Wwrite-strings \
+	  -Wwrite-strings -Wno-unused-parameter \
 	  -Wno-declaration-after-statement \
 	  -Wno-unsafe-loop-optimizations \
 	  -Wno-missing-field-initializers -Wno-format-zero-length

--- a/host/xtest/gp/include/xml_client_api.h
+++ b/host/xtest/gp/include/xml_client_api.h
@@ -8,7 +8,6 @@
 #define XML_CLIENT_API_H_
 
 #include <assert.h>
-#include <compiler.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/host/xtest/gp/include/xml_crypto_api.h
+++ b/host/xtest/gp/include/xml_crypto_api.h
@@ -8,7 +8,6 @@
 #define XML_CRYPTO_API_H_
 
 #include <assert.h>
-#include <compiler.h>
 #include <err.h>
 #include <openssl/bn.h>
 #include <openssl/dsa.h>
@@ -1055,7 +1054,7 @@ static void collapse_crypto_buffers(struct crypto_buffer *in_buffer,
 	}
 }
 
-static TEEC_Result Invoke_Crypto_AllocateOperation(ADBG_Case_t *c __unused,
+static TEEC_Result Invoke_Crypto_AllocateOperation(ADBG_Case_t *c,
 						   TEEC_Session *s,
 						   uint32_t cmd, uint32_t algo,
 						   uint32_t mode,
@@ -1089,7 +1088,7 @@ static TEEC_Result Invoke_Crypto_AllocateOperation(ADBG_Case_t *c __unused,
 	return res;
 }
 
-static TEEC_Result Invoke_Crypto_GetOperationInfo(ADBG_Case_t *c __unused,
+static TEEC_Result Invoke_Crypto_GetOperationInfo(ADBG_Case_t *c ,
 						  TEEC_Session *s,
 						  uint32_t cmd,
 						  uint32_t op_handle)
@@ -1644,8 +1643,8 @@ static TEEC_Result Invoke_Crypto_AEEncryptFinal(ADBG_Case_t *c, TEEC_Session *s,
 						uint32_t op_handle,
 						const void *part_data,
 						size_t partd_length,
-						const void *full_data __unused,
-						size_t fdata_length __unused,
+						const void *full_data,
+						size_t fdata_length,
 						uint32_t case_buf,
 						uint32_t chunk_id)
 {
@@ -1737,7 +1736,7 @@ mem01_exit:
 static TEEC_Result Invoke_Crypto_AEDecryptFinal(ADBG_Case_t *c, TEEC_Session *s,
 						uint32_t cmd,
 						uint32_t op_handle,
-						const void *part_data __unused,
+						const void *part_data,
 						size_t partd_length,
 						const void *full_data,
 						size_t fdata_length,
@@ -1984,8 +1983,8 @@ mem01_exit:
 static TEEC_Result
 Invoke_Crypto_AsymmetricSignDigest(ADBG_Case_t *c, TEEC_Session *s,
 				   uint32_t cmd, uint32_t oph,
-				   const void *full_data __unused,
-				   size_t fdata_length __unused,
+				   const void *full_data,
+				   size_t fdata_length,
 				   uint32_t case_buf)
 {
 	TEEC_Result res;
@@ -2049,7 +2048,7 @@ mem01_exit:
 static TEEC_Result
 Invoke_Crypto_AsymmetricVerifyDigest(ADBG_Case_t *c, TEEC_Session *s,
 				     uint32_t cmd, uint32_t oph,
-				     const void *full_data __unused,
+				     const void *full_data,
 				     size_t fdata_length, uint32_t buffer_case,
 				     uint32_t valid_sig)
 {
@@ -3134,7 +3133,7 @@ static bool padding_is_pkcs1_v1_5(uint32_t algo)
 	}
 }
 
-static int ossl_err_cb(const char *str, size_t len, void *u __unused)
+static int ossl_err_cb(const char *str, size_t len, void *u)
 {
 	warnx("%*s", (int)len, str);
 	return 0;
@@ -3240,8 +3239,8 @@ out:
 }
 
 static bool rsa_verify_digest(ADBG_Case_t *c, const struct rsa_key_vals *kv,
-			      uint32_t algo __unused,
-			      const void *digest, size_t digest_len __unused,
+			      uint32_t algo,
+			      const void *digest, size_t digest_len,
 			      const struct crypto_buffer *in_sdgst)
 {
 	const EVP_MD *md = algo_to_md(algo);

--- a/host/xtest/gp/include/xml_datastorage_api.h
+++ b/host/xtest/gp/include/xml_datastorage_api.h
@@ -8,7 +8,6 @@
 #define XML_DATASTORAGE_API_H_
 
 #include <assert.h>
-#include <compiler.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1299,7 +1298,7 @@ static TEEC_Result Invoke_AllocateTransientObject(ADBG_Case_t *c,
 					 obj_size);
 }
 
-static TEEC_Result Invoke_GetObjectInfo1(ADBG_Case_t *c __unused,
+static TEEC_Result Invoke_GetObjectInfo1(ADBG_Case_t *c,
 					 TEEC_Session *sess, uint32_t cmd,
 					 uint32_t obj_handle, uint32_t obj_info)
 {
@@ -1523,7 +1522,7 @@ static uint32_t get_attribute_and_advance(uint32_t attr_list, size_t *n)
 	return ATTRIBUTE_NONE;
 }
 
-static TEEC_Result Invoke_PopulateTransientObject(ADBG_Case_t *c __unused,
+static TEEC_Result Invoke_PopulateTransientObject(ADBG_Case_t *c,
 						  TEEC_Session *sess,
 						  uint32_t cmd,
 						  uint32_t obj_handle,
@@ -1568,9 +1567,9 @@ static TEEC_Result Invoke_CopyObjectAttributes(ADBG_Case_t *c,
 static TEEC_Result Invoke_InitValueAttribute(ADBG_Case_t *c, TEEC_Session *sess,
 					     uint32_t cmd, uint32_t attr,
 					     uint32_t attr_id, uint32_t a,
-					     uint32_t __unused a_size,
+					     uint32_t a_size,
 					     uint32_t b,
-					     uint32_t __unused b_size)
+					     uint32_t b_size)
 {
 	return Invoke_Simple_Function_v2(c, sess, cmd, attr, attr_id, a, b);
 }
@@ -1713,7 +1712,7 @@ static TEEC_Result Invoke_FreePersistentObjectEnumerator(ADBG_Case_t *c,
 }
 
 
-static TEEC_Result Invoke_GenerateKey(ADBG_Case_t *c __unused,
+static TEEC_Result Invoke_GenerateKey(ADBG_Case_t *c,
 				      TEEC_Session *sess, uint32_t cmd,
 				      uint32_t obj_handle, uint32_t key_size,
 				      uint32_t attr_list)
@@ -1736,7 +1735,7 @@ static TEEC_Result Invoke_GenerateKey(ADBG_Case_t *c __unused,
 	return TEEC_InvokeCommand(sess, cmd, &op, &org);
 }
 
-static TEEC_Result GetObjectValueAttribute_helper(ADBG_Case_t *c __unused,
+static TEEC_Result GetObjectValueAttribute_helper(ADBG_Case_t *c,
 						  TEEC_Session *sess,
 						  uint32_t n, uint32_t cmd,
 						  uint32_t obj,

--- a/host/xtest/gp/include/xml_internal_api.h
+++ b/host/xtest/gp/include/xml_internal_api.h
@@ -9,7 +9,6 @@
 
 #include <arpa/inet.h>
 #include <assert.h>
-#include <compiler.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -355,7 +354,7 @@ exit:
 	return res;
 }
 
-static TEEC_Result Invoke_SetInstanceData(ADBG_Case_t *c __unused,
+static TEEC_Result Invoke_SetInstanceData(ADBG_Case_t *c,
 					  TEEC_Session *sess, uint32_t cmdId,
 					  char *data)
 {
@@ -455,7 +454,7 @@ mem01_exit:
 	return res;
 }
 
-static TEEC_Result Invoke_CheckMemoryAccessRight(ADBG_Case_t *c __unused,
+static TEEC_Result Invoke_CheckMemoryAccessRight(ADBG_Case_t *c,
 						 TEEC_Session *sess,
 						 uint32_t cmdId,
 						 uint32_t memoryParamType,
@@ -502,13 +501,13 @@ mem01_exit:
 	return res;
 }
 
-static TEEC_Result Invoke_MemMove(ADBG_Case_t *c __unused, TEEC_Session *sess,
+static TEEC_Result Invoke_MemMove(ADBG_Case_t *c, TEEC_Session *sess,
 				  uint32_t cmdId, uint32_t memorySize)
 {
 	return Invoke_Simple_Function_v1(c, sess, cmdId, memorySize, 0);
 }
 
-static TEEC_Result Invoke_AllocatePropertyEnumerator(ADBG_Case_t *c __unused,
+static TEEC_Result Invoke_AllocatePropertyEnumerator(ADBG_Case_t *c,
 						     TEEC_Session *sess,
 						     uint32_t cmdId,
 						     uint32_t *enumerator)

--- a/host/xtest/gp/include/xml_timearithm_api.h
+++ b/host/xtest/gp/include/xml_timearithm_api.h
@@ -8,7 +8,6 @@
 #define XML_TIMEARITHM_API_H_
 
 #include <assert.h>
-#include <compiler.h>
 #include <openssl/bn.h>
 #include <pthread.h>
 #include <stdio.h>

--- a/host/xtest/install_ta.c
+++ b/host/xtest/install_ta.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <compiler.h>
 #include <dirent.h>
 #include <err.h>
 #include <errno.h>

--- a/host/xtest/regression_4100.c
+++ b/host/xtest/regression_4100.c
@@ -2,7 +2,6 @@
 /* Copyright (c) 2018, Linaro Limited */
 
 #include <adbg.h>
-#include <compiler.h>
 #include <ctype.h>
 #include <inttypes.h>
 #include <stdarg.h>

--- a/host/xtest/regression_8100.c
+++ b/host/xtest/regression_8100.c
@@ -4,7 +4,6 @@
 #include "xtest_test.h"
 #include "xtest_helpers.h"
 
-#include <compiler.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -257,8 +256,8 @@ out:
 	return ret;
 }
 #else /*!OPENSSL_FOUND*/
-static bool verify_cert(ADBG_Case_t *c __unused, const char *ca __unused,
-			const char *mid __unused, const char *cert __unused)
+static bool verify_cert(ADBG_Case_t *c, const char *ca,
+			const char *mid, const char *cert)
 {
 	Do_ADBG_Log("OpenSSL not available, skipping certificate verification");
 	return true;

--- a/host/xtest/stats.c
+++ b/host/xtest/stats.c
@@ -3,7 +3,6 @@
  * Copyright (c) 2019, Linaro Limited
  */
 
-#include <compiler.h>
 #include <dirent.h>
 #include <err.h>
 #include <errno.h>
@@ -80,7 +79,7 @@ static int close_sess(TEEC_Context *ctx, TEEC_Session *sess)
 	return EXIT_SUCCESS;
 }
 
-static int stat_pager(int argc, char *argv[] __unused)
+static int stat_pager(int argc, char *argv[])
 {
 	TEEC_Context ctx = { };
 	TEEC_Session sess = { };
@@ -113,7 +112,7 @@ static int stat_pager(int argc, char *argv[] __unused)
 	return close_sess(&ctx, &sess);
 }
 
-static int stat_alloc(int argc, char *argv[] __unused)
+static int stat_alloc(int argc, char *argv[])
 {
 	TEEC_Context ctx = { };
 	TEEC_Session sess = { };
@@ -185,7 +184,7 @@ static int stat_alloc(int argc, char *argv[] __unused)
 	return close_sess(&ctx, &sess);
 }
 
-static int stat_memleak(int argc, char *argv[] __unused)
+static int stat_memleak(int argc, char *argv[])
 {
 	TEEC_Context ctx = { };
 	TEEC_Session sess = { };


### PR DESCRIPTION
xtest (the 'host' part, not the TAs) uses __unused from OP-TEE's
<compiler.h>. This does not comply with the following statement from
the C specification:

 In addition to the names documented in this manual, reserved names
 include all external identifiers (global functions and variables)
 that begin with an underscore (‘_’) and all identifiers regardless of
 use that begin with either two underscores or an underscore followed
 by a capital letter are reserved names. This is so that the library
 and header files can define functions, variables, and macros for
 internal purposes without risk of conflict with names in user
 programs.

This is not a hypothetical problem, __unused is used by musl and as
optee-test can't be built with musl.

<compiler.h> and __unused should only be used in TAs (in which case we
know the C library is OP-TEE's libutils). Remove them from xtest and add
-Wno-unused-param to the C flags instead.

Reported-by: Ross Burton <ross.burton@arm.com>
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
