### PR TITLE
Fix failing build

### DIFF
--- a/host/supp_plugin/Makefile
+++ b/host/supp_plugin/Makefile
@@ -6,16 +6,18 @@ PLUGIN_OBJ		= $(patsubst %.c, $(O)/supp_plugin/%.o, $(PLUGIN_SRS))
 PLUGIN_INCLUDES_DIR	= $(CURDIR)/include $(OPTEE_CLIENT_EXPORT)/include
 
 PLUGIN_INCLUDES		= $(addprefix -I, $(PLUGIN_INCLUDES_DIR))
-PLUGIN_CCFLAGS		= -Wall -fPIC
-PLUGIN_LDFLAGS		= -shared
+PLUGIN_CCFLAGS		= $(CFLAGS) -Wall -fPIC
+PLUGIN_LDFLAGS		= $(LDFLAGS) -shared
+
+CC			?= $(CROSS_COMPILE)gcc
 
 $(O)/supp_plugin/$(PLUGIN): $(PLUGIN_OBJ)
-	$(q)$(CROSS_COMPILE)gcc $(PLUGIN_LDFLAGS) $(PLUGIN_OBJ) -o $@
+	$(q)$(CC) $(PLUGIN_LDFLAGS) $(PLUGIN_OBJ) -o $@
 
 $(O)/supp_plugin/%.o: $(CURDIR)/%.c
 	$(q)mkdir -p $(O)/supp_plugin
 	@echo '  CC      $<'
-	$(q)$(CROSS_COMPILE)gcc $(PLUGIN_INCLUDES) $(PLUGIN_CCFLAGS) -c $< -o $@
+	$(q)$(CC) $(PLUGIN_INCLUDES) $(PLUGIN_CCFLAGS) -c $< -o $@
 
 .PHONY: clean
 clean:

--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2354,6 +2354,7 @@ static void xtest_tee_test_1033(ADBG_Case_t *c)
 {
 	TEEC_Session session = { };
 	uint32_t ret_orig = 0;
+	size_t count = 0;
 
 	/* TA will ping the test plugin during open session operation */
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
@@ -2418,7 +2419,8 @@ static void xtest_tee_test_1033(ADBG_Case_t *c)
 		fp = fopen(test_fname, "r");
 		ADBG_EXPECT_NOT_NULL(c, fp);
 		if (fp) {
-			fread(from_file, sizeof(char), sizeof(to_plugin), fp);
+			count = fread(from_file, sizeof(char), sizeof(to_plugin), fp);
+			ADBG_EXPECT_COMPARE_UNSIGNED(c, count, ==, sizeof(to_plugin));
 			ADBG_EXPECT_EQUAL(c, to_plugin, from_file, sizeof(to_plugin));
 			fclose(fp);
 			remove(test_fname);

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -69,7 +69,7 @@ static TEE_Result check_binprop_ones(size_t size, char *bbuf, size_t bblen)
 }
 
 static TEE_Result get_binblock_property(TEE_PropSetHandle h,
-					char *nbuf, char **bbuf, size_t *bblen)
+					char *nbuf __unused, char **bbuf, size_t *bblen)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	uint32_t block_len = 0;


### PR DESCRIPTION
With integration of 01f6f06 ("regression: add tests for the supplicant plugin framework") builds started failing in Yocto.

This PR fixes the issue and also silences older warning.