### PR TITLE
Disable C++ file compilation WITH_CXX_TESTS=n

### DIFF
--- a/ta/os_test_lib/sub.mk
+++ b/ta/os_test_lib/sub.mk
@@ -1,6 +1,8 @@
 cppflags-$(WITH_TLS_TESTS) += -DWITH_TLS_TESTS=1
 global-incdirs-y += include
 srcs-y += os_test_lib.c
+ifeq ($(WITH_CXX_TESTS),y)
 ifneq ($(COMPILER),clang)
 srcs-y += os_test_lib_cxx.cpp
+endif
 endif

--- a/ta/os_test_lib_dl/sub.mk
+++ b/ta/os_test_lib_dl/sub.mk
@@ -1,5 +1,7 @@
 global-incdirs-y += include
 srcs-y += os_test_lib_dl.c
+ifeq ($(WITH_CXX_TESTS),y)
 ifneq ($(COMPILER),clang)
 srcs-y += os_test_lib_dl_cxx.cpp
+endif
 endif


### PR DESCRIPTION
Disable the compilation of C++ files from os_test_lib
and is_test_lib_dl if C++ tests are disabled i.e xtests
are built with option WITH_CXX_TESTS=n.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
