### PR TITLE
regression 1010: test zero-size TEE_Malloc()

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -851,7 +851,7 @@ static void xtest_tee_test_1010(ADBG_Case_t *c)
 	unsigned int idx = 0;
 	size_t memref_sz[] = { 1024, 65536 };
 
-	for (n = 1; n <= 5; n++) {
+	for (n = 1; n <= 7; n++) {
 		Do_ADBG_BeginSubCase(c, "Invalid memory access %u", n);
 		xtest_tee_test_invalid_mem_access(c, n);
 		Do_ADBG_EndSubCase(c, "Invalid memory access %u", n);

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -988,6 +988,8 @@ TEE_Result ta_entry_bad_mem_access(uint32_t param_types, TEE_Param params[4])
 	long int stack = 0;
 	long int stack_addr = (long int)&stack;
 	void (*volatile null_fn_ptr)(void) = NULL;
+	char *zero_size_malloc = NULL;
+	volatile char c = 0;
 
 	if (param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT, 0, 0, 0) &&
 	    param_types != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
@@ -1009,6 +1011,18 @@ TEE_Result ta_entry_bad_mem_access(uint32_t param_types, TEE_Param params[4])
 		break;
 	case 5:
 		undef_instr();
+		break;
+	case 6:
+		zero_size_malloc = TEE_Malloc(0, 0);
+		if (!zero_size_malloc)
+			return TEE_ERROR_GENERIC;
+		c = *zero_size_malloc;
+		break;
+	case 7:
+		zero_size_malloc = TEE_Malloc(0, 0);
+		if (!zero_size_malloc)
+			return TEE_ERROR_GENERIC;
+		*zero_size_malloc = 0;
 		break;
 	default:
 		break;


### PR DESCRIPTION
Check that TEE_Malloc() returns a non-NULL pointer when requested size
is zero and that the returned pointer is inaccessible for read or write.
Testing feature introduced in optee_os commit a83ee50a8047 ("libutee:
Handle zero sized buffer allocations") [1].

Link: https://github.com/OP-TEE/optee_os/commit/a83ee50a8047
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
