### PR TITLE
[RFC] regression: Add test case 1035 for testing bti

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -127,6 +127,7 @@ CFLAGS += -I../../ta/sdp_basic/include
 CFLAGS += -I../../ta/tpm_log_test/include
 CFLAGS += -I../../ta/large/include
 CFLAGS += -I../../ta/supp_plugin/include
+CFLAGS += -I../../ta/bti_test/include
 
 TA_DIR ?= /lib/optee_armtz
 CFLAGS += -DTA_DIR=\"$(TA_DIR)\"

--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -30,6 +30,7 @@
 #include <ta_sims_keepalive_test.h>
 #include <ta_concurrent.h>
 #include <ta_tpm_log_test.h>
+#include <ta_bti.h>
 #include <ta_supp_plugin.h>
 #include <sdp_basic.h>
 #include <pta_secstor_ta_mgmt.h>
@@ -2504,3 +2505,115 @@ static void xtest_tee_test_1034(ADBG_Case_t *c)
 }
 ADBG_CASE_DEFINE(regression, 1034, xtest_tee_test_1034,
 		 "Test loading a large TA");
+
+struct bti_test {
+	uint32_t cmd;
+	uint32_t func;
+};
+
+#define BTI_TEST(caller_func, bti_func) {	\
+		.cmd = caller_func,		\
+		.func = bti_func,	\
+	}
+
+static const struct bti_test bti_cases_success[] = {
+	BTI_TEST(TA_TEST_USING_BLR, TA_FUNC_BTI_C),
+	BTI_TEST(TA_TEST_USING_BLR, TA_FUNC_BTI_JC),
+	BTI_TEST(TA_TEST_USING_BR, TA_FUNC_BTI_J),
+	BTI_TEST(TA_TEST_USING_BR, TA_FUNC_BTI_JC),
+	BTI_TEST(TA_TEST_USING_BR_X16, TA_FUNC_BTI_C),
+	BTI_TEST(TA_TEST_USING_BR_X16, TA_FUNC_BTI_J),
+	BTI_TEST(TA_TEST_USING_BR_X16, TA_FUNC_BTI_JC),
+};
+
+static const struct bti_test bti_cases_panic[] = {
+	BTI_TEST(TA_TEST_USING_BLR, TA_FUNC_BTI_J),
+	BTI_TEST(TA_TEST_USING_BLR, TA_FUNC_BTI_NONE),
+	BTI_TEST(TA_TEST_USING_BR, TA_FUNC_BTI_C),
+	BTI_TEST(TA_TEST_USING_BR, TA_FUNC_BTI_NONE),
+	BTI_TEST(TA_TEST_USING_BR_X16, TA_FUNC_BTI_NONE),
+};
+
+static void get_cpu_feature(bool *bti)
+{
+	TEEC_Session session = {};
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	uint32_t ret_orig = 0;
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_OUTPUT, TEEC_NONE, TEEC_NONE,
+					 TEEC_NONE);
+	xtest_teec_open_session(&session, &bti_test_ta_uuid, NULL, &ret_orig);
+
+	TEEC_InvokeCommand(&session, TA_BTI_FEATURE, &op, &ret_orig);
+
+	if(op.params[0].value.a)
+		*bti = true;
+
+	TEEC_CloseSession(&session);
+}
+
+static void xtest_tee_test_1035(ADBG_Case_t *c)
+{
+	TEEC_Session session = {};
+	TEEC_Operation op = TEEC_OPERATION_INITIALIZER;
+	struct bti_test const *test = NULL;
+	uint32_t ret_orig = 0;
+	TEEC_Result res;
+	unsigned int n = 0;
+	bool cpu_feature_bti = false;
+
+	get_cpu_feature(&cpu_feature_bti);
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT, TEEC_NONE, TEEC_NONE,
+					 TEEC_NONE);
+
+	xtest_teec_open_session(&session, &bti_test_ta_uuid, NULL, &ret_orig);
+
+	Do_ADBG_BeginSubCase(c, "BTI Pass Cases");
+	for (n = 0; n < ARRAY_SIZE(bti_cases_success); n++) {
+		test = &bti_cases_success[n];
+
+		Do_ADBG_BeginSubCase(c, "BTI Case %u", n);
+		op.params[0].value.a = test->func;
+
+		ADBG_EXPECT_TEEC_SUCCESS(c,
+			TEEC_InvokeCommand(&session, test->cmd, &op, &ret_orig));
+
+		Do_ADBG_EndSubCase(c, "BTI Case %u", n);
+	}
+	Do_ADBG_EndSubCase(c, "BTI Pass Cases");
+
+	TEEC_CloseSession(&session);
+
+	Do_ADBG_BeginSubCase(c, "BTI Exception Generation");
+	for (n = 0; n < ARRAY_SIZE(bti_cases_panic); n++) {
+		test = &bti_cases_panic[n];
+		res = TEEC_SUCCESS;
+
+#if defined(CFG_TA_BTI)
+		if (cpu_feature_bti)
+			res = TEEC_ERROR_TARGET_DEAD;
+#endif
+		xtest_teec_open_session(&session, &bti_test_ta_uuid,
+					NULL, &ret_orig);
+
+		Do_ADBG_BeginSubCase(c, "BTI Case %u", n);
+		op.params[0].value.a = test->func;
+
+		(void)ADBG_EXPECT_TEEC_RESULT(c, res,
+		       TEEC_InvokeCommand(&session, test->cmd, &op, &ret_orig));
+
+#if defined(CFG_TA_BTI)
+		if (cpu_feature_bti)
+			(void)ADBG_EXPECT_TEEC_ERROR_ORIGIN(c, TEEC_ORIGIN_TEE,
+							    ret_orig);
+#endif
+
+		Do_ADBG_EndSubCase(c, "BTI Case %u", n);
+
+		TEEC_CloseSession(&session);
+	}
+	Do_ADBG_EndSubCase(c, "BTI Exception Generation");
+
+}
+ADBG_CASE_DEFINE(regression, 1035, xtest_tee_test_1035, "Test BTI");

