### PR TITLE
xtest: Add test of gcov

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -110,6 +110,12 @@ srcs  += gp_7000.c \
 	 gp_9000.c
 endif
 
+# Should be the last object added to be able to capture the code coverage
+# of the test suite
+ifeq ($(CFG_GCOV_SUPPORT),y)
+srcs += gcov.c
+endif
+
 objs 	:= $(patsubst %.c,$(out-dir)/xtest/%.o, $(srcs))
 
 CFLAGS += -I./
@@ -136,6 +142,9 @@ CFLAGS += -I../../ta/aes_perf/include
 CFLAGS += -I../../ta/socket/include
 CFLAGS += -I../../ta/sdp_basic/include
 CFLAGS += -I../../ta/tpm_log_test/include
+ifeq ($(CFG_GCOV_SUPPORT),y)
+CFLAGS += -I../../ta/gcov/include
+endif
 
 ifdef CFG_GP_PACKAGE_PATH
 CFLAGS += -I../../ta/GP_TTA_Arithmetical

--- a/host/xtest/adbg/include/adbg.h
+++ b/host/xtest/adbg/include/adbg.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: GPL-2.0 */
 /*
  * Copyright (c) 2014, STMicroelectronics International N.V.
+ * Copyright 2020 NXP
  */
 
 #ifndef ADBG_H

--- a/host/xtest/adbg/include/adbg.h
+++ b/host/xtest/adbg/include/adbg.h
@@ -59,6 +59,20 @@ typedef struct adbg_suite_def {
 				 &case_def, link); \
 	}
 
