### PR TITLE
regression 4002: add CMAC test case with a 16 bytes increment

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -1160,6 +1160,7 @@ static const struct xtest_mac_case mac_cases[] = {
 	XTEST_MAC_CMAC_CASE(vect10, 9),
 	XTEST_MAC_CMAC_CASE(vect11, 9),
 	XTEST_MAC_CMAC_CASE(vect12, 9),
+	XTEST_MAC_CMAC_CASE(vect12, 16),
 
 	{ TEE_ALG_DES3_CMAC, TEE_TYPE_DES3, mac_des3_cmac_vect1_key,
 	  ARRAY_SIZE(mac_des3_cmac_vect1_key), 0, NULL, 0, mac_des3_cmac_vect1_out,


### PR DESCRIPTION
Hello,

@jforissier
The test to add is in the end very simple ... just one `XTEST_MAC_CMAC_CASE` :)
Should I specify in the commit message, that it's related to the CAAM? I don't know if I should since this test is generic and the CAAM platform specific ..

Please refer to https://github.com/OP-TEE/optee_os/pull/4583

Thanks