### PR TITLE
xtest: sort cases to use a well defined order

### DIFF
--- a/host/xtest/adbg/include/adbg.h
+++ b/host/xtest/adbg/include/adbg.h
@@ -54,9 +54,16 @@ typedef struct adbg_suite_def {
 			.Title_p = Title, \
 			.Run_fp = Run, \
 		}; \
+		struct adbg_case_def_head *ch = &(ADBG_Suite_ ## Suite).cases; \
+		struct adbg_case_def *cd = NULL; \
 		\
-		TAILQ_INSERT_TAIL(&(ADBG_Suite_ ## Suite).cases, \
-				 &case_def, link); \
+		TAILQ_FOREACH(cd, ch, link) \
+			if (strcmp(case_def.TestID_p, cd->TestID_p) < 0) \
+				break; \
+		if (cd) \
+			TAILQ_INSERT_BEFORE(cd, &case_def, link); \
+		else \
+			TAILQ_INSERT_TAIL(ch, &case_def, link); \
 	}
 
 /*


### PR DESCRIPTION
Prior to this patch was the order of the cases depending on link order
and in which order constructors are called inside an object file. To use
a well defined order, sort the cases while registering them.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
