### PR TITLE
regression: add large TA to  build lists in Makefile

### DIFF
--- a/ta/Makefile
+++ b/ta/Makefile
@@ -31,7 +31,8 @@ TA_DIRS := create_fail_test \
 	   sha_perf \
 	   aes_perf \
 	   socket \
-	   supp_plugin
+	   supp_plugin \
+	   large
 
 ifeq ($(CFG_SECURE_DATA_PATH),y)
 TA_DIRS += sdp_basic


### PR DESCRIPTION
Add large TA to the list of the TAs built from ta/Makefile which
change was missing from [1].

Link: [1] 94fb1581e071 ("regression: add case 1034 with a large TA")
Reported-by: Christophe Priouzeau <christophe.priouzeau@st.com>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
