### PR TITLE
xtest: stats: fix trace on pager stats

### DIFF
--- a/host/xtest/stats.c
+++ b/host/xtest/stats.c
@@ -104,12 +104,12 @@ static int stat_pager(int argc, char *argv[])
 		     res, eo);
 
 	printf("Pager statistics (Number of):\n");
-	printf("Available physical pages: %"PRId32"\n", op.params[0].value.a);
-	printf("Faults:                   %"PRId32"\n", op.params[0].value.b);
-	printf("R/O faults:               %"PRId32"\n", op.params[1].value.a);
-	printf("R/W faults:               %"PRId32"\n", op.params[1].value.b);
-	printf("Hidden faults:            %"PRId32"\n", op.params[2].value.a);
-	printf("Zi pages released:        %"PRId32"\n", op.params[2].value.b);
+	printf("Unlocked pages:     %"PRId32"\n", op.params[0].value.a);
+	printf("Page pool size:     %"PRId32"\n", op.params[0].value.b);
+	printf("R/O faults:         %"PRId32"\n", op.params[1].value.a);
+	printf("R/W faults:         %"PRId32"\n", op.params[1].value.b);
+	printf("Hidden faults:      %"PRId32"\n", op.params[2].value.a);
+	printf("Zi pages released:  %"PRId32"\n", op.params[2].value.b);
 
 	return close_sess(&ctx, &sess);
 }


### PR DESCRIPTION
Fix trace message in pager stats: "Available physical pages" is in fact
the number of unlocked pages in pager pool while "Faults" is in fact
the overall number of pages in pager page pool.

Reported-by: Timothée Cercueil <timothee.cercueil@st.com>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
