### PR TITLE
xtest: make: fix make when optee_test and optee_client are not in same directory with CFG_PKCS11_TA=y

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -93,15 +93,13 @@ endif
 
 ifeq ($(CFG_PKCS11_TA),y)
 srcs += pkcs11_1000.c
-
-OPTEE_PKCS11_TA_HEADERS ?= ../../../optee_client/libckteec/include
-CFLAGS += -DCFG_PKCS11_TA
-CFLAGS += -I$(OPTEE_PKCS11_TA_HEADERS)
-LDFLAGS += -L$(OPTEE_CLIENT_EXPORT)/lib -lckteec
 endif
 
 objs 	:= $(patsubst %.c,$(out-dir)/xtest/%.o, $(srcs))
 
+ifeq ($(CFG_PKCS11_TA),y)
+CFLAGS += -DCFG_PKCS11_TA
+endif
 CFLAGS += -I./
 CFLAGS += -I./adbg/include
 CFLAGS += -I../supp_plugin/include
@@ -149,6 +147,9 @@ CFLAGS += -Wall -Wcast-align -Werror \
 CFLAGS += -g3
 
 LDFLAGS += -L$(OPTEE_CLIENT_EXPORT)/lib -lteec
+ifeq ($(CFG_PKCS11_TA),y)
+LDFLAGS += -lckteec
+endif
 LDFLAGS += -lpthread -lm
 
 .PHONY: all


### PR DESCRIPTION
Was seeing below issue when compiling with CFG_PKCS11_TA=y

make CFG_ARM64=y CFG_PKCS11_TA=y OPTEE_CLIENT_EXPORT=/home/optee_client_github/out/export/usr/ TA_DEV_KIT_DIR=/home/optee_os_github/out/arm-plat-ls/export-ta_arm64

make[1]: Entering directory '/home/optee_test_github/host/xtest'
  CC      /home/optee_test_github/host/xtest/regression_1000.c
cc1: error: ../../../optee_client/libckteec/include: No such file or directory [-Werror=missing-include-dirs]
cc1: all warnings being treated as errors
Makefile:162: recipe for target '/home/optee_test_github/out/xtest/regression_1000.o' failed
make[1]: *** [/home/optee_test_github/out/xtest/regression_1000.o] Error 1
make[1]: Leaving directory '/home/optee_test_github/host/xtest'
Makefile:38: recipe for target 'xtest' failed
make: *** [xtest] Error 2

Fixes: https://github.com/OP-TEE/optee_test/issues/505
Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>