### PR TITLE
host: supp_plugin: add missing dependency on teec

### DIFF
--- a/host/supp_plugin/CMakeLists.txt
+++ b/host/supp_plugin/CMakeLists.txt
@@ -6,4 +6,6 @@ set (CMAKE_SHARED_LIBRARY_PREFIX "")
 add_library(${PROJECT_NAME} SHARED test_supp_plugin.c)
 target_include_directories(${PROJECT_NAME} PRIVATE ./include)
 
+target_link_libraries (${PROJECT_NAME} PRIVATE teec)
+
 install (TARGETS ${PROJECT_NAME} DESTINATION ${CFG_TEE_PLUGIN_LOAD_PATH})


### PR DESCRIPTION
Adds missing dependency of supp_plugin test on libteec header files that are brought in by libteec. The issue was reported by compiler with the below build error message:

/tmp/optee/optee_test/host/supp_plugin/test_supp_plugin.c:12:10: fatal error: tee_plugin_method.h: No such file or directory
   12 | #include <tee_plugin_method.h>
      |          ^~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
