### PR TITLE
xtest: fix compilation issue

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2817,6 +2817,9 @@ err:
 static void check_measurement(ADBG_Case_t *c, uint8_t *nonce, size_t nonce_size,
 			      uint8_t *hash, uint8_t *buf)
 {
+	(void)nonce;
+	(void)nonce_size;
+
 	if (hash)
 		ADBG_EXPECT_BUFFER(c, hash, 32, buf, 32);
 


### PR DESCRIPTION
This fixes the following compilation issue:

external/optee_test/host/xtest/regression_1000.c:2817:56: error: unused parameter 'nonce' [-Werror,-Wunused-parameter]
static void check_measurement(ADBG_Case_t *c, uint8_t *nonce, size_t nonce_size,
                                                       ^
external/optee_test/host/xtest/regression_1000.c:2817:70: error: unused parameter 'nonce_size' [-Werror,-Wunused-parameter]
static void check_measurement(ADBG_Case_t *c, uint8_t *nonce, size_t nonce_size,
                                                                     ^

Signed-off-by: Pierre Moos <pmoos@baylibre.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