+#define ADBG_CASE_DEFINE_FRONT(Suite, TestID, Run, Title) \
+	__attribute__((constructor)) static void \
+	__adbg_test_case_ ## TestID(void) \
+	{ \
+		static ADBG_Case_Definition_t case_def = { \
+			.TestID_p = #Suite "_" #TestID, \
+			.Title_p = Title, \
+			.Run_fp = Run, \
+		}; \
+		\
+		TAILQ_INSERT_HEAD(&(ADBG_Suite_ ## Suite).cases, \
+				 &case_def, link); \
+	}
+
 /*
  * Suite definitions
  */

--- a/host/xtest/gcov.c
+++ b/host/xtest/gcov.c
@@ -1,15 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
  * Copyright 2020 NXP
  */
 #include <string.h>
 
 #include <adbg.h>
+#include <pta_gcov.h>
+#include <ta_gcov.h>
+#include <tee_client_api.h>
 #include <xtest_helpers.h>
 #include <xtest_test.h>
-
-#include <tee_client_api.h>
-#include <ta_gcov.h>
-#include <pta_gcov.h>
 
 struct gcov_dump_conf {
 	const char *desc;
@@ -23,7 +23,7 @@ static void do_get_version_command(ADBG_Case_t *c, TEEC_UUID *uuid,
 {
 	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, uuid, NULL, &ret_orig)))
@@ -58,7 +58,7 @@ static void do_dump_command(ADBG_Case_t *c, const struct gcov_dump_conf *conf)
 {
 	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	ADBG_EXPECT_NOT_NULL(c, conf);
 
@@ -93,7 +93,7 @@ static void do_core_reset_command(ADBG_Case_t *c)
 	TEEC_Session session = { };
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	TEEC_UUID pta_uuid = PTA_GCOV_UUID;
-	uint32_t ret_orig;
+	uint32_t ret_orig = 0;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &pta_uuid, NULL, &ret_orig)))
@@ -132,7 +132,7 @@ ADBG_CASE_DEFINE_FRONT(regression, 31001, xtest_tee_test_31001,
 
 static void xtest_tee_test_31005(ADBG_Case_t *c)
 {
-	long unsigned int i;
+	long unsigned int i = 0;
 	TEEC_UUID ta_uuid = TA_GCOV_UUID;
 	TEEC_UUID pta_uuid = PTA_GCOV_UUID;
 

--- a/host/xtest/gcov.c
+++ b/host/xtest/gcov.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2020 NXP
+ */
+#include <string.h>
+
+#include <adbg.h>
+#include <xtest_helpers.h>
+#include <xtest_test.h>
+
+#include <tee_client_api.h>
+#include <ta_gcov.h>
+#include <pta_gcov.h>
+
+struct gcov_dump_conf {
+	const char *desc;
+	TEEC_UUID *uuid;
+	unsigned int cmd;
+};
+
+
+static void do_get_version_command(ADBG_Case_t *c, TEEC_UUID *uuid,
+				   unsigned int cmd)
+{
+	TEEC_Session session = { };
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t ret_orig;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		xtest_teec_open_session(&session, uuid, NULL, &ret_orig)))
+		return;
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_OUTPUT, TEEC_NONE,
+					 TEEC_NONE, TEEC_NONE);
+
+	(void)ADBG_EXPECT_TEEC_SUCCESS(c,
+		TEEC_InvokeCommand(&session, cmd, &op, &ret_orig));
+
+	ADBG_EXPECT_TRUE(c, (op.params[0].value.a != 0));
+
+	TEEC_CloseSession(&session);
+}
+
+static void xtest_tee_test_31001(ADBG_Case_t *c)
+{
+	TEEC_UUID pta_uuid = PTA_GCOV_UUID;
+
+	do_get_version_command(c, &pta_uuid, PTA_CMD_GCOV_GET_VERSION);
+}
+
+static void xtest_tee_test_31002(ADBG_Case_t *c)
+{
+	TEEC_UUID ta_uuid = TA_GCOV_UUID;
+
+	do_get_version_command(c, &ta_uuid, TA_GCOV_CMD_GET_VERSION);
+}
+
+static void do_dump_command(ADBG_Case_t *c, const struct gcov_dump_conf *conf)
+{
+	TEEC_Session session = { };
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t ret_orig;
+
+	ADBG_EXPECT_NOT_NULL(c, conf);
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		xtest_teec_open_session(&session, conf->uuid, NULL,
+					&ret_orig)))
+		return;
+
+	op.params[0].tmpref.buffer = (char *)conf->desc;
+	op.params[0].tmpref.size = strlen(conf->desc) + 1;
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT, TEEC_NONE,
+					 TEEC_NONE, TEEC_NONE);
+
+	(void)ADBG_EXPECT_TEEC_SUCCESS(c,
+		TEEC_InvokeCommand(&session, conf->cmd, &op, &ret_orig));
+
+	TEEC_CloseSession(&session);
+}
+
+static void xtest_tee_test_31003(ADBG_Case_t *c)
+{
+	TEEC_UUID pta_uuid = PTA_GCOV_UUID;
+
+	struct gcov_dump_conf conf = {"boot", &pta_uuid,
+				      PTA_CMD_GCOV_CORE_DUMP_ALL};
+
+	do_dump_command(c, &conf);
+}
+
+static void do_core_reset_command(ADBG_Case_t *c)
+{
+	TEEC_Session session = { };
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	TEEC_UUID pta_uuid = PTA_GCOV_UUID;
+	uint32_t ret_orig;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		xtest_teec_open_session(&session, &pta_uuid, NULL, &ret_orig)))
+		return;
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_NONE, TEEC_NONE, TEEC_NONE,
+					 TEEC_NONE);
+
+	(void)ADBG_EXPECT_TEEC_SUCCESS(c,
+		TEEC_InvokeCommand(&session, PTA_CMD_GCOV_CORE_RESET, &op,
+				   &ret_orig));
+
+	TEEC_CloseSession(&session);
+}
+
+static void xtest_tee_test_31004(ADBG_Case_t *c)
+{
+	do_core_reset_command(c);
+}
+
+/*
+ * Add the test at the front of the test suite to capture the code coverage
+ * of the test suite
+ */
+ADBG_CASE_DEFINE_FRONT(regression, 31004, xtest_tee_test_31004,
+		       "Reset core code coverage data");
+
+ADBG_CASE_DEFINE_FRONT(regression, 31003, xtest_tee_test_31003,
+		       "Dump boot code coverage data of core");
+
+ADBG_CASE_DEFINE_FRONT(regression, 31002, xtest_tee_test_31002,
+		       "Get version of code coverage data for TA");
+
+ADBG_CASE_DEFINE_FRONT(regression, 31001, xtest_tee_test_31001,
+		       "Get version of code coverage data for the core");
+
+static void xtest_tee_test_31005(ADBG_Case_t *c)
+{
+	long unsigned int i;
+	TEEC_UUID ta_uuid = TA_GCOV_UUID;
+	TEEC_UUID pta_uuid = PTA_GCOV_UUID;
+
+	struct gcov_dump_conf list_conf[] = {
+		{"xtest_core_from_ca", &pta_uuid, PTA_CMD_GCOV_CORE_DUMP_ALL},
+		{"xtest_core_from_ta", &ta_uuid, TA_GCOV_CMD_DUMP_CORE},
+		{"xtest_ta_from_ta", &ta_uuid, TA_GCOV_CMD_DUMP_TA},
+	};
+
+	for (i = 0; i < sizeof(list_conf) / sizeof(list_conf[0]); i++) {
+		struct gcov_dump_conf *conf = &list_conf[i];
+
+		Do_ADBG_BeginSubCase(c, "Dump %s", conf->desc);
+
+		/* TODO delete the folder in FS */
+
+		do_dump_command(c, conf);
+
+		/* TODO check the folder is created in FS with files */
+
+		Do_ADBG_EndSubCase(c, "Dump %s", conf->desc);
+	}
+}
+ADBG_CASE_DEFINE(regression, 31005, xtest_tee_test_31005,
+		 "Dump code coverage data of xtest");