--- a/host/xtest/xtest_test.c
+++ b/host/xtest/xtest_test.c
@@ -22,6 +22,7 @@
 #include <ta_storage.h>
 #include <ta_supp_plugin.h>
 #include <ta_tpm_log_test.h>
+#include <ta_bti.h>
 #include <tee_api_defines.h>
 #include <tee_client_api.h>
 #include <__tee_isocket_defines.h>
@@ -200,3 +201,4 @@ const TEEC_UUID sdp_basic_ta_uuid = TA_SDP_BASIC_UUID;
 const TEEC_UUID tpm_log_test_ta_uuid = TA_TPM_LOG_TEST_UUID;
 const TEEC_UUID supp_plugin_test_ta_uuid = TA_SUPP_PLUGIN_UUID;
 const TEEC_UUID large_ta_uuid = TA_LARGE_UUID;
+const TEEC_UUID bti_test_ta_uuid = TA_BTI_UUID;

--- a/host/xtest/xtest_test.h
+++ b/host/xtest/xtest_test.h
@@ -135,6 +135,7 @@ extern const TEEC_UUID sdp_basic_ta_uuid;
 extern const TEEC_UUID tpm_log_test_ta_uuid;
 extern const TEEC_UUID supp_plugin_test_ta_uuid;
 extern const TEEC_UUID large_ta_uuid;
+extern const TEEC_UUID bti_test_ta_uuid;
 extern char *xtest_tee_name;
 
 #endif /*XTEST_TEST_H*/

--- a/ta/CMakeLists.txt
+++ b/ta/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(${PROJECT_NAME}
 	INTERFACE socket/include
 	INTERFACE storage_benchmark/include
 	INTERFACE tpm_log_test/include
+	INTERFACE bti_test/include
 	INTERFACE supp_plugin/include
 	INTERFACE large/include
 )

--- a/ta/bti_test/Android.mk
+++ b/ta/bti_test/Android.mk
@@ -1,0 +1,4 @@
+LOCAL_PATH := $(call my-dir)
+
+local_module := 3616069b-504d-4044-9497-feb84a073a14
+include $(BUILD_OPTEE_MK)

--- a/ta/bti_test/Makefile
+++ b/ta/bti_test/Makefile
@@ -1,0 +1,2 @@
+BINARY = 3616069b-504d-4044-9497-feb84a073a14
+include ../ta_common.mk

