### PR TITLE
Enable compatibility with TEE Internal Core API v1.1

### DIFF
--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -16,6 +16,8 @@ if(OPENSSL_FOUND)
 	set (OPENSSL_PRIVATE_LINK OpenSSL::Crypto)
 endif()
 
+add_compile_options(-D__OPTEE_CORE_API_COMPAT_1_1=1)
+
 find_package(Python REQUIRED)
 
 include(GNUInstallDirs)

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -33,6 +33,8 @@ define cc-bits
 $(if $(filter arm, $(1)),32,$(if $(filter aarch64, $(1)),64,unknown-arch))
 endef
 
+CFLAGS += -D__OPTEE_CORE_API_COMPAT_1_1=1
+
 # OpenSSL is used by:
 # - GP tests series 8500
 # - Mbed TLS test 8103

--- a/host/xtest/gp/patches/0015-Enable-compatibility-with-TEE-Internal-Core-API-v1.1.patch
+++ b/host/xtest/gp/patches/0015-Enable-compatibility-with-TEE-Internal-Core-API-v1.1.patch
@@ -1,0 +1,27 @@
+From 4e495cff6016583a9af14a62a16c2f7988fd9c68 Mon Sep 17 00:00:00 2001
+From: Jens Wiklander <jens.wiklander@linaro.org>
+Date: Wed, 30 Nov 2022 09:00:30 +0100
+Subject: [PATCH] Enable compatibility with TEE Internal Core API v1.1
+
+The test suite is testing TEE Internal Core API v1.1 so make sure that
+the API provided is compatible by setting
+CFG_TA_OPTEE_CORE_API_COMPAT_1_1=y.
+
+Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>
+---
+ TTAs_Internal_API_1_1_1/ta_common.mk | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/TTAs_Internal_API_1_1_1/ta_common.mk b/TTAs_Internal_API_1_1_1/ta_common.mk
+index b8ce142bcf0a..0f8cc7d01314 100644
+--- a/TTAs_Internal_API_1_1_1/ta_common.mk
++++ b/TTAs_Internal_API_1_1_1/ta_common.mk
+@@ -1,3 +1,5 @@
++# These TAs are made for TEE Internal Core API version 1.1
++CFG_TA_OPTEE_CORE_API_COMPAT_1_1=y
+ # Note that it is important that that $(BINARY) is set before we include
+ # ta_dev_kit.mk. In the optee_test this is done in the individual TA Makefiles.
+ include $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk
+-- 
+2.31.1
+

--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -5911,8 +5911,8 @@ static void xtest_tee_test_4016_ed25519(ADBG_Case_t *c)
 			       tv->params.eddsa.public_len);
 
 		if (tv->params.eddsa.flag == 1)
-			xtest_add_attr(&num_attrs, attrs,
-				       TEE_ATTR_EDDSA_PREHASH, NULL, 0);
+			xtest_add_attr_value(&num_attrs, attrs,
+					     TEE_ATTR_EDDSA_PREHASH, 1, 0);
 
 		if (tv->params.eddsa.context_len > 0)
 			xtest_add_attr(&num_attrs, attrs, TEE_ATTR_EDDSA_CTX,

--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -15,6 +15,7 @@
 
 #include <tee_api_types.h>
 #include <tee_api_defines_extensions.h>
+#include <tee_api_compat.h>
 #include <ta_crypt.h>
 #include <utee_defines.h>
 #include <util.h>

--- a/host/xtest/regression_4100.c
+++ b/host/xtest/regression_4100.c
@@ -9,7 +9,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ta_crypt.h>
+#include <tee_api_defines.h>
 #include <tee_api_types.h>
+#include <tee_api_compat.h>
 #include <util.h>
 
 #include "xtest_test.h"

--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -16,6 +16,7 @@
 #include <tee_api_defines.h>
 #include <tee_api_defines_extensions.h>
 #include <tee_api_types.h>
+#include <tee_api_compat.h>
 #include <util.h>
 
 #define DEFINE_TEST_MULTIPLE_STORAGE_IDS(test_name)		 \

--- a/host/xtest/regression_8000.c
+++ b/host/xtest/regression_8000.c
@@ -5,8 +5,10 @@
 #include "xtest_test.h"
 #include "xtest_helpers.h"
 
-#include <tee_api_types.h>
+#include <tee_api_defines.h>
 #include <tee_api_defines_extensions.h>
+#include <tee_api_types.h>
+#include <tee_api_compat.h>
 #include <utee_defines.h>
 #include <string.h>
 #include <enc_fs_key_manager_test.h>

--- a/host/xtest/regression_8100.c
+++ b/host/xtest/regression_8100.c
@@ -9,7 +9,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ta_crypt.h>
+#include <tee_api_defines.h>
 #include <tee_api_types.h>
+#include <tee_api_compat.h>
 #include <adbg.h>
 
 #ifdef OPENSSL_FOUND

--- a/host/xtest/xtest_helpers.h
+++ b/host/xtest/xtest_helpers.h
@@ -8,7 +8,9 @@
 
 #include <adbg.h>
 #include <pthread.h>
+#include <tee_api_defines.h>
 #include <tee_api_types.h>
+#include <tee_api_compat.h>
 #include <tee_client_api.h>
 
 extern unsigned int level;

--- a/host/xtest/xtest_uuid_helpers.h
+++ b/host/xtest/xtest_uuid_helpers.h
@@ -6,7 +6,9 @@
 #ifndef XTEST_UUID_HELPERS_H
 #define XTEST_UUID_HELPERS_H
 
+#include <tee_api_defines.h>
 #include <tee_api_types.h>
+#include <tee_api_compat.h>
 
 /*
  * Convert a UUID string @s into a TEEC_UUID @uuid

--- a/ta/ta_common.mk
+++ b/ta/ta_common.mk
@@ -1,3 +1,4 @@
+CFG_TA_OPTEE_CORE_API_COMPAT_1_1=y
 # Note that it is important that that $(BINARY) is set before we include
 # ta_dev_kit.mk. In the optee_test this is done in the individual TA Makefiles.
 include $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk


### PR DESCRIPTION
While the TEE Internal Core API in OP-TEE OS is updated, enable compatibility with the last support version. This is done by compiling xtest with __OPTEE_CORE_API_COMPAT_1_1=1 and including <tee_api_compat.h> too. The TAs enable it with
CFG_TA_OPTEE_CORE_API_COMPAT_1_1==y in ta/ta_common.mk.

Backwards compatibility is enabled for the GP test suite TAs in the same way, using a new patch.

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
