### PR TITLE
regression 1027, 1028: update comment about required kernel commit

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2076,9 +2076,9 @@ ADBG_CASE_DEFINE(regression, 1026, xtest_tee_test_1026,
 /*
  * regression_1027
  * Depends on OpenSSL
- * Depends on kernel commit "tee: optee: Add support for session login client UUID generation"
- * Linaro tree: https://github.com/linaro-swg/linux/commit/ad19acdcdbc5
- * Upstream: <put sha-1 here when known>
+ * Depends on kernel commit c5b4312bea5d ("tee: optee: Add support for session
+ * login client UUID generation")
+ * https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c5b4312bea5d
  *
  * xtest skips the test when not built with OpenSSL.
  */
@@ -2138,9 +2138,9 @@ ADBG_CASE_DEFINE(regression, 1027, xtest_tee_test_1027,
 
 /*
  * regression_1028
- * Depends on OpenSSL and kernel commit "tee: optee: Add support for session login client UUID generation"
- * Linaro tree: https://github.com/linaro-swg/linux/commit/ad19acdcdbc5
- * Upstream: <put sha-1 here when known>
+ * Depends on kernel commit c5b4312bea5d ("tee: optee: Add support for session
+ * login client UUID generation")
+ * https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c5b4312bea5d
  *
  * xtest skips the test when not built with OpenSSL.
  */


### PR DESCRIPTION
Now that the kernel feature required by tests 1027 and 1028 is upstream,
provide the commit SHA-1 and link to it.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
