### PR TITLE
regression: add case 1034 with a large TA

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -125,6 +125,7 @@ CFLAGS += -I../../ta/aes_perf/include
 CFLAGS += -I../../ta/socket/include
 CFLAGS += -I../../ta/sdp_basic/include
 CFLAGS += -I../../ta/tpm_log_test/include
+CFLAGS += -I../../ta/large/include
 CFLAGS += -I../../ta/supp_plugin/include
 
 TA_DIR ?= /lib/optee_armtz

--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2473,3 +2473,17 @@ static void xtest_tee_test_1033(ADBG_Case_t *c)
 }
 ADBG_CASE_DEFINE(regression, 1033, xtest_tee_test_1033,
 		 "Test the supplicant plugin framework");
+
+static void xtest_tee_test_1034(ADBG_Case_t *c)
+{
+	TEEC_Result res = TEEC_SUCCESS;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+
+	res = xtest_teec_open_session(&session, &large_ta_uuid, NULL,
+				      &ret_orig);
+	if (ADBG_EXPECT_TEEC_SUCCESS(c, res))
+		TEEC_CloseSession(&session);
+}
+ADBG_CASE_DEFINE(regression, 1034, xtest_tee_test_1034,
+		 "Test loading a large TA");

--- a/host/xtest/xtest_test.c
+++ b/host/xtest/xtest_test.c
@@ -4,28 +4,29 @@
  */
 
 #include "xtest_test.h"
+#include <enc_fs_key_manager_test.h>
 #include <pta_invoke_tests.h>
-#include <tee_client_api.h>
-#include <ta_create_fail_test.h>
-#include <ta_crypt.h>
-#include <ta_os_test.h>
-#include <ta_rpc_test.h>
-#include <ta_sims_test.h>
-#include <ta_miss_test.h>
-#include <ta_sims_keepalive_test.h>
-#include <ta_storage.h>
 #include <ta_concurrent.h>
 #include <ta_concurrent_large.h>
-#include <enc_fs_key_manager_test.h>
-#include <ta_storage_benchmark.h>
+#include <ta_create_fail_test.h>
+#include <ta_crypt.h>
+#include <ta_large.h>
+#include <ta_miss_test.h>
+#include <ta_os_test.h>
+#include <ta_rpc_test.h>
+#include <ta_sdp_basic.h>
+#include <ta_sims_keepalive_test.h>
+#include <ta_sims_test.h>
 #include <ta_socket.h>
-#include <ta_tpm_log_test.h>
+#include <ta_storage_benchmark.h>
+#include <ta_storage.h>
 #include <ta_supp_plugin.h>
+#include <ta_tpm_log_test.h>
 #include <tee_api_defines.h>
+#include <tee_client_api.h>
 #include <__tee_isocket_defines.h>
 #include <__tee_tcpsocket_defines.h>
 #include <__tee_udpsocket_defines.h>
-#include <ta_sdp_basic.h>
 
 ADBG_ENUM_TABLE_DEFINE_BEGIN(TEEC_Result)
 ADBG_ENUM_TABLE_ENTRY(TEEC_SUCCESS),
@@ -198,3 +199,4 @@ const TEEC_UUID socket_ta_uuid = TA_SOCKET_UUID;
 const TEEC_UUID sdp_basic_ta_uuid = TA_SDP_BASIC_UUID;
 const TEEC_UUID tpm_log_test_ta_uuid = TA_TPM_LOG_TEST_UUID;
 const TEEC_UUID supp_plugin_test_ta_uuid = TA_SUPP_PLUGIN_UUID;
+const TEEC_UUID large_ta_uuid = TA_LARGE_UUID;

--- a/host/xtest/xtest_test.h
+++ b/host/xtest/xtest_test.h
@@ -134,6 +134,7 @@ extern const TEEC_UUID socket_ta_uuid;
 extern const TEEC_UUID sdp_basic_ta_uuid;
 extern const TEEC_UUID tpm_log_test_ta_uuid;
 extern const TEEC_UUID supp_plugin_test_ta_uuid;
+extern const TEEC_UUID large_ta_uuid;
 extern char *xtest_tee_name;
 
 #endif /*XTEST_TEST_H*/

