### PR TITLE
xtest: pkcs11: Fix parallel session test

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -363,7 +363,7 @@ static void xtest_pkcs11_test_1002(ADBG_Case_t *c)
 	session_flags = CKF_RW_SESSION;
 
 	rv = C_OpenSession(slot, session_flags, NULL, 0, &session[0]);
-	if (!ADBG_EXPECT_CK_RESULT(c, CKR_ARGUMENTS_BAD, rv))
+	if (!ADBG_EXPECT_CK_RESULT(c, CKR_SESSION_PARALLEL_NOT_SUPPORTED, rv))
 		goto bail;
 
 	session_flags = CKF_SERIAL_SESSION;


### PR DESCRIPTION
When trying to open session without CKF_SERIAL_SESSION method should fail
with CKR_SESSION_PARALLEL_NOT_SUPPORTED.

Specified in:

PKCS #11 Cryptographic Token Interface Base Specification Version 2.40
Plus Errata 01
5.6 Session management functions
C_OpenSession

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
