### PR TITLE
xtest: mark unused params

### DIFF
--- a/host/xtest/regression_8100.c
+++ b/host/xtest/regression_8100.c
@@ -259,6 +259,10 @@ out:
 static bool verify_cert(ADBG_Case_t *c, const char *ca,
 			const char *mid, const char *cert)
 {
+	UNUSED(c);
+	UNUSED(ca);
+	UNUSED(mid);
+	UNUSED(cert);
 	Do_ADBG_Log("OpenSSL not available, skipping certificate verification");
 	return true;
 }

--- a/host/xtest/stats.c
+++ b/host/xtest/stats.c
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #include <tee_client_api.h>
 #include <unistd.h>
+#include "xtest_helpers.h"
 #include "xtest_test.h"
 #include "stats.h"
 
@@ -87,6 +88,7 @@ static int stat_pager(int argc, char *argv[])
 	uint32_t eo = 0;
 	TEEC_Operation op = { };
 
+	UNUSED(argv);
 	if (argc != 1)
 		return usage();
 
@@ -123,6 +125,7 @@ static int stat_alloc(int argc, char *argv[])
 	size_t stats_size_bytes = 0;
 	size_t n = 0;
 
+	UNUSED(argv);
 	if (argc != 1)
 		return usage();
 
@@ -191,6 +194,7 @@ static int stat_memleak(int argc, char *argv[])
 	TEEC_Result res = TEEC_ERROR_GENERIC;
 	uint32_t eo = 0;
 
+	UNUSED(argv);
 	if (argc != 1)
 		return usage();
 


### PR DESCRIPTION
Mark unused params to avoid build warnings/errors.

Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
