### PR TITLE
regression 4007_x25519: do not fail if X25519 is not supported

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -4726,6 +4726,12 @@ static void xtest_tee_test_4007_x25519(ADBG_Case_t *c)
 						NULL, &ret_orig)))
 		return;
 
+	if (!ta_crypt_cmd_is_algo_supported(c, &session, TEE_ALG_X25519,
+					    TEE_ECC_CURVE_25519)) {
+		Do_ADBG_Log("X25519 not supported: skip subcase");
+		goto out;
+	}
+
 	Do_ADBG_BeginSubCase(c, "Generate X25519 key");
 
 	if (!ADBG_EXPECT_TRUE(c,
@@ -4735,7 +4741,7 @@ static void xtest_tee_test_4007_x25519(ADBG_Case_t *c)
 		return;
 
 	Do_ADBG_EndSubCase(c, "Generate X25519 key");
-
+out:
 	TEEC_CloseSession(&session);
 }
 ADBG_CASE_DEFINE(regression, 4007_x25519, xtest_tee_test_4007_x25519,


### PR DESCRIPTION
When OP-TEE is built with MBedTLS as the core crypto library, X25519 is
not supported. Do not fail "xest regression_4007_x25519" in that case.
Note that a similar check is done in regression_4015 already.

Fixes: 00b3f2cbf4ad ("Add x25519 test cases")
Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
