### PR TITLE
CFG_SE05X: consider the secure element hardware limitations when running the tests

### DIFF
--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -109,6 +109,10 @@ if (CFG_PKCS11_TA)
 	list (APPEND SRC pkcs11_1000.c)
 endif()
 
+if (CFG_CRYPTO_SE05X)
+	add_compile_options(-DCFG_CRYPTO_SE05X)
+endif()
+
 ################################################################################
 # Built binary
 ################################################################################

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -100,6 +100,11 @@ objs 	:= $(patsubst %.c,$(out-dir)/xtest/%.o, $(srcs))
 ifeq ($(CFG_PKCS11_TA),y)
 CFLAGS += -DCFG_PKCS11_TA
 endif
+
+ifeq ($(CFG_CRYPTO_SE05X),y)
+CFLAGS += -DCFG_CRYPTO_SE05X
+endif
+
 CFLAGS += -I./
 CFLAGS += -I./adbg/include
 CFLAGS += -I../supp_plugin/include

--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -6297,8 +6297,10 @@ static struct {
 	const void *data;
 	CK_ULONG data_size;
 } rsa_pkcs_sign_tests[] = {
+#ifndef CFG_CRYPTO_SE05X
 	RSA_SIGN_TEST("CKM_MD5_RSA_PKCS", CKM_MD5_RSA_PKCS,
 		      digest_test_pattern),
+#endif
 	RSA_SIGN_TEST("CKM_SHA1_RSA_PKCS", CKM_SHA1_RSA_PKCS,
 		      digest_test_pattern),
 	RSA_SIGN_TEST("CKM_SHA224_RSA_PKCS", CKM_SHA224_RSA_PKCS,
@@ -7051,6 +7053,7 @@ static struct {
 	RSA_OAEP_CRYPT_TEST("RSA-OAEP/SHA1/label", 1024, CKM_SHA_1,
 			    CKG_MGF1_SHA1, rsa_oaep_label,
 			    sizeof(rsa_oaep_label)),
+#ifndef CFG_CRYPTO_SE05X
 	RSA_OAEP_CRYPT_TEST("RSA-OAEP/SHA224", 1024, CKM_SHA224,
 			    CKG_MGF1_SHA224, NULL, 0),
 	RSA_OAEP_CRYPT_TEST("RSA-OAEP/SHA224/label", 1024, CKM_SHA224,
@@ -7071,6 +7074,7 @@ static struct {
 	RSA_OAEP_CRYPT_TEST("RSA-OAEP/SHA512/label", 2048, CKM_SHA512,
 			    CKG_MGF1_SHA512, rsa_oaep_label,
 			    sizeof(rsa_oaep_label)),
+#endif
 };
 
 static int test_rsa_oaep_operations(ADBG_Case_t *c,

--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -4401,12 +4401,16 @@ static void xtest_tee_test_4007_rsa(ADBG_Case_t *c)
 	TEEC_Session session = { };
 	uint32_t ret_orig = 0;
 	static const struct key_types_noparam key_types[] = {
+#ifndef CFG_CRYPTO_SE05X
 		{ 0, "RSA-256", TEE_TYPE_RSA_KEYPAIR, 1, 256, 256 },
 		{ 1, "RSA-384", TEE_TYPE_RSA_KEYPAIR, 1, 384, 384 },
+#endif
 		{ 1, "RSA-512", TEE_TYPE_RSA_KEYPAIR, 1, 512, 512 },
+#ifndef CFG_CRYPTO_SE05X
 		{ 1, "RSA-640", TEE_TYPE_RSA_KEYPAIR, 1, 640, 640 },
 		{ 1, "RSA-768", TEE_TYPE_RSA_KEYPAIR, 1, 768, 768 },
 		{ 1, "RSA-896", TEE_TYPE_RSA_KEYPAIR, 1, 896, 896 },
+#endif
 		{ 1, "RSA-1024", TEE_TYPE_RSA_KEYPAIR, 1, 1024, 1024 },
 		{ 1, "RSA-2048", TEE_TYPE_RSA_KEYPAIR, 1, 2048, 2048 },
 		{ 1, "RSA-3072", TEE_TYPE_RSA_KEYPAIR, 1, 3072, 3072 },


### PR DESCRIPTION
xtest: add CFG_CRYPTO_SE05X
--
The following cflag allows to disable  features not supported by
the SE05X hardware.

xtest: disable SE05X unsupported tests
--
The  SE050/1 secure elements do not support all the cryptographic
operations tested in the regression nor pkcs#11 tests.

Since the test framework wont handle a 'feature not supported' return
code from the secure world, this commit disables those tests that are
not supported by the hardware.

```
pkcs11:
	RSA sign:
		CKM_MD5_RSA_PKCS
	RSA OAEP crypto:
	    	RSA-OAEP/SHA224
		RSA-OAEP/SHA224/label
		RSA-OAEP/SHA256
		RSA-OAEP/SHA256/label
		RSA-OAEP/SHA384
		RSA-OAEP/SHA384/label
		RSA-OAEP/SHA512
		RSA-OAEP/SHA512/label
regression:
	RSA keypair generation:
	    	RSA-256
		RSA-384
		RSA-640
		RSA-768
		RSA-896
```
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
