### PR TITLE
xtest: pkcs11: Verify that bad arguments is reported for cipher finals

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -1265,9 +1265,16 @@ static CK_RV cipher_init_final(ADBG_Case_t *c, CK_SESSION_HANDLE session,
 		if (mode == TEE_MODE_DECRYPT)
 			rv = C_DecryptFinal(session, NULL, NULL);
 
-		/* Only check that the operation is no more active */
-		if (!ADBG_EXPECT_TRUE(c, rv != CKR_BUFFER_TOO_SMALL))
+		/*
+		 * Check that return value is expected so that operation is
+		 * released
+		 */
+		if (!ADBG_EXPECT_CK_RESULT(c, CKR_ARGUMENTS_BAD, rv)) {
 			rv = CKR_GENERAL_ERROR;
+			goto out;
+		}
+
+		rv = CKR_OK;
 	}
 
 out:


### PR DESCRIPTION
Verify that CKR_BAD_ARGUMENT is reported properly for:
- C_EncryptFinal with invalid arguments
- C_DecryptFinal with invalid arguments

Test here is expected to fail always with same error so check for that and
then clear the error code so that only expected return value is checked.

Relates to:
- https://github.com/OP-TEE/optee_os/issues/4283

Related PR:
- https://github.com/OP-TEE/optee_client/pull/276

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