--- a/ta/bti_test/bti_test.S
+++ b/ta/bti_test/bti_test.S
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ */
+
+#include <asm.S>
+
+FUNC call_using_blr , : , , , no_bti
+	bti	c
+        stp     x29, x30, [sp, #-16]!
+        blr     x0
+        ldp     x29, x30, [sp], #16
+        ret
+END_FUNC call_using_blr
+
+FUNC call_using_br , : , , , no_bti
+	bti	c
+	br	x0
+END_FUNC call_using_br
+
+FUNC call_using_br_x16 , : , , , no_bti
+	bti	c
+	mov 	x16, x0
+	br	x16
+END_FUNC call_using_br_x16
+
+FUNC bti_j , : , , , no_bti
+	bti	j
+	ret
+END_FUNC bti_j
+
+FUNC bti_c , : , , , no_bti
+	bti	c
+	ret
+END_FUNC bti_c
+
+FUNC bti_jc , : , , , no_bti
+	bti	jc	
+	ret
+END_FUNC bti_jc
+
+FUNC bti_none , : , , , no_bti
+	ret
+END_FUNC bti_none
+
+emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI

--- a/ta/bti_test/include/ta_bti.h
+++ b/ta/bti_test/include/ta_bti.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ * All rights reserved.
+ */
+
+#ifndef TA_BTI_H
+#define TA_BTI_H
+
+#define TA_BTI_UUID { 0x3616069b, 0x504d, 0x4044, \
+	{ 0x94, 0x97, 0xfe, 0xb8, 0x4a, 0x07, 0x3a, 0x14} }
+
+/*
+ * Commands implemented by the TA
+ */
+#define	TA_TEST_USING_BLR		0
+#define	TA_TEST_USING_BR		1
+#define	TA_TEST_USING_BR_X16		2
+#define	TA_BTI_FEATURE			3
+
+/*
+ * Parameter values
+ */
+#define	TA_FUNC_BTI_C			0
+#define	TA_FUNC_BTI_J			1
+#define	TA_FUNC_BTI_JC			2
+#define	TA_FUNC_BTI_NONE		3
+
+#endif /* TA_BTI_H */

--- a/ta/bti_test/include/user_ta_header_defines.h
+++ b/ta/bti_test/include/user_ta_header_defines.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ * All rights reserved.
+ */
+
+#ifndef USER_TA_HEADER_DEFINES_H
+#define USER_TA_HEADER_DEFINES_H
+
+#include "ta_bti.h"
+
+#define TA_UUID TA_BTI_UUID
+
+#define TA_FLAGS		(TA_FLAG_USER_MODE | TA_FLAG_EXEC_DDR)
+#define TA_STACK_SIZE		(2 * 1024)
+#define TA_DATA_SIZE		(32 * 1024)
+
+#endif

--- a/ta/bti_test/sub.mk
+++ b/ta/bti_test/sub.mk
@@ -1,0 +1,4 @@
+global-incdirs-y += include
+
+srcs-y += ta_entry.c
+srcs-y += bti_test.S

