### PR TITLE
xtest: Add more tests for querying signature size for C_Sign/C_SignFinal

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -1676,6 +1676,15 @@ static void xtest_pkcs11_test_1008(ADBG_Case_t *c)
 			if (!ADBG_EXPECT_CK_OK(c, rv))
 				goto err_destr_obj;
 
+			/*
+			 * Test NULL buffer case with size as non-zero
+			 * to get the out_size
+			 */
+			out_size = 42;
+			rv = C_SignFinal(session, NULL, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
 			/* Get to full output */
 			memset(out, 0, out_size);
 			rv = C_SignFinal(session, out, &out_size);
@@ -1733,6 +1742,16 @@ static void xtest_pkcs11_test_1008(ADBG_Case_t *c)
 			 * to get the out_size
 			 */
 			out_size = 0;
+			rv = C_Sign(session, (void *)test->in, test->in_len,
+				    NULL, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/*
+			 * Test NULL buffer case with size as non-zero
+			 * to get the out_size
+			 */
+			out_size = 42;
 			rv = C_Sign(session, (void *)test->in, test->in_len,
 				    NULL, &out_size);
 			if (!ADBG_EXPECT_CK_OK(c, rv))


### PR DESCRIPTION
It is possible that when querying memory that return buffer for signature
size does not have any meaningful value.

It has been observed that some PKCS#11 libraries does not initialize the
memory to zero and it is also completely fine based on specification.

Add test for the case so that it does not regress in future.

Specified in:
PKCS #11 Cryptographic Token Interface Base Specification
Version 2.40 Plus Errata 01
5.2 Conventions for functions returning output in a variable-length buffer

Related PRs:
- https://github.com/OP-TEE/optee_client/pull/273

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
