### PR TITLE
regression: Add test case 1035 for testing bti

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -127,6 +127,7 @@ CFLAGS += -I../../ta/sdp_basic/include
 CFLAGS += -I../../ta/tpm_log_test/include
 CFLAGS += -I../../ta/large/include
 CFLAGS += -I../../ta/supp_plugin/include
+CFLAGS += -I../../ta/bti_test/include
 
 TA_DIR ?= /lib/optee_armtz
 CFLAGS += -DTA_DIR=\"$(TA_DIR)\"

--- a/host/xtest/xtest_test.c
+++ b/host/xtest/xtest_test.c
@@ -22,6 +22,7 @@
 #include <ta_storage.h>
 #include <ta_supp_plugin.h>
 #include <ta_tpm_log_test.h>
+#include <ta_arm_bti.h>
 #include <tee_api_defines.h>
 #include <tee_client_api.h>
 #include <__tee_isocket_defines.h>
@@ -200,3 +201,4 @@ const TEEC_UUID sdp_basic_ta_uuid = TA_SDP_BASIC_UUID;
 const TEEC_UUID tpm_log_test_ta_uuid = TA_TPM_LOG_TEST_UUID;
 const TEEC_UUID supp_plugin_test_ta_uuid = TA_SUPP_PLUGIN_UUID;
 const TEEC_UUID large_ta_uuid = TA_LARGE_UUID;
+const TEEC_UUID bti_test_ta_uuid = TA_BTI_UUID;

--- a/host/xtest/xtest_test.h
+++ b/host/xtest/xtest_test.h
@@ -135,6 +135,7 @@ extern const TEEC_UUID sdp_basic_ta_uuid;
 extern const TEEC_UUID tpm_log_test_ta_uuid;
 extern const TEEC_UUID supp_plugin_test_ta_uuid;
 extern const TEEC_UUID large_ta_uuid;
+extern const TEEC_UUID bti_test_ta_uuid;
 extern char *xtest_tee_name;
 
 #endif /*XTEST_TEST_H*/

--- a/ta/CMakeLists.txt
+++ b/ta/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(${PROJECT_NAME}
 	INTERFACE socket/include
 	INTERFACE storage_benchmark/include
 	INTERFACE tpm_log_test/include
+	INTERFACE bti_test/include
 	INTERFACE supp_plugin/include
 	INTERFACE large/include
 )

--- a/ta/Makefile
+++ b/ta/Makefile
@@ -38,6 +38,10 @@ ifeq ($(CFG_SECURE_DATA_PATH),y)
 TA_DIRS += sdp_basic
 endif
 
+ifeq ($(CFG_TA_BTI),y)
+TA_DIRS += bti_test
+endif
+
 .PHONY: all
 all: ta
 

--- a/ta/bti_test/Android.mk
+++ b/ta/bti_test/Android.mk
@@ -1,0 +1,4 @@
+LOCAL_PATH := $(call my-dir)
+
+local_module := 3616069b-504d-4044-9497-feb84a073a14
+include $(BUILD_OPTEE_MK)

--- a/ta/bti_test/Makefile
+++ b/ta/bti_test/Makefile
@@ -1,0 +1,2 @@
+BINARY = 3616069b-504d-4044-9497-feb84a073a14
+include ../ta_common.mk

