### PR TITLE
xtest: remove some warnings to fix builds with Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ add_compile_options (
 	-Wfloat-equal -Wformat-nonliteral -Wformat-security
 	-Wformat=2 -Winit-self -Wmissing-declarations
 	-Wmissing-format-attribute -Wmissing-include-dirs
-	-Wmissing-noreturn -Wmissing-prototypes -Wnested-externs
+	-Wmissing-prototypes -Wnested-externs
 	-Wpointer-arith -Wshadow -Wstrict-prototypes
 	-Wswitch-default -Wunsafe-loop-optimizations
 	-Wwrite-strings -Werror -fPIC

--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -86,10 +86,6 @@ if (WITH_GP_TESTS)
 	set (GP_INCLUDES PRIVATE gp/include)
 endif()
 
-set_source_files_properties(
-	regression_4100.c PROPERTIES COMPILE_FLAGS -Wno-unsafe-loop-optimizations
-)
-
 if (CFG_GP_SOCKETS)
 	list (APPEND SRC
 		regression_2000.c

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -167,12 +167,11 @@ CFLAGS += -Wall -Wcast-align -Werror \
 	  -Werror-implicit-function-declaration -Wextra -Wfloat-equal \
 	  -Wformat-nonliteral -Wformat-security -Wformat=2 -Winit-self \
 	  -Wmissing-declarations -Wmissing-format-attribute \
-	  -Wmissing-include-dirs -Wmissing-noreturn \
+	  -Wmissing-include-dirs \
 	  -Wmissing-prototypes -Wnested-externs -Wpointer-arith \
 	  -Wshadow -Wstrict-prototypes -Wswitch-default \
 	  -Wwrite-strings -Wno-unused-parameter \
 	  -Wno-declaration-after-statement \
-	  -Wno-unsafe-loop-optimizations \
 	  -Wno-missing-field-initializers -Wno-format-zero-length
 endif
 


### PR DESCRIPTION
Two compiler flags are GCC-specific and cause build failures with Clang.

-Wno-unsafe-loop-optimizations was added by 5a83a50 specifically for GCC 7.x.
As GCC 9 is common now, this can be removed.

-Wmissing-noreturn is of negliable benefit and doesn't show actual problems
in the code.

Fixes #452.

Signed-off-by: Ross Burton <ross.burton@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
