### PR TITLE
ta: makefile: add compilation of subkey TAs

### DIFF
--- a/ta/Makefile
+++ b/ta/Makefile
@@ -32,7 +32,9 @@ TA_DIRS := create_fail_test \
 	   aes_perf \
 	   socket \
 	   supp_plugin \
-	   large
+	   large \
+	   subkey1 \
+	   subkey2
 
 ifeq ($(CFG_SECURE_DATA_PATH),y)
 TA_DIRS += sdp_basic


### PR DESCRIPTION
With the addition of regression_1039 tests, the compilation of subkey1 and subkey2 TAs is required in the Makefile for xtest to pass.

* regression_1039 Test subkey verification o regression_1039.1 Load TA with two levels of subkeys /usr/src/debug/optee-test/upstream.imx-r0/git/host/xtest/regression_1000.c:3206:xtest_teec_open_session(&session, &subkey1_ta_uuid, ((void *)0),&ret_orig) has an unexpected value: 0xffff0008 = TEEC_ERROR_ITEM_NOT_FOUND, expected 0x0 = TEEC_SUCCESS
  regression_1039.1 FAILED
o regression_1039.2 Load TA with identity subkey
/usr/src/debug/optee-test/upstream.imx-r0/git/host/xtest/regression_1000.c:3213: xtest_teec_open_session(&session, &subkey2_ta_uuid, ((void *)0), &ret_orig) has an unexpected value: 0xffff0008 = TEEC_ERROR_ITEM_NOT_FOUND, expected 0x0 = TEEC_SUCCESS
  regression_1039.2 FAILED
  regression_1039 FAILED

Signed-off-by: Clement Faure <clement.faure@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
