### PR TITLE
xtest: fix compilation issue

### DIFF
--- a/host/xtest/sdp_basic.h
+++ b/host/xtest/sdp_basic.h
@@ -33,6 +33,8 @@ enum test_target_ta {
 int allocate_dma_buffer(size_t size, const char *heap_name, int verbosity);
 static inline int allocate_buffer(size_t size, const char *heap_name, int heap_id, int verbosity)
 {
+	(void)heap_id;
+
 	return allocate_dma_buffer(size, heap_name, verbosity);
 }
 #else


### PR DESCRIPTION
This fixes the following compilation error:

external/optee_test/host/xtest/sdp_basic.h:34:75: error: unused parameter 'heap_id' [-Werror,-Wunused-parameter]
static inline int allocate_buffer(size_t size, const char *heap_name, int heap_id, int verbosity)

Signed-off-by: Pierre Moos <pmoos@baylibre.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
