### PR TITLE
xtest: pkcs11: Add tests for more HMAC CKMs

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <utee_defines.h>
 #include <util.h>
 
 #include "xtest_test.h"
@@ -64,6 +65,39 @@ static CK_MECHANISM cktest_hmac_sha384_mechanism = {
 static CK_MECHANISM cktest_hmac_sha512_mechanism = {
 	CKM_SHA512_HMAC, NULL, 0,
 };
+
+static CK_ULONG cktest_general_mechanism_hmac_len = 8;
+static CK_MECHANISM cktest_hmac_general_md5_mechanism = {
+	CKM_MD5_HMAC_GENERAL,
+	(CK_VOID_PTR)&cktest_general_mechanism_hmac_len,
+	sizeof(CK_ULONG),
+};
+static CK_MECHANISM cktest_hmac_general_sha1_mechanism = {
+	CKM_SHA_1_HMAC_GENERAL,
+	(CK_VOID_PTR)&cktest_general_mechanism_hmac_len,
+	sizeof(CK_ULONG),
+};
+static CK_MECHANISM cktest_hmac_general_sha224_mechanism = {
+	CKM_SHA224_HMAC_GENERAL,
+	(CK_VOID_PTR)&cktest_general_mechanism_hmac_len,
+	sizeof(CK_ULONG),
+};
+static CK_MECHANISM cktest_hmac_general_sha256_mechanism = {
+	CKM_SHA256_HMAC_GENERAL,
+	(CK_VOID_PTR)&cktest_general_mechanism_hmac_len,
+	sizeof(CK_ULONG),
+};
+static CK_MECHANISM cktest_hmac_general_sha384_mechanism = {
+	CKM_SHA384_HMAC_GENERAL,
+	(CK_VOID_PTR)&cktest_general_mechanism_hmac_len,
+	sizeof(CK_ULONG),
+};
+static CK_MECHANISM cktest_hmac_general_sha512_mechanism = {
+	CKM_SHA512_HMAC_GENERAL,
+	(CK_VOID_PTR)&cktest_general_mechanism_hmac_len,
+	sizeof(CK_ULONG),
+};
+
 static CK_MECHANISM cktest_gensecret_keygen_mechanism = {
 	CKM_GENERIC_SECRET_KEY_GEN, NULL, 0,
 };
@@ -1611,7 +1645,49 @@ static const struct mac_test cktest_mac_cases[] = {
 			11, mac_data_sha384_in1, mac_data_sha384_out1, false),
 	CKTEST_MAC_TEST(cktest_hmac_sha512_key, &cktest_hmac_sha512_mechanism,
 			13, mac_data_sha512_in1, mac_data_sha512_out1, false),
+	CKTEST_MAC_TEST(cktest_hmac_md5_key,
+			&cktest_hmac_general_md5_mechanism, 4,
+			mac_data_md5_in1, mac_data_md5_out1, false),
+	CKTEST_MAC_TEST(cktest_hmac_sha1_key,
+			&cktest_hmac_general_sha1_mechanism, 5,
+			mac_data_sha1_in1, mac_data_sha1_out1, false),
+	CKTEST_MAC_TEST(cktest_hmac_sha224_key,
+			&cktest_hmac_general_sha224_mechanism, 8,
+			mac_data_sha224_in1, mac_data_sha224_out1, false),
+	CKTEST_MAC_TEST(cktest_hmac_sha256_key1,
+			&cktest_hmac_general_sha256_mechanism, 1,
+			mac_data_sha256_in1, mac_data_sha256_out1, false),
+	CKTEST_MAC_TEST(cktest_hmac_sha256_key2,
+			&cktest_hmac_general_sha256_mechanism, 7,
+			mac_data_sha256_in2, mac_data_sha256_out2, false),
+	CKTEST_MAC_TEST(cktest_hmac_sha384_key,
+			&cktest_hmac_general_sha384_mechanism, 11,
+			mac_data_sha384_in1, mac_data_sha384_out1, false),
+	CKTEST_MAC_TEST(cktest_hmac_sha512_key,
+			&cktest_hmac_general_sha512_mechanism, 13,
+			mac_data_sha512_in1, mac_data_sha512_out1, false),
 };
+
+static size_t get_test_out_len(struct mac_test const *test)
+{
+	switch (test->mechanism->mechanism) {
+	case CKM_MD5_HMAC_GENERAL:
+	case CKM_SHA_1_HMAC_GENERAL:
+	case CKM_SHA224_HMAC_GENERAL:
+	case CKM_SHA256_HMAC_GENERAL:
+	case CKM_SHA384_HMAC_GENERAL:
+	case CKM_SHA512_HMAC_GENERAL:
+		return (size_t)cktest_general_mechanism_hmac_len;
+	case CKM_MD5_HMAC:
+	case CKM_SHA_1_HMAC:
+	case CKM_SHA224_HMAC:
+	case CKM_SHA256_HMAC:
+	case CKM_SHA384_HMAC:
+	case CKM_SHA512_HMAC:
+	default:
+		return test->out_len;
+	}
+}
 
 static void xtest_pkcs11_test_1008(ADBG_Case_t *c)
 {
@@ -1692,7 +1768,7 @@ static void xtest_pkcs11_test_1008(ADBG_Case_t *c)
 				goto err_destr_obj;
 
 			(void)ADBG_EXPECT_BUFFER(c, test->out,
-						 test->out_len,
+						 get_test_out_len(test),
 						 out, out_size);
 		}
 
