### PR TITLE
[v2] ta: regression: Add test 1036 to test PAuth

### DIFF
--- a/ta/os_test/include/os_test.h
+++ b/ta/os_test/include/os_test.h
@@ -37,5 +37,7 @@ TEE_Result ta_entry_cxx_ctor_shlib(void);
 TEE_Result ta_entry_cxx_ctor_shlib_dl(void);
 TEE_Result ta_entry_cxx_exc_main(void);
 TEE_Result ta_entry_cxx_exc_mixed(void);
+TEE_Result ta_entry_pauth_test_nop(void);
+TEE_Result ta_entry_pauth_corrupt_pac(void);
 
 #endif /*OS_TEST_H */

--- a/ta/os_test/include/ta_os_test.h
+++ b/ta/os_test/include/ta_os_test.h
@@ -39,5 +39,7 @@
 #define TA_OS_TEST_CMD_CXX_CTOR_SHLIB_DL    27
 #define TA_OS_TEST_CMD_CXX_EXC_MAIN         28
 #define TA_OS_TEST_CMD_CXX_EXC_MIXED        29
+#define TA_OS_TEST_CMD_PAUTH_NOP            30
+#define TA_OS_TEST_CMD_PAUTH_CORRUPT_PAC    31
 
 #endif /*TA_OS_TEST_H */

--- a/ta/os_test/pauth_a64.S
+++ b/ta/os_test/pauth_a64.S
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#include <asm.S>
+
+/*
+ * void corrupt_pac(void)
+ *
+ * The function corrupts a single bit of the PAC to ensure that the
+ * authentication will fail. paciasp calculates and adds the PAC to the
+ * link register and autiasp is used to authenticate the PAC.
+ */
+FUNC corrupt_pac , :
+	paciasp
+	/* Flip a random bit in PAC field of the return address */
+	eor lr, lr , 1 << 58
+	autiasp
+	ret
+END_FUNC corrupt_pac
+
+emit_aarch64_feature_1_and     GNU_PROPERTY_AARCH64_FEATURE_1_BTI

--- a/ta/os_test/sub.mk
+++ b/ta/os_test/sub.mk
@@ -20,3 +20,11 @@ cxxflags-remove-cxx_tests.cpp-y += -pg
 srcs-y += cxx_tests_c.c
 cflags-remove-cxx_tests_c.c-y += -pg
 endif
+
+ifeq ($(sm),ta_arm64)
+srcs-$(CFG_TA_PAUTH) += pauth_a64.S
+srcs-$(CFG_TA_PAUTH) += ta_arm_pauth.c
+# -march=armv8.3-a enables the non-nops instructions for PAC. We are using one
+#  such instruction in the PAC test.
+cflags-$(CFG_TA_PAUTH) += -march=armv8.3-a
+endif

--- a/ta/os_test/ta_arm_pauth.c
+++ b/ta/os_test/ta_arm_pauth.c
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2022, Linaro Limited
+ */
+
+#include <inttypes.h>
+#include <os_test.h>
+#include <string.h>
+#include <ta_os_test.h>
+#include <tee_internal_api.h>
+
+void corrupt_pac(void);
+
+/* Assuming VA_MASK considering maximum 48 bit of VA */
+#define VA_MASK		0xfffff0000000000
+
+static uint64_t sign_using_keyia(uint64_t ptr)
+{
+	asm volatile("paciza %0 " : "+r" (ptr));
+	return ptr;
+}
+
+TEE_Result ta_entry_pauth_test_nop(void)
+{
+	uint64_t pac = 0;
+	bool implemented = false;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = TEE_GetPropertyAsBool(
+			TEE_PROPSET_TEE_IMPLEMENTATION,
+			"org.trustedfirmware.optee.cpu.feat_pauth_implemented",
+			&implemented);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	if (!implemented)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	/* Check if PAC instruction generates the authentication code */
+	for (int i = 0; i < 10; i++)
+		pac |= sign_using_keyia(i) & VA_MASK;
+
+	if (implemented && pac)
+		return TEE_SUCCESS;
+
+	return TEE_ERROR_GENERIC;
+}
+
+TEE_Result ta_entry_pauth_corrupt_pac(void)
+{
+	corrupt_pac();
+
+	return TEE_SUCCESS;
+}

--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -47,6 +47,16 @@ void TA_CloseSessionEntryPoint(void *pSessionContext)
 	DMSG("TA_CloseSessionEntryPoint");
 }
 
+__weak TEE_Result ta_entry_pauth_test_nop(void)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+__weak TEE_Result ta_entry_pauth_corrupt_pac(void)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
 /* Called when a command is invoked */
 TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 				      uint32_t nCommandID, uint32_t nParamTypes,
@@ -142,6 +152,18 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 	case TA_OS_TEST_CMD_CXX_CTOR_SHLIB_DL:
 	case TA_OS_TEST_CMD_CXX_EXC_MAIN:
 	case TA_OS_TEST_CMD_CXX_EXC_MIXED:
+		return TEE_ERROR_NOT_SUPPORTED;
+#endif
+
+#if defined(CFG_TA_PAUTH)
+	case TA_OS_TEST_CMD_PAUTH_NOP:
+		return ta_entry_pauth_test_nop();
+
+	case TA_OS_TEST_CMD_PAUTH_CORRUPT_PAC:
+		return ta_entry_pauth_corrupt_pac();
+#else
+	case TA_OS_TEST_CMD_PAUTH_NOP:
+	case TA_OS_TEST_CMD_PAUTH_CORRUPT_PAC:
 		return TEE_ERROR_NOT_SUPPORTED;
 #endif
 


### PR DESCRIPTION
Added the PAuth test in os_test TA as suggested.

Test 1036 is added to test the ARM Security extension
feature PAuth (Pointer Authentication).

Signed-off-by: Ruchika Gupta <ruchika.gupta@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
