### PR TITLE
xtest: Verify that sensitive information is protected

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -3382,6 +3382,7 @@ static void xtest_pkcs11_test_1015(ADBG_Case_t *c)
 	CK_BBOOL g_nextract = CK_FALSE;
 	CK_BBOOL g_asensitive = CK_FALSE;
 	CK_BBOOL g_local =  CK_FALSE;
+	CK_BYTE g_value[16] = { };
 	CK_ATTRIBUTE get_template[] = {
 		{ CKA_TOKEN, &g_token, sizeof(CK_BBOOL) },
 		{ CKA_PRIVATE, &g_private, sizeof(CK_BBOOL) },
@@ -3393,6 +3394,9 @@ static void xtest_pkcs11_test_1015(ADBG_Case_t *c)
 		{ CKA_NEVER_EXTRACTABLE, &g_nextract, sizeof(CK_BBOOL) },
 		{ CKA_ALWAYS_SENSITIVE, &g_asensitive, sizeof(CK_BBOOL) },
 		{ CKA_LOCAL, &g_local, sizeof(CK_BBOOL) },
+	};
+	CK_ATTRIBUTE get_value_template[] = {
+		{ CKA_VALUE, &g_value, sizeof(g_value) }
 	};
 	CK_ATTRIBUTE copy_template[] = {
 		{ CKA_TOKEN, &(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
@@ -3453,6 +3457,15 @@ static void xtest_pkcs11_test_1015(ADBG_Case_t *c)
 	    !ADBG_EXPECT_COMPARE_UNSIGNED(c, g_nextract, ==, CK_FALSE) ||
 	    !ADBG_EXPECT_COMPARE_UNSIGNED(c, g_sensitive, ==, CK_FALSE) ||
 	    !ADBG_EXPECT_COMPARE_UNSIGNED(c, g_asensitive, ==, CK_FALSE))
+		goto close_session;
+
+	/* Check that we can get (secret) CKA_VALUE */
+	get_value_template[0].ulValueLen = sizeof(g_value);
+	rv = C_GetAttributeValue(rw_session, obj_hdl, get_value_template,
+				 ARRAY_SIZE(get_value_template));
+	if (!ADBG_EXPECT_CK_OK(c, rv) ||
+	    !ADBG_EXPECT_COMPARE_UNSIGNED(c, get_value_template[0].ulValueLen,
+					  ==, sizeof(g_value)))
 		goto close_session;
 
 	/* Create a secret key object in ro session*/
@@ -3573,6 +3586,14 @@ static void xtest_pkcs11_test_1015(ADBG_Case_t *c)
 	    !ADBG_EXPECT_COMPARE_UNSIGNED(c, g_sensitive, ==, CK_TRUE) ||
 	    !ADBG_EXPECT_COMPARE_UNSIGNED(c, g_asensitive, ==, CK_FALSE))
 		goto out;
+
+	/* Check that we cannot anymore get (secret) CKA_VALUE */
+	get_value_template[0].ulValueLen = sizeof(g_value);
+	rv = C_GetAttributeValue(rw_session, obj_hdl_cp, get_value_template,
+				 ARRAY_SIZE(get_value_template));
+	if (!ADBG_EXPECT_CK_RESULT(c, CKR_ATTRIBUTE_SENSITIVE, rv) ||
+	    !(get_value_template[0].ulValueLen == CK_UNAVAILABLE_INFORMATION))
+		goto close_session;
 
 	/*
 	 * The copied object has CKA_MODIFIABLE set to FALSE. Check if


### PR DESCRIPTION
When secret object's properties are not protected make sure that they can
be read normally.

When they are protected make sure that proper error values are reported:

- C_GetAttributeValue return value is CKR_ATTRIBUTE_SENSITIVE
- For field that is protected size is CK_UNAVAILABLE_INFORMATION

Specified in:
PKCS #11 Cryptographic Token Interface Base Specification
Version 2.40 Plus Errata 01
C_GetAttributeValue

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
