### PR TITLE
xtest: add regression_1037 to test remote attestation

### DIFF
--- a/ta/os_test/attestation.c
+++ b/ta/os_test/attestation.c
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Huawei Technologies Co., Ltd
+ */
+#include <pta_attestation.h>
+#include <ta_os_test.h>
+#include <tee_internal_api.h>
+
+#include "os_test.h"
+
+TEE_Result ta_entry_attestation(uint32_t param_types, TEE_Param params[4])
+{
+	TEE_TASessionHandle sess = TEE_HANDLE_NULL;
+	TEE_UUID att_uuid = PTA_ATTESTATION_UUID;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t ret_orig = 0;
+
+	res = TEE_OpenTASession(&att_uuid, TEE_TIMEOUT_INFINITE, 0, NULL, &sess,
+				&ret_orig);
+	if (res)
+		goto out;
+	res = TEE_InvokeTACommand(sess, TEE_TIMEOUT_INFINITE,
+				  PTA_ATTESTATION_HASH_TA_MEMORY, param_types,
+				  params, &ret_orig);
+out:
+	TEE_CloseTASession(sess);
+	return res;
+}

--- a/ta/os_test/include/os_test.h
+++ b/ta/os_test/include/os_test.h
@@ -39,5 +39,6 @@ TEE_Result ta_entry_cxx_exc_main(void);
 TEE_Result ta_entry_cxx_exc_mixed(void);
 TEE_Result ta_entry_pauth_test_nop(void);
 TEE_Result ta_entry_pauth_corrupt_pac(void);
+TEE_Result ta_entry_attestation(uint32_t param_types, TEE_Param params[4]);
 
 #endif /*OS_TEST_H */

--- a/ta/os_test/include/ta_os_test.h
+++ b/ta/os_test/include/ta_os_test.h
@@ -41,5 +41,6 @@
 #define TA_OS_TEST_CMD_CXX_EXC_MIXED        29
 #define TA_OS_TEST_CMD_PAUTH_NOP            30
 #define TA_OS_TEST_CMD_PAUTH_CORRUPT_PAC    31
+#define TA_OS_TEST_CMD_ATTESTATION          32
 
 #endif /*TA_OS_TEST_H */

--- a/ta/os_test/sub.mk
+++ b/ta/os_test/sub.mk
@@ -20,7 +20,6 @@ cxxflags-remove-cxx_tests.cpp-y += -pg
 srcs-y += cxx_tests_c.c
 cflags-remove-cxx_tests_c.c-y += -pg
 endif
-
 ifeq ($(sm),ta_arm64)
 srcs-$(CFG_TA_PAUTH) += pauth_a64.S
 srcs-$(CFG_TA_PAUTH) += ta_arm_pauth.c
@@ -28,3 +27,4 @@ srcs-$(CFG_TA_PAUTH) += ta_arm_pauth.c
 #  such instruction in the PAC test.
 cflags-$(CFG_TA_PAUTH) += -march=armv8.3-a
 endif
+srcs-y += attestation.c

--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -167,6 +167,9 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 		return TEE_ERROR_NOT_SUPPORTED;
 #endif
 
+	case TA_OS_TEST_CMD_ATTESTATION:
+		return ta_entry_attestation(nParamTypes, pParams);
+
 	default:
 		return TEE_ERROR_BAD_PARAMETERS;
 	}


### PR DESCRIPTION
Add test cases for remote attestation: get public key, hash TEE
memory, get TA shdr digest, hash TA memory.

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