--- a/ta/CMakeLists.txt
+++ b/ta/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(${PROJECT_NAME}
 	INTERFACE create_fail_test/include
 	INTERFACE crypt/include
 	INTERFACE enc_fs/include
+	INTERFACE gcov/include
 	INTERFACE os_test/include
 	INTERFACE rpc_test/include
 	INTERFACE sdp_basic/include
@@ -20,5 +21,4 @@ target_include_directories(${PROJECT_NAME}
 	INTERFACE socket/include
 	INTERFACE storage_benchmark/include
 	INTERFACE tpm_log_test/include
-	INTERFACE gcov/include
 )

--- a/ta/CMakeLists.txt
+++ b/ta/CMakeLists.txt
@@ -20,4 +20,5 @@ target_include_directories(${PROJECT_NAME}
 	INTERFACE socket/include
 	INTERFACE storage_benchmark/include
 	INTERFACE tpm_log_test/include
+	INTERFACE gcov/include
 )

--- a/ta/Makefile
+++ b/ta/Makefile
@@ -32,6 +32,10 @@ TA_DIRS := create_fail_test \
 	   aes_perf \
 	   socket
 
+ifeq ($(CFG_GCOV_SUPPORT),y)
+TA_DIRS += gcov
+endif
+
 ifeq ($(CFG_SECURE_DATA_PATH),y)
 TA_DIRS += sdp_basic
 endif

--- a/ta/gcov/Android.mk
+++ b/ta/gcov/Android.mk
@@ -1,0 +1,4 @@
+LOCAL_PATH := $(call my-dir)
+
+local_module := a424901c-4810-4e4d-aa76-62ef0045343f
+include $(BUILD_OPTEE_MK)

--- a/ta/gcov/Makefile
+++ b/ta/gcov/Makefile
@@ -1,0 +1,3 @@
+BINARY = a424901c-4810-4e4d-aa76-62ef0045343f
+
+include ../ta_common.mk

--- a/ta/gcov/include/ta_gcov.h
+++ b/ta/gcov/include/ta_gcov.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2020 NXP
+ */
+
+#ifndef TA_GCOV_H
+#define TA_GCOV_H
+
+#define TA_GCOV_UUID { 0xa424901c, 0x4810, 0x4e4d, \
+		{ 0xaa, 0x76, 0x62, 0xef, 0x00, 0x45, 0x34, 0x3f} }
+
+#define TA_GCOV_CMD_GET_VERSION	0
+#define TA_GCOV_CMD_DUMP_CORE	1
+#define TA_GCOV_CMD_DUMP_TA	2
+
+#endif /* TA_GCOV_H */

--- a/ta/gcov/include/ta_gcov.h
+++ b/ta/gcov/include/ta_gcov.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0 */
 /*
  * Copyright 2020 NXP
  */
@@ -8,8 +9,27 @@
 #define TA_GCOV_UUID { 0xa424901c, 0x4810, 0x4e4d, \
 		{ 0xaa, 0x76, 0x62, 0xef, 0x00, 0x45, 0x34, 0x3f} }
 
+/*
+ * TA_GCOV_CMD_GET_VERSION - Proxy function which calls gcov_get_version()
+ *
+ * [out]    value[0].a	    version of gcov
+ */
 #define TA_GCOV_CMD_GET_VERSION	0