--- a/ta/bti_test/bti_stubs_a64.S
+++ b/ta/bti_test/bti_stubs_a64.S
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ */
+
+#include <asm.S>
+
+FUNC call_using_blr , : , , , no_bti
+	bti	c
+	stp     x29, x30, [sp, #-16]!
+	blr     x0
+	ldp     x29, x30, [sp], #16
+	ret
+END_FUNC call_using_blr
+
+FUNC call_using_br , : , , , no_bti
+	bti	c
+	br	x0
+END_FUNC call_using_br
+
+FUNC call_using_br_x16 , : , , , no_bti
+	bti	c
+	mov 	x16, x0
+	br	x16
+END_FUNC call_using_br_x16
+
+FUNC bti_j , : , , , no_bti
+	bti	j
+	ret
+END_FUNC bti_j
+
+FUNC bti_c , : , , , no_bti
+	bti	c
+	ret
+END_FUNC bti_c
+
+FUNC bti_jc , : , , , no_bti
+	bti	jc
+	ret
+END_FUNC bti_jc
+
+FUNC bti_none , : , , , no_bti
+	ret
+END_FUNC bti_none
+
+emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI

--- a/ta/bti_test/include/ta_arm_bti.h
+++ b/ta/bti_test/include/ta_arm_bti.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ * All rights reserved.
+ */
+
+#ifndef TA_ARM_BTI_H
+#define TA_ARM_BTI_H
+
+#define TA_BTI_UUID { 0x3616069b, 0x504d, 0x4044, \
+	{ 0x94, 0x97, 0xfe, 0xb8, 0x4a, 0x07, 0x3a, 0x14} }
+
+/*
+ * Commands implemented by the TA
+ */
+#define	TA_TEST_USING_BLR		0
+#define	TA_TEST_USING_BR		1
+#define	TA_TEST_USING_BR_X16		2
+#define	TA_FEAT_BTI_IMPLEMENTED		3
+
+/*
+ * Parameter values
+ */
+#define	TA_FUNC_BTI_C			0
+#define	TA_FUNC_BTI_J			1
+#define	TA_FUNC_BTI_JC			2
+#define	TA_FUNC_BTI_NONE		3
+
+#endif /* TA_ARM_BTI_H */

--- a/ta/bti_test/include/ta_arm_bti_priv.h
+++ b/ta/bti_test/include/ta_arm_bti_priv.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ * All rights reserved.
+ */
+
+#ifndef TA_ARM_BTI_PRIVATE_H
+#define TA_ARM_BTI_PRIVATE_H
+
+#include <tee_api.h>
+
+TEE_Result test_bti(uint32_t nCommandID, uint32_t nParamTypes,
+		    TEE_Param pParams[4]);
+
+#endif /* TA_ARM_BTI_PRIVATE_H */

--- a/ta/bti_test/include/user_ta_header_defines.h
+++ b/ta/bti_test/include/user_ta_header_defines.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ * All rights reserved.
+ */
+
+#ifndef USER_TA_HEADER_DEFINES_H
+#define USER_TA_HEADER_DEFINES_H
+
+#include "ta_arm_bti.h"
+
+#define TA_UUID TA_BTI_UUID
+
+#define TA_FLAGS		(TA_FLAG_USER_MODE | TA_FLAG_EXEC_DDR)
+#define TA_STACK_SIZE		(2 * 1024)
+#define TA_DATA_SIZE		(32 * 1024)
+
+#endif

--- a/ta/bti_test/sub.mk
+++ b/ta/bti_test/sub.mk
@@ -1,0 +1,7 @@
+global-incdirs-y += include
+
+srcs-y += ta_entry.c
+ifeq ($(sm),ta_arm64)
+srcs-$(CFG_TA_BTI) += bti_stubs_a64.S
+srcs-$(CFG_TA_BTI) += ta_arm_bti.c
+endif

