### PR TITLE
Android.mk: specify scripts/common.mk path with $(LOCAL_PATH)

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,7 +16,7 @@ VERSION = $(shell git describe --always --dirty=-dev 2>/dev/null || echo Unknown
 TA_DEV_KIT_DIR ?= ../invalid_include_path
 
 -include $(TA_DEV_KIT_DIR)/host_include/conf.mk
-include scripts/common.mk
+include $(LOCAL_PATH)/scripts/common.mk
 
 ################################################################################
 # Build xtest                                                                  #


### PR DESCRIPTION
otherwise it will report build error like this:
    12:16:49 [ 48% 267/555] including external/optee_test/Android.mk ...
    12:16:49 FAILED:
    12:16:49 external/optee_test/Android.mk:19: error: scripts/common.mk: No such file or directory
    12:16:49 04:16:49 ckati failed with: exit status 1

which is reported here:
    https://ci.linaro.org/job/android-lcr-reference-hikey960-q/129/console

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>
Reviewed-by: Victor Chong <victor.chong@linaro.org>
