### PR TITLE
regression 1008: only test open session failure once

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -749,19 +749,15 @@ static void xtest_tee_test_1008(ADBG_Case_t *c)
 	{
 		size_t n = 0;
 
-		(void)ADBG_EXPECT_TEEC_RESULT(c, TEEC_ERROR_GENERIC,
-			xtest_teec_open_session(&session_crypt,
-						&create_fail_test_ta_uuid, NULL,
-						&ret_orig));
-		/*
-		 * Run this several times to see that there's no memory leakage.
-		 */
 		for (n = 0; n < 100; n++) {
 			Do_ADBG_Log("n = %zu", n);
 			(void)ADBG_EXPECT_TEEC_RESULT(c, TEEC_ERROR_GENERIC,
 				xtest_teec_open_session(&session_crypt,
 					&create_fail_test_ta_uuid,
 					NULL, &ret_orig));
+			/* level > 0 may be used to detect/debug memory leaks */
+			if (!level)
+				break;
 		}
 	}
 	Do_ADBG_EndSubCase(c, "Create session fail");


### PR DESCRIPTION
Test 1008 runs a negative test for TEEC_OpenSession() 100 times in a
loop. A comment says it is to check for memory leaks, but it is a bit
pointless because there is no guarantee that such a leak would be
detected this way. xtest is a functional test suite, not a stress test
tool so this kind of test is not really appropriate. It increases the
execution time and the amount of logs produced for very little benefit.

Therefore, remove the loop and test the open session failure only once.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