--- a/ta/bti_test/ta_arm_bti.c
+++ b/ta/bti_test/ta_arm_bti.c
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ * All rights reserved.
+ */
+
+#include <inttypes.h>
+#include <string.h>
+#include <ta_arm_bti.h>
+#include <ta_arm_bti_priv.h>
+#include <tee_internal_api.h>
+
+void call_using_blr(void (*)(void));
+void call_using_br(void (*)(void));
+void call_using_br_x16(void (*)(void));
+void bti_j(void);
+void bti_c(void);
+void bti_jc(void);
+void bti_none(void);
+
+TEE_Result test_bti(uint32_t nCommandID, uint32_t nParamTypes, TEE_Param pParams[4])
+{
+	void (*func)(void) = NULL;
+
+	if (nParamTypes != TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT, 0, 0, 0))
+		return TEE_ERROR_GENERIC;
+
+	switch (pParams[0].value.a) {
+	case TA_FUNC_BTI_C:
+		func = bti_c;
+		break;
+	case TA_FUNC_BTI_J:
+		func = bti_j;
+		break;
+	case TA_FUNC_BTI_JC:
+		func = bti_jc;
+		break;
+	case TA_FUNC_BTI_NONE:
+		func = bti_none;
+		break;
+	default:
+		break;
+	}
+
+	switch (nCommandID) {
+	case TA_TEST_USING_BLR :
+		call_using_blr(func);
+		break;
+	case TA_TEST_USING_BR :
+		call_using_br(func);
+		break;
+	case TA_TEST_USING_BR_X16 :
+		call_using_br_x16(func);
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return TEE_SUCCESS;
+}

--- a/ta/bti_test/ta_entry.c
+++ b/ta/bti_test/ta_entry.c
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Linaro Limited
+ * All rights reserved.
+ */
+
+#include <inttypes.h>
+#include <string.h>
+#include <ta_arm_bti.h>
+#include <ta_arm_bti_priv.h>
+#include <tee_internal_api.h>
+
+/*
+ * Trusted Application Entry Points
+ */
+
+/* Called each time a new instance is created */
+TEE_Result TA_CreateEntryPoint(void)
+{
+	return TEE_SUCCESS;
+}
+
+/* Called each time an instance is destroyed */
+void TA_DestroyEntryPoint(void)
+{
+}
+
+/* Called each time a session is opened */
+TEE_Result TA_OpenSessionEntryPoint(uint32_t nParamTypes __unused,
+				    TEE_Param pParams[4] __unused,
+				    void **ppSessionContext __unused)
+{
+	return TEE_SUCCESS;
+}
+
+/* Called each time a session is closed */
+void TA_CloseSessionEntryPoint(void *pSessionContext __unused)
+{
+}
+
+static TEE_Result check_bti_implemented(uint32_t param_types,
+					TEE_Param params[4])
+{
+	bool implemented = false;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (param_types !=
+	    TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+			    TEE_PARAM_TYPE_NONE,
+			    TEE_PARAM_TYPE_NONE,
+			    TEE_PARAM_TYPE_NONE)) {
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	res = TEE_GetPropertyAsBool(
+			TEE_PROPSET_TEE_IMPLEMENTATION,
+			"org.trustedfirmware.optee.cpu.feat_bti_implemented",
+			&implemented);
+	if (res == TEE_SUCCESS && implemented)
+		params[0].value.a = 1;
+
+	if (res == TEE_ERROR_ITEM_NOT_FOUND) {
+		params[0].value.a = 0;
+		res = TEE_SUCCESS;
+	}
+
+	return res;
+}
+
+__weak TEE_Result test_bti(uint32_t nCommandID __unused,
+			   uint32_t nParamTypes __unused,
+			   TEE_Param pParams[4] __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+/* Called when a command is invoked */
+TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext __unused,
+				      uint32_t nCommandID,
+				      uint32_t nParamTypes,
+				      TEE_Param pParams[4] )
+{
+	TEE_Result res = TEE_SUCCESS;
+
+	switch (nCommandID) {
+	case TA_TEST_USING_BLR :
+	case TA_TEST_USING_BR :
+	case TA_TEST_USING_BR_X16 :
+		res = test_bti(nCommandID, nParamTypes, pParams);
+		break;
+	case TA_FEAT_BTI_IMPLEMENTED :
+		res = check_bti_implemented(nParamTypes, pParams);
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	return res;
+}


### PR DESCRIPTION
Check that not having appropriate bti launchpads when using
br or blr results in exception getting generated.

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>
Reviewed-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
