### PR TITLE
xtest: create output dir before generating regression_8100 header files

### DIFF
--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -215,6 +215,7 @@ define embed-file
 cleanfiles += $(out-dir)/xtest/$(1).h
 
 $(out-dir)/xtest/$(1).h: $(2)
+	$(q)mkdir -p $(out-dir)/xtest/
 	@echo '  GEN     $$@'
 	$(q)$(PYTHON3) ../../scripts/file_to_c.py --inf $$< --out $$@ --name $(1)
 


### PR DESCRIPTION
In some rare occurrence and with a lot of parallel jobs, the following
compilation failure of xtest could happen:
  GEN     out/xtest/regression_8100_ca_crt.h
python3 ../../scripts/file_to_c.py --inf ../../cert/ca.crt --out out/xtest/regression_8100_ca_crt.h --name regression_8100_ca_crt
Traceback (most recent call last):
  File "../../scripts/file_to_c.py", line 48, in <module>
    main()
  File "../../scripts/file_to_c.py", line 24, in main
    f = open(args.out, 'w')
FileNotFoundError: [Errno 2] No such file or directory: 'out/xtest/regression_8100_ca_crt.h'
make: *** [Makefile:226: out/xtest/regression_8100_ca_crt.h] Error 1

This is caused by the output directory `out/xtest/` not being created
when generating the following header files with the `embed-file` macro:
 * regression_8100_ca_crt.h
 * regression_8100_mid_crt.h
 * regression_8100_my_crt.h
 * regression_8100_my_csr.h

To avoid this issue, make sure the output directory is created before
generating the header files.

Fixes: 97d6e290 ("regression: add case 8102")
Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
