### PR TITLE
xtest: pkcs11: Add test for calling C_EncryptInit twice

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -4228,6 +4228,14 @@ static void xtest_pkcs11_test_1017(ADBG_Case_t *c)
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto out;
 
+	/*
+	 * Initializing the encryption operation again should not alter or
+	 * terminate already started operation.
+	 */
+	rv = C_EncryptInit(session, &cktest_aes_cbc_mechanism, aes_key_enc);
+	if (!ADBG_EXPECT_CK_RESULT(c, CKR_OPERATION_ACTIVE, rv))
+		goto out;
+
 	data_len = 32;
 	key_len = 32;
 	rv = derive_sym_key(session, aes_key2, CKM_AES_ECB_ENCRYPT_DATA,


### PR DESCRIPTION
Tests that C_EncryptInit intiializes operation and calling it twice does
not terminate it.

Relates to:
- https://github.com/OP-TEE/optee_os/issues/4283

Related PRs:
- https://github.com/OP-TEE/optee_os/pull/4756

Signed-off-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
