### PR TITLE
xtest: pkcs11: Fix size of Generic Secret Key

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -1970,12 +1970,12 @@ static CK_ATTRIBUTE cktest_generate_gensecret_object_error3[] = {
 	{ CKA_CLASS, &(CK_OBJECT_CLASS){CKO_DATA}, sizeof(CK_OBJECT_CLASS) },
 	{ CKA_KEY_TYPE, &(CK_KEY_TYPE){CKK_GENERIC_SECRET},
 						sizeof(CK_KEY_TYPE) },
-	{ CKA_VALUE_LEN, &(CK_ULONG){16 * 8}, sizeof(CK_ULONG) },
+	{ CKA_VALUE_LEN, &(CK_ULONG){16}, sizeof(CK_ULONG) },
 };
 
 /* Invalid template with CKA_LOCAL */
 static CK_ATTRIBUTE cktest_generate_gensecret_object_error4[] = {
-	{ CKA_VALUE_LEN, &(CK_ULONG){16 * 8}, sizeof(CK_ULONG) },
+	{ CKA_VALUE_LEN, &(CK_ULONG){16}, sizeof(CK_ULONG) },
 	{ CKA_LOCAL, &(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
 };
 
@@ -1987,12 +1987,12 @@ static CK_ATTRIBUTE cktest_generate_gensecret_object_valid1[] = {
 						sizeof(CK_KEY_TYPE) },
 	{ CKA_SIGN, &(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
 	{ CKA_VERIFY, &(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
-	{ CKA_VALUE_LEN, &(CK_ULONG){16 * 8}, sizeof(CK_ULONG) },
+	{ CKA_VALUE_LEN, &(CK_ULONG){16}, sizeof(CK_ULONG) },
 };
 
 /* Valid template to generate a generic secret with only VALUE_LEN */
 static CK_ATTRIBUTE cktest_generate_gensecret_object_valid2[] = {
-	{ CKA_VALUE_LEN, &(CK_ULONG){16 * 8}, sizeof(CK_ULONG) },
+	{ CKA_VALUE_LEN, &(CK_ULONG){16}, sizeof(CK_ULONG) },
 	{ CKA_SIGN, &(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
 };
 
@@ -3144,7 +3144,7 @@ static void xtest_pkcs11_test_1014(ADBG_Case_t *c)
 		{ CKA_KEY_TYPE, &(CK_KEY_TYPE){CKK_GENERIC_SECRET},
 						sizeof(CK_KEY_TYPE) },
 		{ CKA_LABEL, (CK_UTF8CHAR_PTR)label, strlen(label) },
-		{ CKA_VALUE_LEN, &(CK_ULONG){16 * 8}, sizeof(CK_ULONG) },
+		{ CKA_VALUE_LEN, &(CK_ULONG){16}, sizeof(CK_ULONG) },
 		{ CKA_SIGN, &(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
 		{ CKA_VERIFY, &(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
 		{ CKA_ENCRYPT, &(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },


### PR DESCRIPTION
Earlier it was wrongly assumed that size (CKA_VALUE_LENGTH)
of CKK_GENERIC_SECRET object has to be in bits. This is
not correct as CKA_VALUE_LENGTH is the key size in bytes.

Reviewed-by: Etienne Carriere <etienne.carriere@linaro.org>
Reviewed-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>
Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