@@ -1722,7 +1798,8 @@ static void xtest_pkcs11_test_1008(ADBG_Case_t *c)
 			goto err_destr_obj;
 
 		(void)ADBG_EXPECT_BUFFER(c, test->out,
-					 test->out_len, out, out_size);
+					 get_test_out_len(test), out,
+					 out_size);
 
 		/* Test 3 signature in one shot */
 		if (test->in != NULL) {
@@ -1765,7 +1842,7 @@ static void xtest_pkcs11_test_1008(ADBG_Case_t *c)
 				goto err_destr_obj;
 
 			(void)ADBG_EXPECT_BUFFER(c, test->out,
-						 test->out_len,
+						 get_test_out_len(test),
 						 out, out_size);
 		}
 
@@ -1788,6 +1865,27 @@ err_close_lib:
 }
 ADBG_CASE_DEFINE(pkcs11, 1008, xtest_pkcs11_test_1008,
 		 "PKCS11: Check Compliance of C_Sign - HMAC algorithms");
+
+static bool is_ckm_hmac_general(struct mac_test const *test)
+{
+	switch (test->mechanism->mechanism) {
+	case CKM_MD5_HMAC_GENERAL:
+	case CKM_SHA_1_HMAC_GENERAL:
+	case CKM_SHA224_HMAC_GENERAL:
+	case CKM_SHA256_HMAC_GENERAL:
+	case CKM_SHA384_HMAC_GENERAL:
+	case CKM_SHA512_HMAC_GENERAL:
+		return true;
+	case CKM_MD5_HMAC:
+	case CKM_SHA_1_HMAC:
+	case CKM_SHA224_HMAC:
+	case CKM_SHA256_HMAC:
+	case CKM_SHA384_HMAC:
+	case CKM_SHA512_HMAC:
+	default:
+		return false;
+	}
+}
 
 static void xtest_pkcs11_test_1009(ADBG_Case_t *c)
 {
@@ -1835,7 +1933,8 @@ static void xtest_pkcs11_test_1009(ADBG_Case_t *c)
 				goto err_destr_obj;
 
 			rv = C_VerifyFinal(session,
-					   (void *)test->out, test->out_len);
+					   (void *)test->out,
+					   get_test_out_len(test));
 			if (!ADBG_EXPECT_CK_OK(c, rv))
 				goto err_destr_obj;
 
@@ -1859,14 +1958,15 @@ static void xtest_pkcs11_test_1009(ADBG_Case_t *c)
 				goto err_destr_obj;
 		}
 
-		rv = C_VerifyFinal(session, (void *)test->out, test->out_len);
+		rv = C_VerifyFinal(session, (void *)test->out,
+				   get_test_out_len(test));
 		if (!ADBG_EXPECT_CK_OK(c, rv))
 			goto err_destr_obj;
 
 		/* Error as Operation has already completed */
 		rv = C_Verify(session,
 			      (void *)test->in, test->in_len,
-			      (void *)test->out, test->out_len);
+			      (void *)test->out, get_test_out_len(test));
 		if (!ADBG_EXPECT_CK_RESULT(c, CKR_OPERATION_NOT_INITIALIZED,
 					   rv))
 			goto err_destr_obj;
@@ -1879,14 +1979,16 @@ static void xtest_pkcs11_test_1009(ADBG_Case_t *c)
 
 			rv = C_Verify(session,
 				      (void *)test->in, test->in_len,
-				      (void *)test->out, test->out_len);
+				      (void *)test->out,
+				      get_test_out_len(test));
 			if (!ADBG_EXPECT_CK_OK(c, rv))
 				goto err_destr_obj;
 
 			/* Try calling Verify again */
 			rv = C_Verify(session,
 				      (void *)test->in, test->in_len,
-				      (void *)test->out, test->out_len);
+				      (void *)test->out,
+				      get_test_out_len(test));
 			if (!ADBG_EXPECT_CK_RESULT(c,
 						  CKR_OPERATION_NOT_INITIALIZED,
 						  rv))
@@ -1908,7 +2010,10 @@ static void xtest_pkcs11_test_1009(ADBG_Case_t *c)
 				goto err_destr_obj;
 
 			rv = C_VerifyFinal(session, (void *)test->out, 3);
-			if (!ADBG_EXPECT_CK_RESULT(c, CKR_SIGNATURE_LEN_RANGE,
+			if (!ADBG_EXPECT_CK_RESULT(c,
+						   is_ckm_hmac_general(test) ?
+						   CKR_OK :
+						   CKR_SIGNATURE_LEN_RANGE,
 						   rv))
 				goto err_destr_obj;
 		}
@@ -1930,6 +2035,20 @@ static void xtest_pkcs11_test_1009(ADBG_Case_t *c)
 				goto err_destr_obj;
 		}
 
+		if (test->in != NULL) {
+			rv = C_VerifyInit(session, test->mechanism, key_handle);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			rv = C_Verify(session,
+				      (void *)test->in, test->in_len,
+				      (void *)test->out,
+				      TEE_MAX_HASH_SIZE + 1);
+			if (!ADBG_EXPECT_CK_RESULT(c, CKR_SIGNATURE_LEN_RANGE,
+						   rv))
+				goto err_destr_obj;
+		}
+
 		/* Test 6 verification - Invalid Operation sequence */
 		if (test->in != NULL) {
 			rv = C_VerifyInit(session, test->mechanism, key_handle);
@@ -1938,7 +2057,8 @@ static void xtest_pkcs11_test_1009(ADBG_Case_t *c)
 
 			rv = C_Verify(session,
 				      (void *)test->in, test->in_len,
-				      (void *)test->out, test->out_len);
+				      (void *)test->out,
+				      get_test_out_len(test));
 			if (!ADBG_EXPECT_CK_OK(c, rv))
 				goto err_destr_obj;
 


### PR DESCRIPTION
Add tests for *_GENERAL MD5 and SHA based HMAC mechanisms.

Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
