### PR TITLE
xtest: sdp: fix resource leak in get_random_bytes

### DIFF
--- a/host/xtest/sdp_basic.c
+++ b/host/xtest/sdp_basic.c
@@ -402,6 +402,7 @@ static int get_random_bytes(char *out, size_t len)
 		if (rc != RANDOM_BUFFER_SIZE) {
 			fprintf(stderr, "failed to read %d bytes from %s\n",
 				RANDOM_BUFFER_SIZE, rand_dev);
+			close(fd);
 			return -1;
 		}
 		close(fd);


### PR DESCRIPTION
Close file descriptor before returning when failing to read
from /dev/urandom.

Fixes: 41343db4 ("xtest: add SDP basic tests")
Signed-off-by: Cyrille Fleury <cyrille.fleury@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
