### PR TITLE
Android.mk: improve legibility

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -24,10 +24,6 @@ LOCAL_SHARED_LIBRARIES := libteec
 
 TA_DIR ?= /vendor/lib/optee_armtz
 
-ifeq ($(CFG_PKCS11_TA),y)
-LOCAL_SHARED_LIBRARIES += libckteec
-endif
-
 srcs := regression_1000.c
 
 ifeq ($(CFG_GP_SOCKETS),y)
@@ -67,6 +63,8 @@ endif
 
 ifeq ($(CFG_PKCS11_TA),y)
 srcs += pkcs11_1000.c
+LOCAL_CFLAGS += -DCFG_PKCS11_TA
+LOCAL_SHARED_LIBRARIES += libckteec
 endif
 
 define my-embed-file
@@ -87,8 +85,7 @@ LOCAL_SRC_FILES := $(patsubst %,host/xtest/%,$(srcs))
 
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/host/xtest \
 		$(LOCAL_PATH)/host/xtest/adbg/include\
-		$(LOCAL_PATH)/ta/concurrent/include \
-		$(LOCAL_PATH)/ta/concurrent_large/include \
+		$(LOCAL_PATH)/ta/include \
 		$(LOCAL_PATH)/ta/create_fail_test/include \
 		$(LOCAL_PATH)/ta/crypt/include \
 		$(LOCAL_PATH)/ta/enc_fs/include \
@@ -97,8 +94,9 @@ LOCAL_C_INCLUDES += $(LOCAL_PATH)/host/xtest \
 		$(LOCAL_PATH)/ta/sims/include \
 		$(LOCAL_PATH)/ta/miss/include \
 		$(LOCAL_PATH)/ta/sims_keepalive/include \
-		$(LOCAL_PATH)/ta/include \
 		$(LOCAL_PATH)/ta/storage_benchmark/include \
+		$(LOCAL_PATH)/ta/concurrent/include \
+		$(LOCAL_PATH)/ta/concurrent_large/include \
 		$(LOCAL_PATH)/ta/sha_perf/include \
 		$(LOCAL_PATH)/ta/aes_perf/include \
 		$(LOCAL_PATH)/ta/socket/include \
@@ -113,10 +111,6 @@ LOCAL_CFLAGS += -Wno-missing-field-initializers -Wno-format-zero-length
 
 ifneq ($(TA_DIR),)
 LOCAL_CFLAGS += -DTA_DIR=\"$(TA_DIR)\"
-endif
-
-ifeq ($(CFG_PKCS11_TA),y)
-LOCAL_CFLAGS += -DCFG_PKCS11_TA
 endif
 
 ## $(OPTEE_BIN) is the path of tee.bin like

--- a/Android.mk
+++ b/Android.mk
@@ -51,7 +51,8 @@ srcs +=	adbg/src/adbg_case.c \
 	stats.c \
 	xtest_helpers.c \
 	xtest_main.c \
-	xtest_test.c
+	xtest_test.c \
+	xtest_uuid_helpers.c
 
 ifeq ($(CFG_SECSTOR_TA_MGMT_PTA),y)
 srcs += install_ta.c


### PR DESCRIPTION
Rearrange some code segments to make Android.mk more in sync with
host/xtest/Makefile and improve legibility.

xtest_uuid_helpers.c is also missing from 'srcs' so add that too.

Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
