### PR TITLE
xtest 1034: ignore out of memory errors on large TA

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2487,7 +2487,6 @@ static void xtest_tee_test_1033(ADBG_Case_t *c)
 ADBG_CASE_DEFINE(regression, 1033, xtest_tee_test_1033,
 		 "Test the supplicant plugin framework");
 
-#ifndef CFG_VIRTUALIZATION
 static void xtest_tee_test_1034(ADBG_Case_t *c)
 {
 	TEEC_Result res = TEEC_SUCCESS;
@@ -2496,9 +2495,12 @@ static void xtest_tee_test_1034(ADBG_Case_t *c)
 
 	res = xtest_teec_open_session(&session, &large_ta_uuid, NULL,
 				      &ret_orig);
-	if (ADBG_EXPECT_TEEC_SUCCESS(c, res))
+	if (res == TEEC_ERROR_OUT_OF_MEMORY) {
+		Do_ADBG_Log("TEEC_ERROR_OUT_OF_MEMORY - ignored");
+	} else {
+		ADBG_EXPECT_TEEC_SUCCESS(c, res);
 		TEEC_CloseSession(&session);
+	}
 }
 ADBG_CASE_DEFINE(regression, 1034, xtest_tee_test_1034,
 		 "Test loading a large TA");
-#endif


### PR DESCRIPTION
Same fix than commit fbdc175bb9f3 ("xtest 1013: ignore out of memory
errors on large TA") for regression test 1034.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
