### PR TITLE
xtest: pkcs11: Modify testcase 1011 for changes in C_Logout()

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -2339,10 +2339,32 @@ static void xtest_pkcs11_test_1011(ADBG_Case_t *c)
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto out;
 
-	rv = C_Logout(session);
-	ADBG_EXPECT_CK_OK(c, rv);
+	Do_ADBG_EndSubCase(c, NULL);
 
-	logged_in = false;
+	/*
+	 * Sub test: finalize search without getting the handles found
+	 */
+	Do_ADBG_BeginSubCase(c, "Initiate and finalize straight a search");
+
+	rv = C_FindObjectsInit(session, find_template,
+			       ARRAY_SIZE(find_template));
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto out;
+
+	rv = C_FindObjectsFinal(session);
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto out;
+
+	/*
+	 * Check if object handles returned when creating objects with this
+	 * session are still valid
+	 */
+	for (i = 0; i < object_id; i++) {
+		rv = C_GetAttributeValue(session, obj_hdl[i], get_attr_template,
+					 ARRAY_SIZE(get_attr_template));
+		if (!ADBG_EXPECT_CK_OK(c, rv))
+			goto out;
+	}
 	Do_ADBG_EndSubCase(c, NULL);
 
 	/*
@@ -2350,6 +2372,11 @@ static void xtest_pkcs11_test_1011(ADBG_Case_t *c)
 	 * objects (2)
 	 */
 	Do_ADBG_BeginSubCase(c, "Find created Data objects when logged out");
+
+	rv = C_Logout(session);
+	ADBG_EXPECT_CK_OK(c, rv);
+
+	logged_in = false;
 
 	rv = test_find_objects(c, session, find_template,
 			       ARRAY_SIZE(find_template),
@@ -2439,36 +2466,9 @@ static void xtest_pkcs11_test_1011(ADBG_Case_t *c)
 
 	rv = test_find_objects(c, session, find_template,
 			       ARRAY_SIZE(find_template),
-			       obj_found, ARRAY_SIZE(obj_found), 4);
+			       obj_found, ARRAY_SIZE(obj_found), 3);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto out;
-
-	Do_ADBG_EndSubCase(c, NULL);
-
-	/*
-	 * Sub test: finalize search without getting the handles found
-	 */
-	Do_ADBG_BeginSubCase(c, "Initiate and finalize straight a search");
-
-	rv = C_FindObjectsInit(session, find_template,
-			       ARRAY_SIZE(find_template));
-	if (!ADBG_EXPECT_CK_OK(c, rv))
-		goto out;
-
-	rv = C_FindObjectsFinal(session);
-	if (!ADBG_EXPECT_CK_OK(c, rv))
-		goto out;
-
-	/*
-	 * Check if object handles returned when creating objects with this
-	 * session are still valid
-	 */
-	for (i = 0; i < object_id; i++) {
-		rv = C_GetAttributeValue(session, obj_hdl[i], get_attr_template,
-					 ARRAY_SIZE(get_attr_template));
-		if (!ADBG_EXPECT_CK_OK(c, rv))
-			goto out;
-	}
 
 	rv = C_Logout(session);
 	ADBG_EXPECT_CK_OK(c, rv);


### PR DESCRIPTION
PKCS#11 specification states that :
When C_Logout successfully executes, any of the application’s
handles to private objects should become invalid (even if a user
is later logged back into the token, those handles remain invalid).
In addition, all private session objects from sessions belonging
to the application should also be destroyed.

One of the find sub-test case was expecting that after logging back
in a session , private session object would be visible which was
a wrong assumption. This has been modified.

Another subcase assumed the handle of the token object returned
would be same as that when the token object was created by that
session. This assumption would hold good only during the first
log in into this session. If a user logs out and then logs in
again, the token object handles would change. So this sub-case
has been moved to be tested during the first login to the session.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
