### PR TITLE
benchmark: remove TEE_DATA_FLAG_OVERWRITE in call to TEE_OpenPersistentObject

### DIFF
--- a/ta/storage_benchmark/benchmark.c
+++ b/ta/storage_benchmark/benchmark.c
@@ -344,8 +344,7 @@ static TEE_Result ta_stroage_benchmark_chunk_access_test(uint32_t nCommandID,
 			filename, sizeof(filename),
 			TEE_DATA_FLAG_ACCESS_READ |
 			TEE_DATA_FLAG_ACCESS_WRITE |
-			TEE_DATA_FLAG_ACCESS_WRITE_META |
-			TEE_DATA_FLAG_OVERWRITE,
+			TEE_DATA_FLAG_ACCESS_WRITE_META,
 			&object);
 	if (res != TEE_SUCCESS) {
 		EMSG("Failed to open persistent object, res=0x%08x",


### PR DESCRIPTION
During Storage benchmark testing.
When we try to Open persistent object with following flags:

TEE_DATA_FLAG_ACCESS_READ | TEE_DATA_FLAG_ACCESS_WRITE |
TEE_DATA_FLAG_ACCESS_WRITE_META | TEE_DATA_FLAG_OVERWRITE

which lands into syscall_storage_obj_open(), where it checks the flags
which were passed during opening the object and valid flags

TEE_DATA_FLAG_ACCESS_READ | TEE_DATA_FLAG_ACCESS_WRITE |
TEE_DATA_FLAG_ACCESS_WRITE_META | TEE_DATA_FLAG_SHARE_READ |
TEE_DATA_FLAG_SHARE_WRITE

TEE_DATA_FLAG_OVERWRITE flag is not a valid flag in
TEE_OpenPersistentObject(), thats why this call will always
fail.

Removing TEE_DATA_FLAG_OVERWRITE in call to TEE_OpenPersistentObject

Signed-off-by: Sahil Malhotra <sahil.malhotra@nxp.com>
Fixes: https://github.com/OP-TEE/optee_os/issues/4659

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
