### PR TITLE
xtest: regression_1015: exclude when CFG_REE_FS not set

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -1276,6 +1276,7 @@ ADBG_CASE_DEFINE(regression, 1014, xtest_tee_test_1014,
 		"Test secure data path against SDP TAs and pTAs");
 #endif /*CFG_SECURE_DATA_PATH*/
 
+#ifdef CFG_REE_FS
 static void xtest_tee_test_1015(ADBG_Case_t *c)
 {
 	TEEC_Result res = TEEC_ERROR_GENERIC;
@@ -1298,6 +1299,7 @@ static void xtest_tee_test_1015(ADBG_Case_t *c)
 }
 ADBG_CASE_DEFINE(regression, 1015, xtest_tee_test_1015,
 		"FS hash-tree corner cases");
+#endif /*CFG_REE_FS*/
 
 static void xtest_tee_test_1016(ADBG_Case_t *c)
 {


### PR DESCRIPTION
Since optee_os commit c6b34ea8d5b5 ("core: fix build dependencies for
fs_htree.c") [1], the fs_htree tests are disabled in the test PTA unless
CFG_REE_FS=y. Therefore do the same thing in xtest.

Fixes the following error:

 $ CFG_REE_FS=n CFG_RPMB_FS=y CFG_RPMB_WRITE_KEY=y run
 [...]
 $ xtest 1015
 [...]
 * regression_1015 FS hash-tree corner cases
 regression_1000.c:1293: TEEC_InvokeCommand(&session, 6, ((void *)0), &ret_orig) has an unexpected value: 0xffff0006 = TEEC_ERROR_BAD_PARAMETERS, expected 0x0 = TEEC_SUCCESS
   regression_1015 FAILED

Link: [1] https://github.com/OP-TEE/optee_os/commit/c6b34ea8d5b52b74eafa7a749a30d4d542d30ab6
Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
