### PR TITLE
storage: add test cases with zero-sized object IDs

### DIFF
--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -694,6 +694,25 @@ static void xtest_tee_test_6001_single(ADBG_Case_t *c, uint32_t storage_id)
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_unlink(&sess, obj)))
 		goto exit;
 
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		fs_create(&sess, file_00, 0,
+			  TEE_DATA_FLAG_ACCESS_WRITE |
+			  TEE_DATA_FLAG_ACCESS_WRITE_META, 0, data_00,
+			  sizeof(data_00), &obj, storage_id)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_unlink(&sess, obj)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		fs_create(&sess, NULL, 0,
+			  TEE_DATA_FLAG_ACCESS_WRITE |
+			  TEE_DATA_FLAG_ACCESS_WRITE_META, 0, data_00,
+			  sizeof(data_00), &obj, storage_id)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_unlink(&sess, obj)))
+		goto exit;
 exit:
 	TEEC_CloseSession(&sess);
 }
@@ -738,6 +757,39 @@ static void xtest_tee_test_6002_single(ADBG_Case_t *c, uint32_t storage_id)
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_unlink(&sess, obj)))
 		goto exit;
 
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		fs_create(&sess, file_01, 0,
+			  TEE_DATA_FLAG_ACCESS_WRITE, 0, data_00,
+			  sizeof(data_00), &obj, storage_id)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_close(&sess, obj)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		fs_open(&sess, file_01, 0,
+			TEE_DATA_FLAG_ACCESS_WRITE_META, &obj, storage_id)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_unlink(&sess, obj)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		fs_create(&sess, NULL, 0,
+			  TEE_DATA_FLAG_ACCESS_WRITE, 0, data_00,
+			  sizeof(data_00), &obj, storage_id)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_close(&sess, obj)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		fs_open(&sess, NULL, 0,
+			TEE_DATA_FLAG_ACCESS_WRITE_META, &obj, storage_id)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_unlink(&sess, obj)))
+		goto exit;
 exit:
 	TEEC_CloseSession(&sess);
 }
@@ -997,6 +1049,52 @@ static void xtest_tee_test_6008_single(ADBG_Case_t *c, uint32_t storage_id)
 		goto exit;
 
 	/* check buffer */
+	(void)ADBG_EXPECT_BUFFER(c, data_00, 10, out, count);
+
+	/* Object ID = (non-NULL, 0) */
+
+	memset(out, 0, sizeof(out));
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_rename(&sess, obj, file_03, 0)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_close(&sess, obj)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		fs_open(&sess, file_03, 0,
+			TEE_DATA_FLAG_ACCESS_READ |
+			TEE_DATA_FLAG_ACCESS_WRITE_META, &obj, storage_id)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_read(&sess, obj, out, 10, &count)))
+		goto exit;
+
+	(void)ADBG_EXPECT_BUFFER(c, data_00, 10, out, count);
+
+	/* Object ID = (NULL, 0) */
+
+	memset(out, 0, sizeof(out));
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		fs_rename(&sess, obj, file_03, sizeof(file_03))))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_rename(&sess, obj, NULL, 0)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_close(&sess, obj)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
+		fs_open(&sess, NULL, 0,
+			TEE_DATA_FLAG_ACCESS_READ |
+			TEE_DATA_FLAG_ACCESS_WRITE_META, &obj, storage_id)))
+		goto exit;
+
+	if (!ADBG_EXPECT_TEEC_SUCCESS(c, fs_read(&sess, obj, out, 10, &count)))
+		goto exit;
+
 	(void)ADBG_EXPECT_BUFFER(c, data_00, 10, out, count);
 
 	/* clean */

--- a/ta/storage/storage.c
+++ b/ta/storage/storage.c
@@ -33,12 +33,14 @@ TEE_Result ta_storage_cmd_open(uint32_t command,
 
 	switch (command) {
 	case TA_STORAGE_CMD_OPEN:
-		object_id = TEE_Malloc(params[0].memref.size, 0);
-		if (!object_id)
-			return TEE_ERROR_OUT_OF_MEMORY;
+		if (params[0].memref.buffer) {
+			object_id = TEE_Malloc(params[0].memref.size, 0);
+			if (!object_id)
+				return TEE_ERROR_OUT_OF_MEMORY;
 
-		TEE_MemMove(object_id, params[0].memref.buffer,
-			    params[0].memref.size);
+			TEE_MemMove(object_id, params[0].memref.buffer,
+				    params[0].memref.size);
+		}
 		break;
 	case TA_STORAGE_CMD_OPEN_ID_IN_SHM:
 		object_id = params[0].memref.buffer;
@@ -75,12 +77,14 @@ TEE_Result ta_storage_cmd_create(uint32_t command,
 
 	switch (command) {
 	case TA_STORAGE_CMD_CREATE:
-		object_id = TEE_Malloc(params[0].memref.size, 0);
-		if (!object_id)
-			return TEE_ERROR_OUT_OF_MEMORY;
+		if (params[0].memref.buffer) {
+			object_id = TEE_Malloc(params[0].memref.size, 0);
+			if (!object_id)
+				return TEE_ERROR_OUT_OF_MEMORY;
 
-		TEE_MemMove(object_id, params[0].memref.buffer,
-			    params[0].memref.size);
+			TEE_MemMove(object_id, params[0].memref.buffer,
+				    params[0].memref.size);
+		}
 		break;
 	case TA_STORAGE_CMD_CREATE_ID_IN_SHM:
 		object_id = params[0].memref.buffer;
@@ -254,12 +258,14 @@ TEE_Result ta_storage_cmd_rename(uint32_t command, uint32_t param_types,
 
 	switch (command) {
 	case TA_STORAGE_CMD_RENAME:
-		object_id = TEE_Malloc(params[1].memref.size, 0);
-		if (!object_id)
-			return TEE_ERROR_OUT_OF_MEMORY;
+		if (params[0].memref.buffer) {
+			object_id = TEE_Malloc(params[1].memref.size, 0);
+			if (!object_id)
+				return TEE_ERROR_OUT_OF_MEMORY;
 
-		TEE_MemMove(object_id, params[1].memref.buffer,
-			    params[1].memref.size);
+			TEE_MemMove(object_id, params[1].memref.buffer,
+				    params[1].memref.size);
+		}
 		break;
 	case TA_STORAGE_CMD_RENAME_ID_IN_SHM:
 		object_id = params[1].memref.buffer;


### PR DESCRIPTION
The TEE Internal Core API specification (v1.3.1) explicitly allows the
use of an empty object ID in TEE_RenamePersistentObject(). The text is:

 newObjectID, newObjectIDLen: A buffer containing the new object
   identifier. The identifier contains arbitrary bytes, including the
   zero byte. The identifier length SHALL be less than or equal to
   TEE_OBJECT_ID_MAX_LEN and can be zero.

(note the mention: "and can be zero").

Therefore, add a couple of test cases in regression_6008. Both
(non-NULL, 0) and (NULL, 0) are tested for the parameters
(newObjectID, newObjectIDLen).

Since it follows from the above that zero-sized object IDs are indeed
valid, similar test cases are added to regression_6001
(TEE_CreatePersistentObject()) and regression_6002
(TEE_OpenPersistentObject()).

Signed-off-by: Jerome Forissier <jerome@forissier.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
