### PR TITLE
host: supp_plugin: fix cross compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ ta:
 .PHONY: test_plugin
 test_plugin:
 	$(q)$(MAKE) -C host/supp_plugin CROSS_COMPILE="$(CROSS_COMPILE_HOST)" \
+			     --no-builtin-variables \
 			     O=$(out-dir)
 
 .PHONY: clean


### PR DESCRIPTION
In host/supp_plugin/Makefile, CC is assigned the cross compiler set in
the Makefile only if the CC is not assigned any value previously. But
according to the GNU make implicit variables, CC will have a default
value of cc and hence the cross compiler set in the Makefile will not be
used while compiling the supp_plugin using makefiles.
"--no-builtin-variables" will cancel all variables used by implicit
rules.

Signed-off-by: Davidson K <davidson.kumaresan@arm.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
