### PR TITLE
[RFC 2] xtest: add regression_1035 to test user TA attestation

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -72,6 +72,10 @@ LOCAL_CFLAGS += -DCFG_PKCS11_TA
 LOCAL_SHARED_LIBRARIES += libckteec
 endif
 
+ifeq ($(CFG_ATTESTATION_PTA),y)
+LOCAL_CFLAGS += -DCFG_ATTESTATION_PTA
+endif
+
 define my-embed-file
 $(TARGET_OUT_HEADERS)/$(1).h: $(LOCAL_PATH)/$(2)
 	@echo '  GEN     $$@'

--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -109,6 +109,10 @@ if (CFG_PKCS11_TA)
 	list (APPEND SRC pkcs11_1000.c)
 endif()
 
+if (CFG_ATTESTATION_TA)
+	add_compile_options(-DCFG_ATTESTATION_PTA)
+endif()
+
 ################################################################################
 # Built binary
 ################################################################################

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -100,6 +100,9 @@ objs 	:= $(patsubst %.c,$(out-dir)/xtest/%.o, $(srcs))
 ifeq ($(CFG_PKCS11_TA),y)
 CFLAGS += -DCFG_PKCS11_TA
 endif
+ifeq ($(CFG_ATTESTATION_PTA),y)
+CFLAGS += -DCFG_ATTESTATION_PTA
+endif
 CFLAGS += -I./
 CFLAGS += -I./adbg/include
 CFLAGS += -I../supp_plugin/include

--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -6,35 +6,34 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <pta_attestation.h>
+#include <pta_invoke_tests.h>
+#include <pta_secstor_ta_mgmt.h>
 #include <pthread.h>
+#include <sdp_basic.h>
+#include <signed_hdr.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <ta_concurrent.h>
+#include <ta_create_fail_test.h>
+#include <ta_crypt.h>
+#include <ta_miss_test.h>
+#include <ta_os_test.h>
+#include <ta_rpc_test.h>
+#include <ta_sims_keepalive_test.h>
+#include <ta_sims_test.h>
+#include <ta_supp_plugin.h>
+#include <ta_tpm_log_test.h>
+#include <test_supp_plugin.h>
 #include <unistd.h>
-
-#include "xtest_test.h"
-#include "xtest_helpers.h"
-#include "xtest_uuid_helpers.h"
-#include <signed_hdr.h>
 #include <util.h>
 
-#include <pta_invoke_tests.h>
-#include <ta_crypt.h>
-#include <ta_os_test.h>
-#include <ta_create_fail_test.h>
-#include <ta_rpc_test.h>
-#include <ta_sims_test.h>
-#include <ta_miss_test.h>
-#include <ta_sims_keepalive_test.h>
-#include <ta_concurrent.h>
-#include <ta_tpm_log_test.h>
-#include <ta_supp_plugin.h>
-#include <sdp_basic.h>
-#include <pta_secstor_ta_mgmt.h>
-
-#include <test_supp_plugin.h>
+#include "xtest_helpers.h"
+#include "xtest_test.h"
+#include "xtest_uuid_helpers.h"
 
 #ifndef MIN
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
@@ -2504,3 +2503,107 @@ static void xtest_tee_test_1034(ADBG_Case_t *c)
 }
 ADBG_CASE_DEFINE(regression, 1034, xtest_tee_test_1034,
 		 "Test loading a large TA");
