### PR TITLE
Fix key size tests (from == to <=)

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -4500,7 +4500,7 @@ static bool test_keygen_attributes(ADBG_Case_t *c, TEEC_Session *s,
 				return false;
 
 			if (attrs[m].keysize_check)
-				ADBG_EXPECT_COMPARE_UNSIGNED(c, out_size, ==,
+				ADBG_EXPECT_COMPARE_UNSIGNED(c, out_size, <=,
 							     key_size / 8);
 
 			if (out_size > 0) {


### PR DESCRIPTION
Test 4007_dh was found to fail occasionally when the core crypto
library is MBed TLS, but not with LibTomCrypt. It is because the OP-TEE
custom DH key generation in LibTomCrypt has a bug [1]: it always sets
bit 'xbits' when xbits != 0, and the tests do verify this property.

This patch changes the key size test so that it checks that the byte
size of the private key is smaller or equal to the requested key size,
not strictly equal.

This change also impacts other algorithms than DH, although no failure
have been found with them. But what garantee do we have that a n-bit
private key should always have a non-zero top n/8th byte?

To reproduce the failure with MBed TLS prior to this patch:

 $ make CFG_CRYPTOLIB_NAME=mbedtls CFG_CRYPTOLIB_DIR=lib/libmbedtls
 QEMU $ while [ $? -eq 0 ]; do xtest -l 15 4007_dh; done

Link: [1] https://github.com/OP-TEE/optee_os/pull/4215
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