+
+/*
+ * TA_GCOV_CMD_DUMP_CORE - Proxy function which invoke
+ * PTA_CMD_GCOV_CORE_DUMP_ALL from gcov PTA
+ *
+ * [in]    memref[0]	     Name of the dump
+*/
 #define TA_GCOV_CMD_DUMP_CORE	1
+
+/*
+ * TA_GCOV_CMD_DUMP_TA - Proxy function which calls
+ * gcov_dump_all_coverage_data()
+ *
+ * [in]    memref[0]	    Name of the dump
+ */
 #define TA_GCOV_CMD_DUMP_TA	2
 
 #endif /* TA_GCOV_H */

--- a/ta/gcov/include/user_ta_header_defines.h
+++ b/ta/gcov/include/user_ta_header_defines.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0 */
 /*
  * Copyright 2020 NXP
  */
@@ -9,9 +10,7 @@
 
 #define TA_UUID TA_GCOV_UUID
 
-#define TA_FLAGS                (TA_FLAG_USER_MODE | TA_FLAG_EXEC_DDR | \
-				TA_FLAG_SECURE_DATA_PATH | \
-				TA_FLAG_CACHE_MAINTENANCE)
+#define TA_FLAGS 0
 
 #define TA_STACK_SIZE		(2 * 1024)
 #define TA_DATA_SIZE		(32 * 1024)

--- a/ta/gcov/include/user_ta_header_defines.h
+++ b/ta/gcov/include/user_ta_header_defines.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 NXP
+ */
+
+#ifndef USER_TA_HEADER_DEFINES_H
+#define USER_TA_HEADER_DEFINES_H
+
+#include "ta_gcov.h"
+
+#define TA_UUID TA_GCOV_UUID
+
+#define TA_FLAGS                (TA_FLAG_USER_MODE | TA_FLAG_EXEC_DDR | \
+				TA_FLAG_SECURE_DATA_PATH | \
+				TA_FLAG_CACHE_MAINTENANCE)
+
+#define TA_STACK_SIZE		(2 * 1024)
+#define TA_DATA_SIZE		(32 * 1024)
+
+#endif

--- a/ta/gcov/sub.mk
+++ b/ta/gcov/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += include
+srcs-y += ta_gcov.c

