### PR TITLE
regression 1033: fix memref direction

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2434,7 +2434,7 @@ static void xtest_tee_test_1033(ADBG_Case_t *c)
 
 		op.params[0].tmpref.buffer = to_plugin;
 		op.params[0].tmpref.size = sizeof(to_plugin);
-		op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
+		op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INOUT,
 						 TEEC_VALUE_OUTPUT,
 						 TEEC_NONE, TEEC_NONE);
 

--- a/ta/supp_plugin/ta_entry.c
+++ b/ta/supp_plugin/ta_entry.c
@@ -68,7 +68,7 @@ static TEE_Result pass_values(uint32_t param_types,
 static TEE_Result write_array(uint32_t param_types,
 			      TEE_Param params[TEE_NUM_PARAMS])
 {
-	uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+	uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INOUT,
 					  TEE_PARAM_TYPE_VALUE_OUTPUT,
 					  TEE_PARAM_TYPE_NONE,
 					  TEE_PARAM_TYPE_NONE);


### PR DESCRIPTION
For the "Pass array to a plugin" sub-case make the passed buffer in/out since it's passed like that to in that TA with tee_invoke_supp_plugin().

Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
