### PR TITLE
xtest: fix compilation issue

### DIFF
--- a/host/xtest/sdp_basic.c
+++ b/host/xtest/sdp_basic.c
@@ -700,6 +700,8 @@ static void usage(const char *progname, size_t size, int loop, const char *heap_
 	fprintf(stderr, " -n LOOP           Test loop iterations [%u]\n", loop);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
 	fprintf(stderr, " --heap ID         Target heap ID [%d]\n", ion_heap);
+#else
+	(void)ion_heap;
 #endif
 	fprintf(stderr, " --heap-name NAME  Target heap name [%s]\n", heap_name);
 	fprintf(stderr, " --no-offset       No random offset [0 255] in buffer\n");


### PR DESCRIPTION
This fixes the following compilation error:

external/optee_test/host/xtest/sdp_basic.c:687:91: error: unused parameter 'ion_heap' [-Werror,-Wunused-parameter]
static void usage(const char *progname, size_t size, int loop, const char *heap_name, int ion_heap)

Signed-off-by: Pierre Moos <pmoos@baylibre.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
