### PR TITLE
xtest: Add test for querying CK_ULONG size

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -2674,6 +2674,16 @@ static void xtest_pkcs11_test_1012(ADBG_Case_t *c)
 		{ CKA_TOKEN, &g_token, sizeof(g_token) },
 	};
 
+	CK_ATTRIBUTE get_attr_template_query_bc[] = {
+		{ CKA_TOKEN, NULL, 0 },
+		{ CKA_CLASS, NULL, 0 },
+	};
+
+	CK_ATTRIBUTE get_attr_template_query_cb[] = {
+		{ CKA_CLASS, NULL, 0 },
+		{ CKA_TOKEN, NULL, 0 },
+	};
+
 	CK_ATTRIBUTE get_attr_template_ve[] = {
 		{ CKA_VALUE, &g_value, sizeof(obj_value) },
 	};
@@ -2753,6 +2763,44 @@ static void xtest_pkcs11_test_1012(ADBG_Case_t *c)
 
 	ADBG_EXPECT_COMPARE_UNSIGNED(c, g_class, ==, CKO_DATA);
 	ADBG_EXPECT_COMPARE_UNSIGNED(c, g_token, ==, CK_FALSE);
+
+	Do_ADBG_EndSubCase(c, NULL);
+
+	/*
+	 * Sub test: Query size boolean (1 byte) + object class (CK_ULONG)
+	 */
+	Do_ADBG_BeginSubCase(c, "Get Attribute - query size boolean + class");
+	g_token = CK_TRUE;
+	g_class = ~0;
+
+	rv = C_GetAttributeValue(session, obj_hdl, get_attr_template_query_bc,
+				 ARRAY_SIZE(get_attr_template_query_bc));
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto out;
+
+	ADBG_EXPECT_COMPARE_UNSIGNED(c,
+		get_attr_template_query_bc[0].ulValueLen, ==, 1);
+	ADBG_EXPECT_COMPARE_UNSIGNED(c,
+		get_attr_template_query_bc[1].ulValueLen, ==, sizeof(CK_ULONG));
+
+	Do_ADBG_EndSubCase(c, NULL);
+
+	/*
+	 * Sub test: Query size object class (CK_ULONG) + boolean (1 byte)
+	 */
+	Do_ADBG_BeginSubCase(c, "Get Attribute - query size class + boolean");
+	g_token = CK_TRUE;
+	g_class = ~0;
+
+	rv = C_GetAttributeValue(session, obj_hdl, get_attr_template_query_cb,
+				 ARRAY_SIZE(get_attr_template_query_cb));
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto out;
+
+	ADBG_EXPECT_COMPARE_UNSIGNED(c,
+		get_attr_template_query_cb[0].ulValueLen, ==, sizeof(CK_ULONG));
+	ADBG_EXPECT_COMPARE_UNSIGNED(c,
+		get_attr_template_query_cb[1].ulValueLen, ==, 1);
 
 	Do_ADBG_EndSubCase(c, NULL);
 


### PR DESCRIPTION
Test that querying size for CK_ULONG works.

Related PRs:
- https://github.com/OP-TEE/optee_client/pull/274

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
