### PR TITLE
Makefile: use the updated path for optee_client_config.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 endif
 
 -include $(TA_DEV_KIT_DIR)/host_include/conf.mk
--include $(OPTEE_CLIENT_EXPORT)/../optee_client_config.mk
+-include $(OPTEE_CLIENT_EXPORT)/include/optee_client_config.mk
 
 ifneq ($V,1)
 	q := @


### PR DESCRIPTION
Follow change done in optee_client which now installs
optee_client_config.mk in the include directory by default.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>