### PR TITLE
gp: fix warning in TEEC_initialize_memory()

### DIFF
--- a/host/xtest/gp/include/xml_client_api.h
+++ b/host/xtest/gp/include/xml_client_api.h
@@ -269,12 +269,12 @@ static void init_mem(uint8_t *buf, size_t buf_size, size_t begin_size,
 #define TEEC_initialize_memory(shm, tmpMem, offset, _size, value_beginning, \
 			       value_middle, value_end) \
 	do { \
-		if ((long)shm != IGNORE) {\
+		if ((unsigned long)shm != IGNORE) {\
 			TEEC_SharedMemory *__shm = (void *)(long)shm; \
 			init_mem(__shm->buffer, __shm->size, offset, _size, \
 				 value_beginning, value_middle, value_end); \
 			assert(tempMem == IGNORE); \
-		} else if ((long)tmpMem != IGNORE) {\
+		} else if ((unsigned long)tmpMem != IGNORE) {\
 			/* \
 			 * We can't tell the size of tmpMem, so we assume \
 			 * it's offset + size large. \


### PR DESCRIPTION
Fixes a multitude of warnings emitted for the function
TEEC_initialize_memory() when compiling for a 32-bit target.

In file included from gp_10000.c:21:
gp_10000.c: In function ‘gp_test_teec_10023’:
gp/include/xml_client_api.h:272:17: error: comparison of integer expressions of different signedness: ‘long int’ and ‘unsigned int’ [-Werror=sign-compare]
  272 |   if ((long)shm != IGNORE) {\
      |                 ^~
gp_10000.c:318:5: note: in expansion of macro ‘TEEC_initialize_memory’
  318 |     TEEC_initialize_memory(SHARE_MEM01, IGNORE, OFFSET_02, SIZE_02, BYTE_01, BYTE_02, BYTE_03);
      |     ^~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
