### PR TITLE
xtest: pkcs11: Add test case for C_SignUpdate()/C_VerifyUpdate()

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -1597,6 +1597,12 @@ static void xtest_pkcs11_test_1008(ADBG_Case_t *c)
 			if (!ADBG_EXPECT_CK_OK(c, rv))
 				goto err_destr_obj;
 
+			/* Pass input buffer of size 0 */
+			rv = C_SignUpdate(session,
+					  (void *)test->in, 0);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
 			rv = C_SignUpdate(session,
 					  (void *)test->in, test->in_len);
 			if (!ADBG_EXPECT_CK_OK(c, rv))
@@ -1743,6 +1749,11 @@ static void xtest_pkcs11_test_1009(ADBG_Case_t *c)
 		/* Test Verification in 1 step */
 		if (test->in != NULL) {
 			rv = C_VerifyInit(session, test->mechanism, key_handle);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/* Pass input buffer with size 0 - No affect */
+			rv = C_VerifyUpdate(session, (void *)test->in, 0);
 			if (!ADBG_EXPECT_CK_OK(c, rv))
 				goto err_destr_obj;
 


### PR DESCRIPTION
Add test case for checking that a call to C_SignUpdate()/
C_VerifyUpdate() with valid input buffer and size as 0 returns
no error and has no effect on output result.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
