### PR TITLE
xtest : disable large TA tests with virtualization

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -1199,7 +1199,7 @@ static void xtest_tee_test_1013(ADBG_Case_t *c)
 	Do_ADBG_Log("    Mean concurrency: %g", mean_concurrency);
 	Do_ADBG_EndSubCase(c, "Using small concurrency TA");
 
-#ifndef CFG_PAGED_USER_TA
+#if !defined(CFG_PAGED_USER_TA) && !defined(CFG_VIRTUALIZATION)
 	Do_ADBG_BeginSubCase(c, "Using large concurrency TA");
 	mean_concurrency = 0;
 	for (i = 0; i < nb_loops; i++) {
@@ -2474,6 +2474,7 @@ static void xtest_tee_test_1033(ADBG_Case_t *c)
 ADBG_CASE_DEFINE(regression, 1033, xtest_tee_test_1033,
 		 "Test the supplicant plugin framework");
 
+#ifndef CFG_VIRTUALIZATION
 static void xtest_tee_test_1034(ADBG_Case_t *c)
 {
 	TEEC_Result res = TEEC_SUCCESS;
@@ -2487,3 +2488,4 @@ static void xtest_tee_test_1034(ADBG_Case_t *c)
 }
 ADBG_CASE_DEFINE(regression, 1034, xtest_tee_test_1034,
 		 "Test loading a large TA");
+#endif


### PR DESCRIPTION
Disabled the large TA part of 1013 and large TA test 1034
when virtualization is enabled since it uses too much secure heap.
For QEMU environment, enough secure memory is not available
for each guest, so these testcases fail when CFG_VIRTUALIZATION=y

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
