### PR TITLE
gp: fix Invoke_Crypto_CipherInit()

### DIFF
--- a/host/xtest/gp/include/xml_crypto_api.h
+++ b/host/xtest/gp/include/xml_crypto_api.h
@@ -2480,6 +2480,9 @@ static TEEC_Result Invoke_Crypto_CipherInit(
 			saved_cipher_iv.size = iv_len;
 			saved_cipher_iv.buffer = malloc(iv_len);
 			memcpy(saved_cipher_iv.buffer, iv, iv_len);
+		} else {
+			saved_cipher_iv.size = 0;
+			saved_cipher_iv.buffer = NULL;
 		}
 	}
 


### PR DESCRIPTION
```
Reset saved IV parameters after test when test case passes no IV.
Otherwise, the values from the previously run test would be re-used,
possibly causing an error due to incompatibility with other parameters
(such as the algorithm requiring no IV). This bug was revealed by
optee_os PR#5087 [1]:

 ## Test 50163 is OK on its own

 $ xtest 50163
 Test ID: 50163
 [...]
 * gp_50163 50-c6-0b
   gp_50163 OK
 [...]

 ## Now run 50162 then 50163, fails

 $ xtest 5016 -x 50160 -x 50161  -x 50164 -x 50165 -x 50166 -x 50167 \
              -x 50168 -x 50169
 [...]
 * gp_50162 50-d8-77
   gp_50162 OK

 * gp_50163 50-c6-0b
 gp/include/xml_crypto_api.h:2618: res = cipher_do_final(c, s, full_data, fulld_length, & full_ciphered_data) has an unexpected value: 0xffff3024 = TEE_ERROR_TARGET_DEAD, expected 0x0 = TEEC_SUCCESS
 gp_50000.c:3768: Invoke_Crypto_CipherDoFinal(c, SESSION01, 0x0001000E, 1, DATA_FOR_CRYPTO1_PART3, 32, DATA_FOR_CRYPTO1, 96, 1) has an unexpected value: 0xffff3024 = TEE_ERROR_TARGET_DEAD, expected 0x0 = TEEC_SUCCESS
 gp_50000.c:3769: Invoke_Crypto_FreeAllKeysAndOperations(c, SESSION01, 0x00010002, 1) has an unexpected value: 0xffff3024 = TEE_ERROR_TARGET_DEAD, expected 0x0 = TEEC_SUCCESS
   gp_50163 FAILED

Link: https://github.com/OP-TEE/optee_os/pull/5087
Signed-off-by: Jerome Forissier <jerome@forissier.org>
```