### PR TITLE
xtest: CMake: enable CFG_PKCS11_TA when building with CFG_PKCS11_TA=y

### DIFF
--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -103,6 +103,7 @@ if (CFG_SECURE_DATA_PATH)
 endif()
 
 if (CFG_PKCS11_TA)
+	add_compile_options(-DCFG_PKCS11_TA)
 	list (APPEND SRC pkcs11_1000.c)
 endif()
 


### PR DESCRIPTION
Define CFG_PKCS11_TA macro in xtest source compilation when
CFG_PKCS11_TA=y unless what build fails when optee_test is built with
CFG_PKCS11_TA=y while optee_os was built without.

Fixes: https://github.com/OP-TEE/optee_os/issues/4550
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
