### PR TITLE
pkcs11 1010: Fix generic secret key test

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -2207,7 +2207,10 @@ static void xtest_pkcs11_test_1010(ADBG_Case_t *c)
 	CK_SESSION_HANDLE session = CK_INVALID_HANDLE;
 	CK_FLAGS session_flags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
 	CK_OBJECT_HANDLE key_handle = CK_INVALID_HANDLE;
-	struct mac_test const *test = &cktest_mac_cases[0];
+	struct mac_test test_sign = CKTEST_MAC_TEST(cktest_hmac_md5_key,
+						    &cktest_hmac_md5_mechanism,
+						    4, mac_data_md5_in1,
+						    mac_data_md5_out1, false);
 	uint8_t out[512] = { 0 };
 	CK_ULONG out_len = 512;
 
@@ -2295,12 +2298,12 @@ static void xtest_pkcs11_test_1010(ADBG_Case_t *c)
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err;
 
-	rv = C_SignInit(session, test->mechanism, key_handle);
+	rv = C_SignInit(session, test_sign.mechanism, key_handle);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;
 
-	rv = C_Sign(session, (void *)test->in, test->in_len,
-		      (void *)out, &out_len);
+	rv = C_Sign(session, (void *)test_sign.in, test_sign.in_len,
+		    (void *)out, &out_len);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;
 


### PR DESCRIPTION
Fix generic secret key test corrupted by commit [1] that changed
cktest_mac_cases[] first cell and made an AES_CMAC operation used by test
pcsk11_ to sign data with a generic secret key which is not allowed.
Let's define defining specific test data for pkcs11_1010 rather than
reuse cktest_mac_cases[] content which is dedicated to HMAC tests
(pkcs11_1008) and CMAC tests (pkcs11_1009).

Fixes: [1] da1e3aaa8e0f ("xtest: pkcs11: Add tests for AES CMAC mechanisms")
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
