### PR TITLE
xtest: remove ADBG_REQUIRE* macros

### DIFF
--- a/host/xtest/adbg/include/adbg.h
+++ b/host/xtest/adbg/include/adbg.h
@@ -157,52 +157,6 @@ ADBG_ENUM_TABLE_DECLARE(Boolean);
 				     Val1, Val2, (Val1)Compar( \
 					     Val2), #Val1, #Compar, #Val2)
 
-#define ADBG_REQUIRE(Case_p, Recovery, Expected, Got) {\
-	if (!ADBG_EXPECT(Case_p, Expected, Got)) \
-		Recovery }
-
-#define ADBG_REQUIRE_ENUM(Case_p, Recovery, Expected, Got, EnumTable_p) {\
-	if (!ADBG_EXPECT_ENUM(Case_p, Expected, Got, EnumTable_p)) \
-		Recovery }
-
-#define ADBG_REQUIRE_BOOLEAN(Case_p, Recovery, Expected, Got) {\
-	if (!ADBG_EXPECT_BOOLEAN(Case_p, Expected, Got)) \
-		Recovery }
-
-#define ADBG_REQUIRE_TRUE(Case_p, Recovery, Got) {\
-	if (!ADBG_EXPECT_TRUE(Case_p, Got)) \
-		Recovery }
-
-#define ADBG_REQUIRE_EQUAL(Case_p, Recovery, Buf1_p, Buf2_p, Length) {\
-	if (!ADBG_EXPECT_EQUAL(Case_p, Buf1_p, Buf2_p, Length)) \
-		Recovery }
-
-#define ADBG_REQUIRE_BUFFER(Case_p, Recovery, ExpBuf_p, ExpBufLen, GotBuf_p, \
-			    GotBufLen) {\
-	if (!ADBG_EXPECT_BUFFER(Case_p, ExpBuf_p, ExpBufLen, GotBuf_p, \
-				GotBufLen)) \
-		Recovery }
-
-#define ADBG_REQUIRE_POINTER(Case_p, Recovery, Expected, Got) {\
-	if (!ADBG_EXPECT_POINTER(Case_p, Expected, Got)) \
-		Recovery }
-
-#define ADBG_REQUIRE_NOT_NULL(Case_p, Recovery, Got) {\
-	if (!ADBG_EXPECT_NOT_NULL(Case_p, Got)) \
-		Recovery }
-
-#define ADBG_REQUIRE_COMPARE_SIGNED(Case_p, Recovery, Val1, Compar, Val2) {\
-	if (!ADBG_EXPECT_COMPARE_SIGNED(Case_p, Val1, Compar, Val2)) \
-		Recovery }
-
-#define ADBG_REQUIRE_COMPARE_UNSIGNED(Case_p, Recovery, Val1, Compar, Val2) {\
-	if (!ADBG_EXPECT_COMPARE_UNSIGNED(Case_p, Val1, Compar, Val2)) \
-		Recovery }
-
-#define ADBG_REQUIRE_COMPARE_POINTER(Case_p, Recovery, Val1, Compar, Val2) {\
-	if (!ADBG_EXPECT_COMPARE_POINTER(Case_p, Val1, Compar, Val2)) \
-		Recovery }
-
 bool Do_ADBG_Expect(ADBG_Case_t *const Case_p, const char *const FileName_p,
 		    const int LineNumber, const int Expected, const int Got,
 		    const char *const GotVarName_p,


### PR DESCRIPTION
Removes the unused ADBG_REQUIRE* macros. It's not recommended to use those macros.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
