### PR TITLE
regression 8102, 8103: change myasprintf implementation

### DIFF
--- a/host/xtest/regression_8100.c
+++ b/host/xtest/regression_8100.c
@@ -54,6 +54,7 @@ static int __printf(2, 3) myasprintf(char **strp, const char *fmt, ...)
 
 	va_start(ap, fmt);
 	rc = vsnprintf(str, rc, fmt, ap);
+	va_end(ap);
 	if (rc <= 0)
 		goto out;
 
@@ -63,14 +64,15 @@ static int __printf(2, 3) myasprintf(char **strp, const char *fmt, ...)
 		goto out;
 	}
 
+	va_start(ap, fmt);
 	rc = vsnprintf(str, rc, fmt, ap);
+	va_end(ap);
 	if (rc <= 0)
 		free(str);
 	else
 		*strp = str;
 
 out:
-	va_end(ap);
 	return rc;
 }
 


### PR DESCRIPTION
va_list ap is undefined after a call to vsnprintf, so need
to put va_start and va_end before and after every vsnprintf.
Otherwise, the content of str buffer may be messed up.

Signed-off-by: Jingdong Lu <jingdong.lu@intel.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