--- a/ta/bti_test/ta_entry.c
+++ b/ta/bti_test/ta_entry.c
@@ -1,0 +1,151 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ * All rights reserved.
+ */
+
+#include <inttypes.h>
+#include <pta_system.h>
+#include <string.h>
+#include <ta_bti.h>
+#include <tee_internal_api.h>
+
+/*
+ * Trusted Application Entry Points
+ */
+
+/* Called each time a new instance is created */
+TEE_Result TA_CreateEntryPoint(void)
+{
+	return TEE_SUCCESS;
+}
+
+/* Called each time an instance is destroyed */
+void TA_DestroyEntryPoint(void)
+{
+}
+
+/* Called each time a session is opened */
+TEE_Result TA_OpenSessionEntryPoint(uint32_t nParamTypes __unused,
+				    TEE_Param pParams[4] __unused,
+				    void **ppSessionContext __unused)
+{
+	return TEE_SUCCESS;
+}
+
+/* Called each time a session is closed */
+void TA_CloseSessionEntryPoint(void *pSessionContext __unused)
+{
+}
+
+static TEE_Result get_cpu_features(uint32_t param_types, TEE_Param params[4])
+{
+	static const TEE_UUID system_uuid = PTA_SYSTEM_UUID;
+	TEE_TASessionHandle sess = TEE_HANDLE_NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t ret_orig = 0;
+
+	if (param_types !=
+	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+			    TEE_PARAM_TYPE_NONE,
+			    TEE_PARAM_TYPE_NONE,
+			    TEE_PARAM_TYPE_NONE)) {
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	res = TEE_OpenTASession(&system_uuid, TEE_TIMEOUT_INFINITE, 0, NULL,
+				&sess, &ret_orig);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_OpenTASession failed");
+		goto cleanup_return;
+	}
+
+	res = TEE_InvokeTACommand(sess, TEE_TIMEOUT_INFINITE,
+				  PTA_SYSTEM_GET_CPU_FEATURES,
+				  param_types, params, &ret_orig);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_InvokeTACommand failed");
+		goto cleanup_return;
+	}
+
+	if (CPU_FEATURE_BTI & params[0].value.a)
+		params[0].value.a = 1;
+
+cleanup_return:
+	TEE_CloseTASession(sess);
+	return res;
+}
+
+void call_using_blr(void (*)(void));
+void call_using_br(void (*)(void));
+void call_using_br_x16(void (*)(void));
+void bti_j(void);
+void bti_c(void);
+void bti_jc(void);
+void bti_none(void);
+
+static TEE_Result test_bti(uint32_t nCommandID, uint32_t nParamTypes, TEE_Param pParams[4])
+{
+	void (*func)(void) = NULL;
+
+	if (nParamTypes != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT, 0, 0, 0))
+		return TEE_ERROR_GENERIC;
+
+	switch (pParams[0].value.a) {
+	case TA_FUNC_BTI_C:
+		func = bti_c;
+		break;
+	case TA_FUNC_BTI_J:
+		func = bti_j;
+		break;
+	case TA_FUNC_BTI_JC:
+		func = bti_jc;
+		break;
+	case TA_FUNC_BTI_NONE:
+		func = bti_none;
+		break;
+	default:
+		break;
+	}
+
+	switch (nCommandID) {
+	case TA_TEST_USING_BLR :
+		call_using_blr(func);
+		break;
+	case TA_TEST_USING_BR :
+		call_using_br(func);
+		break;
+	case TA_TEST_USING_BR_X16 :
+		call_using_br_x16(func);
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return TEE_SUCCESS;
+}
+
+/* Called when a command is invoked */
+TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext __unused,
+				      uint32_t nCommandID,
+				      uint32_t nParamTypes,
+				      TEE_Param pParams[4] )
+{
+
+	TEE_Result res = TEE_SUCCESS;
+
+	switch (nCommandID) {
+	case TA_TEST_USING_BLR :
+	case TA_TEST_USING_BR :
+	case TA_TEST_USING_BR_X16 :
+		res = test_bti(nCommandID, nParamTypes, pParams);
+		break;
+	case TA_BTI_FEATURE :
+		res = get_cpu_features(nParamTypes, pParams);
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return res;
+}


### PR DESCRIPTION
Check that not having appropriate bti launchpads when using
br or blr results in exception getting generated.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

This PR helps in testing the bti support. 
For the cores supporting bti mechanism (ARMv8.5 and above), if the page is marked Guarded (GP bit set), not having a launchpad bti instruction for target addressed with br , blr results in an exception. For cores not supporting bti mechanism, bti instructions are treated as nops.

So we can have following scenarios in testing
With CFG_TA_BTI enabled
1. For cores not supporting BTI mechanism -> having/not having bti doesn't matter as bti's are treated as nops and GP bit is ignored and exception is not generated
2. For cores supporting BTI mechanism -> for pages marked with GP bit i.e CFG_TA_BTI enabled, not having bti would result in exception

So, effectively apart from CFG_TA_BTI, we also need to  know whether core supports the feature BTI or not. This can be determined by reading the register ID_AA64PFR1_EL1. 

In this PR, I am using an added command in the system PTA to get the cpu feature and determine if the core supports bti or not. I am not sure if that is the most appropriate way to do it, hence the RFC. 

For optee_os, the corresponding changes are availabel at
https://github.com/ruchi393/optee_os/tree/bti_pta
[ I have not pushed these changes in the existing PR for BTI for now. Would do so once we figure if this is the right way to do this]