--- a/ta/gcov/ta_gcov.c
+++ b/ta/gcov/ta_gcov.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 NXP
+ */
+
+#define STR_TRACE_USER_TA "GCOV"
+
+#include <tee_internal_api.h>
+#include <tee_internal_api_extensions.h>
+
+#include <gcov.h>
+#include <pta_gcov.h>
+#include "ta_gcov.h"
+
+TEE_Result TA_CreateEntryPoint(void)
+{
+	return TEE_SUCCESS;
+}
+
+void TA_DestroyEntryPoint(void)
+{
+}
+
+TEE_Result TA_OpenSessionEntryPoint(uint32_t param_types,
+		TEE_Param  params[4], void **sess_ctx)
+{
+	uint32_t exp_param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE);
+	if (param_types != exp_param_types) {
+		EMSG("Wrong param_types, exp %x, got %x", exp_param_types,
+		     param_types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	(void)&params;
+	(void)&sess_ctx;
+
+	return TEE_SUCCESS;
+}
+
+void TA_CloseSessionEntryPoint(void *sess_ctx)
+{
+	(void)&sess_ctx;
+}
+
+static TEE_Result get_version(uint32_t param_types, TEE_Param params[4])
+{
+	uint32_t exp_param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+						   TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE);
+
+	if (param_types != exp_param_types) {
+		EMSG("Wrong param_types, exp %x, got %x", exp_param_types,
+		     param_types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return gcov_get_version(&params[0].value.a);
+}
+
+static TEE_Result dump_core(uint32_t param_types, TEE_Param params[4])
+{
+	TEE_Result res;
+	uint32_t exp_param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+						   TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE);
+	uint32_t cRT = TEE_TIMEOUT_INFINITE;
+	TEE_UUID uuid = (TEE_UUID)PTA_GCOV_UUID;
+	TEE_TASessionHandle sess;
+	uint32_t err_origin;
+	uint32_t int_ptypes = 0;
+	TEE_Param int_params[TEE_NUM_PARAMS] = {0};
+
+	if (param_types != exp_param_types) {
+		EMSG("Wrong param_types, exp %x, got %x", exp_param_types,
+		     param_types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/* Call gcov pta to dump the data */
+	res = TEE_OpenTASession(&uuid, cRT, 0, NULL, &sess, &err_origin);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_OpenTASession failed with code 0x%x origin 0x%x",
+		     res, err_origin);
+		goto exit;
+	}
+
+	int_ptypes = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				     TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE,
+				     TEE_PARAM_TYPE_NONE);
+
+	/* new_filepath */
+	int_params[0].memref.buffer = params[0].memref.buffer;
+	int_params[0].memref.size = params[0].memref.size;
+
+	res = TEE_InvokeTACommand(sess, cRT, PTA_CMD_GCOV_CORE_DUMP_ALL,
+				  int_ptypes, int_params, &err_origin);
+	if (res != TEE_SUCCESS)
+		EMSG("TEE_InvokeTACommand failed with code 0x%x origin 0x%x",
+		     res, err_origin);
+
+exit:
+	TEE_CloseTASession(sess);
+
+	return res;
+}
+
+static TEE_Result dump_ta(uint32_t param_types, TEE_Param params[4])
+{
+	uint32_t exp_param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+						   TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE);
+
+	if (param_types != exp_param_types) {
+		EMSG("Wrong param_types, exp %x, got %x", exp_param_types,
+		     param_types);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return gcov_dump_all_coverage_data(params[0].memref.buffer);
+}
+
+TEE_Result TA_InvokeCommandEntryPoint(void *sess_ctx, uint32_t cmd_id,
+			uint32_t param_types, TEE_Param params[4])
+{
+	(void)&sess_ctx;
+
+	switch (cmd_id) {
+	case TA_GCOV_CMD_GET_VERSION:
+		return get_version(param_types, params);
+	case TA_GCOV_CMD_DUMP_CORE:
+		return dump_core(param_types, params);
+	case TA_GCOV_CMD_DUMP_TA:
+		return dump_ta(param_types, params);
+	default:
+		EMSG("Command %d not supported", cmd_id);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+}

--- a/ta/gcov/ta_gcov.c
+++ b/ta/gcov/ta_gcov.c
@@ -1,15 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
  * Copyright 2020 NXP
  */
 
 #define STR_TRACE_USER_TA "GCOV"
 
-#include <tee_internal_api.h>
-#include <tee_internal_api_extensions.h>
-
 #include <gcov.h>
 #include <pta_gcov.h>
 #include "ta_gcov.h"
+#include <tee_internal_api.h>
+#include <tee_internal_api_extensions.h>
 
 TEE_Result TA_CreateEntryPoint(void)
 {
@@ -69,10 +69,10 @@ static TEE_Result dump_core(uint32_t param_types, TEE_Param params[4])
 						   TEE_PARAM_TYPE_NONE);
 	uint32_t cRT = TEE_TIMEOUT_INFINITE;
 	TEE_UUID uuid = (TEE_UUID)PTA_GCOV_UUID;
-	TEE_TASessionHandle sess;
-	uint32_t err_origin;
+	TEE_TASessionHandle sess = { 0 };
+	uint32_t err_origin = 0;
 	uint32_t int_ptypes = 0;
-	TEE_Param int_params[TEE_NUM_PARAMS] = {0};
+	TEE_Param int_params[TEE_NUM_PARAMS] = { 0 };
 
 	if (param_types != exp_param_types) {
 		EMSG("Wrong param_types, exp %x, got %x", exp_param_types,
@@ -102,9 +102,9 @@ static TEE_Result dump_core(uint32_t param_types, TEE_Param params[4])
 		EMSG("TEE_InvokeTACommand failed with code 0x%x origin 0x%x",
 		     res, err_origin);
 
-exit:
 	TEE_CloseTASession(sess);
 
+exit:
 	return res;
 }
 


### PR DESCRIPTION
Adds test for gcov in the range 31000

This patch adds a set of test of the generation of code coverage:
(At the font of the test suite)
 - 31001: Check the code coverage is enabled for the core:
 - 31002: Check the code coverage is enabled for the TA:
 - 31003: Dump the current code coverage of the core
 - 31004: Reset the code coverage of the core
(Normal execution in order, should be at the end)
 - 31005: Dump different code coverage:
   - 31005.1: Core code coverage from xtest
   - 31005.2: Core code coverage from TA
   - 31005.3: TA code coverage from TA

The test are added using ADBG_CASE_DEFINE_FRONT to the test suite
so the code coverage of the core is resetted before executing xtest
suite and dump at the end.
It allows to capture the code coverage of the core when running
xtest.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
