### PR TITLE
Xilinx/AMD Versal ACAD support

### DIFF
--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -113,6 +113,10 @@ if (CFG_CRYPTO_SE05X)
 	add_compile_options(-DCFG_CRYPTO_SE05X)
 endif()
 
+if (CFG_CRYPTO_VERSAL)
+	add_compile_options(-DCFG_CRYPTO_VERSAL)
+endif()
+
 ################################################################################
 # Built binary
 ################################################################################

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -105,6 +105,10 @@ ifeq ($(CFG_CRYPTO_SE05X),y)
 CFLAGS += -DCFG_CRYPTO_SE05X
 endif
 
+ifeq ($(CFG_CRYPTO_VERSAL),y)
+CFLAGS += -DCFG_CRYPTO_VERSAL
+endif
+
 CFLAGS += -I./
 CFLAGS += -I./adbg/include
 CFLAGS += -I../supp_plugin/include

--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -2426,7 +2426,7 @@ static const struct xtest_ae_case ae_cases[] = {
 	XTEST_AE_CASE_AES_CCM(vect1, 3, 2),
 	XTEST_AE_CASE_AES_CCM(vect2, 7, 13),
 	XTEST_AE_CASE_AES_CCM(vect3, 5, 21),
-
+#ifndef CFG_CRYPTO_VERSAL
 	XTEST_AE_CASE_AES_GCM(vect1, 0, 0, NULL_ARRAY, NULL_ARRAY, NULL_ARRAY),
 	XTEST_AE_CASE_AES_GCM(vect2, 0, 9, NULL_ARRAY, ARRAY, ARRAY),
 	XTEST_AE_CASE_AES_GCM(vect3, 0, 9, NULL_ARRAY, ARRAY, ARRAY),
@@ -2446,6 +2446,7 @@ static const struct xtest_ae_case ae_cases[] = {
 	XTEST_AE_CASE_AES_GCM(vect16, 5, 9, ARRAY, ARRAY, ARRAY),
 	XTEST_AE_CASE_AES_GCM(vect17, 5, 9, ARRAY, ARRAY, ARRAY),
 	XTEST_AE_CASE_AES_GCM(vect18, 5, 9, ARRAY, ARRAY, ARRAY),
+#endif
 #ifdef CFG_GCM_NIST_VECTORS
 #include "gcmDecrypt128.h"
 #include "gcmDecrypt192.h"


### PR DESCRIPTION
With these changes and https://github.com/OP-TEE/optee_os/pull/5426  all xtests (regression and pkcs11) pass on the Versal ACAD platform

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
