### PR TITLE
[RFC] xtest: add regression_1035 to test TA remote attestation

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2505,7 +2505,7 @@ ADBG_CASE_DEFINE(regression, 1034, xtest_tee_test_1034,
 		 "Test loading a large TA");
 
 #ifdef CFG_ATTESTATION_PTA
-static void xtest_tee_test_1035(ADBG_Case_t *c)
+static void xtest_tee_test_attestation(ADBG_Case_t *c, uint32_t hash_mode)
 {
 	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
 	TEEC_UUID ta_uuid = os_test_ta_uuid;
@@ -2531,6 +2531,7 @@ static void xtest_tee_test_1035(ADBG_Case_t *c)
 					 TEEC_MEMREF_TEMP_OUTPUT, TEEC_NONE,
 					 TEEC_NONE);
 	op.params[0].value.a = session.session_id;
+	op.params[0].value.b = hash_mode;
 	op.params[1].tmpref.buffer = hash1;
 	op.params[1].tmpref.size = sizeof(hash1);
 
@@ -2599,6 +2600,17 @@ static void xtest_tee_test_1035(ADBG_Case_t *c)
 
 	TEEC_CloseSession(&session);
 	TEEC_CloseSession(&att_session);
+}
+
+static void xtest_tee_test_1035(ADBG_Case_t *c)
+{
+	Do_ADBG_BeginSubCase(c, "Mode: PTA_ATTESTATION_HASH_MODE_FULL");
+	xtest_tee_test_attestation(c, PTA_ATTESTATION_HASH_MODE_FULL);
+	Do_ADBG_EndSubCase(c, "Mode: PTA_ATTESTATION_HASH_MODE_FULL");
+
+	Do_ADBG_BeginSubCase(c, "Mode: PTA_ATTESTATION_HASH_MODE_TAGS");
+	xtest_tee_test_attestation(c, PTA_ATTESTATION_HASH_MODE_TAGS);
+	Do_ADBG_EndSubCase(c, "Mode: PTA_ATTESTATION_HASH_MODE_TAGS");
 }
 ADBG_CASE_DEFINE(regression, 1035, xtest_tee_test_1035,
 		 "TA remote attestation");


### PR DESCRIPTION
Add test cases for user TA remote attestation. At this point, we check
that:
- Two consecutive hashing of the same TA session yield the same hash,
- This hash value is also returned after reloading the TA,
- A different hash is obtained if an additional shared library is mapped
into the TA memory space via dlopen()/dlsym().

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
