### PR TITLE
xtest: pkcs11: Add tests for AES CMAC mechanisms

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -1622,7 +1622,7 @@ static CK_ATTRIBUTE cktest_aes_cmac_key3[] =
 		{ CKA_KEY_TYPE,	&(CK_KEY_TYPE){_type},			\
 				sizeof(CK_KEY_TYPE) },			\
 		{ CKA_VALUE,	(void *)(_key_array),			\
-				sizeof(_key_array) }			\
+				sizeof(_key_array) },			\
 	}
 
 static CK_ATTRIBUTE cktest_hmac_md5_key[] =
@@ -1679,7 +1679,7 @@ struct mac_test {
 		.in_len = 0,				\
 		.out = output,				\
 		.out_len = ARRAY_SIZE(output),		\
-		.multiple_incr = incr			\
+		.multiple_incr = incr,			\
 	}
 
 static const struct mac_test cktest_mac_cases[] = {


### PR DESCRIPTION
Add tests for CKM_AES_CMAC* mechanisms.

Signed-off-by: Victor Chong <victor.chong@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
