### PR TITLE
Makefile: fix ownership contamination when installing output files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,10 @@ checkpatch-staging:
 install:
 	$(echo) '  INSTALL ${DESTDIR}/lib/optee_armtz'
 	$(q)mkdir -p ${DESTDIR}/lib/optee_armtz
-	$(q)find $(out-dir) -name \*.ta -exec cp -a {} ${DESTDIR}/lib/optee_armtz \;
+	$(q)find $(out-dir) -name \*.ta -exec cp {} ${DESTDIR}/lib/optee_armtz \;
 	$(echo) '  INSTALL ${DESTDIR}/bin'
 	$(q)mkdir -p ${DESTDIR}/bin
-	$(q)cp -a $(out-dir)/xtest/xtest ${DESTDIR}/bin
+	$(q)cp $(out-dir)/xtest/xtest ${DESTDIR}/bin
 	$(echo) '  INSTALL ${DESTDIR}/$(CFG_TEE_PLUGIN_LOAD_PATH)'
 	$(q)mkdir -p ${DESTDIR}/$(CFG_TEE_PLUGIN_LOAD_PATH)
 	$(q)cp $(out-dir)/supp_plugin/*.plugin ${DESTDIR}/$(CFG_TEE_PLUGIN_LOAD_PATH)


### PR DESCRIPTION
When installing output files with the `install` Makefile target, the
output file ownership is preserved because the file copy to the
destination directory is done with `cp -a/--archive`.

When using the `install` Makefile target in a Yocto recipe, it triggers
the following Bitbake host contamination warning:

WARNING: optee-test-3.17.0.imx-r0 do_package_qa: QA Issue: optee-test: /lib/optee_armtz/b689f2a7-8adf-477a-9f99-32e90c0ad0a2.ta is owned by uid 1001, which is the same as the user running bitbake. This may be due to host contamination
optee-test: /lib/optee_armtz/5ce0c432-0ab0-40e5-a056-782ca0e6aba2.ta is owned by uid 1001, which is the same as the user running bitbake.  This may be due to host contamination

`cp` instead of `cp -a` solves the issue.

Fixes: 2a1ef2c76f ("Add install target")
Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