--- a/ta/CMakeLists.txt
+++ b/ta/CMakeLists.txt
@@ -21,4 +21,5 @@ target_include_directories(${PROJECT_NAME}
 	INTERFACE storage_benchmark/include
 	INTERFACE tpm_log_test/include
 	INTERFACE supp_plugin/include
+	INTERFACE large/include
 )

--- a/ta/large/Android.mk
+++ b/ta/large/Android.mk
@@ -1,0 +1,4 @@
+LOCAL_PATH := $(call my-dir)
+
+local_module :=  25497083-a58a-4fc5-8a72-1ad7b69b8562.ta
+include $(BUILD_OPTEE_MK)

--- a/ta/large/Makefile
+++ b/ta/large/Makefile
@@ -1,0 +1,2 @@
+BINARY =  25497083-a58a-4fc5-8a72-1ad7b69b8562
+include ../ta_common.mk

--- a/ta/large/include/ta_large.h
+++ b/ta/large/include/ta_large.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ */
+
+#ifndef TA_LARGE_H
+#define TA_LARGE_H
+
+#define TA_LARGE_UUID { 0x25497083, 0xa58a, 0x4fc5, \
+	{ 0x8a, 0x72, 0x1a, 0xd7, 0xb6, 0x9b, 0x85, 0x62 } }
+
+#endif /*TA_LARGE_H */

--- a/ta/large/include/user_ta_header_defines.h
+++ b/ta/large/include/user_ta_header_defines.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ */
+
+#ifndef USER_TA_HEADER_DEFINES_H
+#define USER_TA_HEADER_DEFINES_H
+
+#include <ta_large.h>
+#include <user_ta_header.h>
+
+#define TA_UUID TA_LARGE_UUID
+
+#define TA_FLAGS	(TA_FLAG_MULTI_SESSION)
+#define TA_STACK_SIZE	(2 * 1024)
+#define TA_DATA_SIZE	(2 * 1024)
+
+#endif /*USER_TA_HEADER_DEFINES_H*/

--- a/ta/large/sub.mk
+++ b/ta/large/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += include
+srcs-y += ta_entry.c

--- a/ta/large/ta_entry.c
+++ b/ta/large/ta_entry.c
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Linaro Limited
+ */
+
+#include <ta_large.h>
+#include <tee_internal_api.h>
+
+/*
+ * Declare a large buffer likely to span mutiple translation tables.
+ *
+ * Ideally we'd like to have one that is slightly larger than 2MiB since
+ * that would guarantee this. But that would consume yet another static
+ * translation table (MAX_XLAT_TABLES) which would typically only be needed
+ * when loading this TA but would cause a permanent increase in the OP-TEE
+ * memory footprint.
+ *
+ * So we settle with this size, it should quite often be enough if
+ * configured with CFG_TA_ASLR=y. It will be 100% effective with
+ * CFG_WITH_LPAE=n.
+ */
+static const uint8_t large_buffer[1024 * 1024 ] = { 1 };
+
+TEE_Result TA_CreateEntryPoint(void)
+{
+	return TEE_SUCCESS;
+}
+
+void TA_DestroyEntryPoint(void)
+{
+}
+
+TEE_Result TA_OpenSessionEntryPoint(uint32_t param_types,
+				    TEE_Param params[4],
+				    void **session_ctx)
+{
+	(void)param_types;
+	(void)params;
+
+	/* Don't let the linker garbage collect this symbol. */
+	*session_ctx = (void *)large_buffer;
+
+	return TEE_SUCCESS;
+}
+
+void TA_CloseSessionEntryPoint(void *session_ctx)
+{
+	(void)session_ctx;
+}
+
+TEE_Result TA_InvokeCommandEntryPoint(void *session_ctx,
+				      uint32_t cmd_id, uint32_t param_types,
+				      TEE_Param params[4])
+{
+	(void)session_ctx;
+	(void)cmd_id;
+	(void)param_types;
+	(void)params;
+
+	return TEE_ERROR_GENERIC;
+}


### PR DESCRIPTION
Adds the case 1034 which tests loading a large TA to see that the pager
can manage initialized read-only pages spanning two translation tables.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

Needs https://github.com/OP-TEE/optee_os/pull/4628 to pass reliably with paging enabled.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
