### PR TITLE
gp: fix endianness of two RSA public exponents

### DIFF
--- a/host/xtest/gp/include/xml_datastorage_api.h
+++ b/host/xtest/gp/include/xml_datastorage_api.h
@@ -242,7 +242,7 @@ TEE_ATTR_RSA_PUBLIC_EXPONENT_VALUE_GEN_OUT_OF_RANGE_INF[] = {
 };
 
 static const uint8_t TEE_ATTR_RSA_PUBLIC_EXPONENT_VALUE_GEN_NOT_ODD[] = {
-	0x02, 0x00, 0x01, /* 65538 */
+	0x01, 0x00, 0x02, /* 65538 */
 };
 
 static const uint8_t TEE_ATTR_RSA_PUBLIC_EXPONENT_VALUE_65537[] = {
@@ -250,7 +250,7 @@ static const uint8_t TEE_ATTR_RSA_PUBLIC_EXPONENT_VALUE_65537[] = {
 };
 
 static const uint8_t TEE_ATTR_RSA_PUBLIC_EXPONENT_VALUE_NOT_GEN_DEFAULT[] = {
-	0xd1, 0x01, 0x01, /* 66001 */
+	0x01, 0x01, 0xd1, /* 66001 */
 };
 
 static const uint8_t TEE_ATTR_AES_192_VALUE01[] = {


### PR DESCRIPTION
GP tests 30125 (9d-21-98) and 30127 (9d-28-5d) use badly encoded
constants: TEE_ATTR_RSA_PUBLIC_EXPONENT_VALUE_GEN_NOT_ODD (= 65538)
TEE_ATTR_RSA_PUBLIC_EXPONENT_VALUE_NOT_GEN_DEFAULT (= 66001),
respectively.

The values are given in decimal in the test suite documentation and
were erroneously encoded in little endian order in source file
host/xtest/gp/include/xml_datastorage_api.h.

Fix the values by using big endian encoding as expected by the GP API
when big numbers are provided as input to crypto functions.

Fixes the failure of "xtest gp_30125" after OP-TEE OS commit [1] (prior
to that commit, both the code and the test were wrong).

Link: [1] https://github.com/OP-TEE/optee_os/commit/c9366c1eeaa1c3dcecafeb03bef24e9e6fc660c4
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
