### PR TITLE
xtest: regression 1014: rename pTA name used in SDP tests

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -1238,16 +1238,16 @@ static void xtest_tee_test_1014(ADBG_Case_t *c)
 	Do_ADBG_EndSubCase(c, "SDP: SDP TA invokes a SDP TA");
 
 	test = TEST_TA_TO_PTA;
-	Do_ADBG_BeginSubCase(c, "SDP: SDP TA invokes a SDP pTA");
+	Do_ADBG_BeginSubCase(c, "SDP: SDP TA invokes a test pTA (invoke_tests.pta)");
 	ret = sdp_basic_test(test, size, loop, ion_heap, rnd_offset, 0);
 	ADBG_EXPECT(c, 0, ret);
-	Do_ADBG_EndSubCase(c, "SDP: SDP TA invokes a SDP pTA");
+	Do_ADBG_EndSubCase(c, "SDP: SDP TA invokes a test pTA (invoke_tests.pta)");
 
 	test = TEST_NS_TO_PTA;
-	Do_ADBG_BeginSubCase(c, "SDP: NSec CA invokes SDP pTA (should fail)");
+	Do_ADBG_BeginSubCase(c, "SDP: NSec CA invokes a test pTA (invoke_tests.pta) (should fail)");
 	ret = sdp_basic_test(test, size, loop, ion_heap, rnd_offset, 0);
 	ADBG_EXPECT(c, 1, ret);
-	Do_ADBG_EndSubCase(c, "SDP: NSec CA invokes SDP pTA (should fail)");
+	Do_ADBG_EndSubCase(c, "SDP: NSec CA invokes a test pTA (invoke_tests.pta) (should fail)");
 
 	Do_ADBG_BeginSubCase(c, "SDP: Invoke TA with out of bounds SDP memref");
 	ret = sdp_out_of_bounds_memref_test(size, ion_heap, 0);


### PR DESCRIPTION
```
pTA UUID which used for SDP tests is PTA_INVOKE_TESTS_UUID`, which points
to a different "invokes_tests.pta", not "sdp.pta".
Rename it to avoid future confusion.

Signed-off-by: Igor Opaniuk <igor.opaniuk@gmail.com>
```
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