+
+#ifdef CFG_ATTESTATION_PTA
+static void xtest_tee_test_attestation(ADBG_Case_t *c, uint32_t hash_method)
+{
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	TEEC_UUID ta_uuid = os_test_ta_uuid;
+	uint8_t hash1[32] = { }; /* 32 bytes for SHA-256 */
+	uint8_t hash2[32] = { };
+	TEEC_Result res = TEEC_SUCCESS;
+	TEEC_Session session = { };
+	uint32_t ret_orig = 0;
+
+	Do_ADBG_BeginSubCase(c, "Consecutive calls");
+
+	/* Open session to os_test TA */
+	res = xtest_teec_open_session(&session, &ta_uuid, NULL, &ret_orig);
+	ADBG_EXPECT_TEEC_SUCCESS(c, res);
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT,
+					 TEEC_MEMREF_TEMP_OUTPUT, TEEC_NONE,
+					 TEEC_NONE);
+	op.params[0].value.a = hash_method;
+	op.params[1].tmpref.buffer = hash1;
+	op.params[1].tmpref.size = sizeof(hash1);
+
+	/* Hash TA */
+	ADBG_EXPECT_TEEC_SUCCESS(c, TEEC_InvokeCommand(&session,
+					TA_OS_TEST_CMD_ATTESTATION, &op,
+					&ret_orig));
+
+	op.params[1].tmpref.buffer = hash2;
+	op.params[1].tmpref.size = sizeof(hash2);
+
+	/* Hash TA again */
+	ADBG_EXPECT_TEEC_SUCCESS(c, TEEC_InvokeCommand(&session,
+					TA_OS_TEST_CMD_ATTESTATION, &op,
+					&ret_orig));
+
+	/* Hashes should be identical */
+	ADBG_EXPECT_EQUAL(c, hash1, hash2, sizeof(hash1));
+
+	Do_ADBG_EndSubCase(c, "Consecutive calls");
+
+	/* Close TA session, will cause unload of TA */
+	TEEC_CloseSession(&session);
+
+	Do_ADBG_BeginSubCase(c, "TA reload");
+
+	/* Load TA again and open a new session */
+	res = xtest_teec_open_session(&session, &ta_uuid, NULL, &ret_orig);
+	ADBG_EXPECT_TEEC_SUCCESS(c, res);
+
+	memset(hash2, 0, sizeof(hash2));
+
+	/* Hash TA one more time */
+	ADBG_EXPECT_TEEC_SUCCESS(c, TEEC_InvokeCommand(&session,
+					TA_OS_TEST_CMD_ATTESTATION, &op,
+					&ret_orig));
+
+	/* Hash after reload should still be the same */
+	ADBG_EXPECT_EQUAL(c, hash1, hash2, sizeof(hash1));
+
+	Do_ADBG_EndSubCase(c, "TA reload");
+
+	Do_ADBG_BeginSubCase(c, "Add shared library");
+
+	/*
+	 * Invoke a TA command that causes some additional code to be mapped
+	 * (shared library)
+	 */
+	ADBG_EXPECT_TEEC_SUCCESS(c, TEEC_InvokeCommand(&session,
+						TA_OS_TEST_CMD_CALL_LIB_DL,
+						NULL, &ret_orig));
+
+	op.params[1].tmpref.buffer = hash1;
+	op.params[1].tmpref.size = sizeof(hash1);
+
+	/* Hash TA one last time */
+	ADBG_EXPECT_TEEC_SUCCESS(c, TEEC_InvokeCommand(&session,
+					TA_OS_TEST_CMD_ATTESTATION, &op,
+					&ret_orig));
+
+	/* Different binaries mapped mean different hashes */
+	ADBG_EXPECT_COMPARE_SIGNED(c, memcmp(hash1, hash2, sizeof(hash1)), !=,
+				   0);
+
+	Do_ADBG_EndSubCase(c, "Add shared library");
+
+	TEEC_CloseSession(&session);
+}
+
+static void xtest_tee_test_1035(ADBG_Case_t *c)
+{
+	Do_ADBG_BeginSubCase(c, "Mode: PTA_ATTESTATION_HASH_METHOD_FULL");
+	xtest_tee_test_attestation(c, PTA_ATTESTATION_HASH_METHOD_FULL);
+	Do_ADBG_EndSubCase(c, "Mode: PTA_ATTESTATION_HASH_METHOD_FULL");
+
+	Do_ADBG_BeginSubCase(c, "Mode: PTA_ATTESTATION_HASH_METHOD_TAGS");
+	xtest_tee_test_attestation(c, PTA_ATTESTATION_HASH_METHOD_TAGS);
+	Do_ADBG_EndSubCase(c, "Mode: PTA_ATTESTATION_HASH_METHOD_TAGS");
+}
+ADBG_CASE_DEFINE(regression, 1035, xtest_tee_test_1035,
+		 "TA remote attestation");
+#endif

--- a/ta/os_test/attestation.c
+++ b/ta/os_test/attestation.c
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Huawei Technologies Co., Ltd
+ */
+#include <pta_attestation.h>
+#include <ta_os_test.h>
+#include <tee_internal_api.h>
+
+#include "os_test.h"
+
+TEE_Result ta_entry_attestation(uint32_t param_types, TEE_Param params[4])
+{
+	TEE_TASessionHandle sess = TEE_HANDLE_NULL;
+	TEE_UUID att_uuid = PTA_ATTESTATION_UUID;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t ret_orig = 0;
+
+	res = TEE_OpenTASession(&att_uuid, TEE_TIMEOUT_INFINITE, param_types,
+				params, &sess, &ret_orig);
+	if (!res)
+		TEE_CloseTASession(sess);
+	return res;
+}

--- a/ta/os_test/include/os_test.h
+++ b/ta/os_test/include/os_test.h
@@ -37,5 +37,6 @@ TEE_Result ta_entry_cxx_ctor_shlib(void);
 TEE_Result ta_entry_cxx_ctor_shlib_dl(void);
 TEE_Result ta_entry_cxx_exc_main(void);
 TEE_Result ta_entry_cxx_exc_mixed(void);
+TEE_Result ta_entry_attestation(uint32_t param_types, TEE_Param params[4]);
 
 #endif /*OS_TEST_H */

--- a/ta/os_test/include/ta_os_test.h
+++ b/ta/os_test/include/ta_os_test.h
@@ -39,5 +39,6 @@
 #define TA_OS_TEST_CMD_CXX_CTOR_SHLIB_DL    27
 #define TA_OS_TEST_CMD_CXX_EXC_MAIN         28
 #define TA_OS_TEST_CMD_CXX_EXC_MIXED        29
+#define TA_OS_TEST_CMD_ATTESTATION          30
 
 #endif /*TA_OS_TEST_H */

--- a/ta/os_test/sub.mk
+++ b/ta/os_test/sub.mk
@@ -20,3 +20,4 @@ cxxflags-remove-cxx_tests.cpp-y += -pg
 srcs-y += cxx_tests_c.c
 cflags-remove-cxx_tests_c.c-y += -pg
 endif
+srcs-$(CFG_ATTESTATION_PTA) += attestation.c

--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -144,7 +144,10 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_OS_TEST_CMD_CXX_EXC_MIXED:
 		return TEE_ERROR_NOT_SUPPORTED;
 #endif
-
+#if defined(CFG_ATTESTATION_PTA)
+	case TA_OS_TEST_CMD_ATTESTATION:
+		return ta_entry_attestation(nParamTypes, pParams);
+#endif
 	default:
 		return TEE_ERROR_BAD_PARAMETERS;
 	}


### PR DESCRIPTION
Add test cases for user TA attestation. At this point, we check
that:
- Two consecutive hashing of the same TA yield the same hash,
- This hash value is also returned after reloading the TA,
- A different hash is obtained if an additional shared library is mapped
into the TA memory space via dlopen()/dlsym().

The two hashing methods defined by the attestation PTA are tested.

TODO: add authentication code (nonce, signature verification).

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
