### PR TITLE
pkcs11: fix regression in RSA AES key wrap tests

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -8246,7 +8246,7 @@ static CK_RV test_rsa_aes_wrap(ADBG_Case_t *c, CK_SESSION_HANDLE session,
 	assert(t->target_type == CKK_RSA || t->target_type == CKK_AES);
 
 	Do_ADBG_BeginSubCase(c,
-			"Test RSA AES wrap/unwrap of %lu %s key with %lu RSA",
+			"Test RSA AES wrap/unwrap of %lu %s key with %zu RSA",
 			target_bits, (t->target_type == CKK_AES) ? "AES" : "RSA",
 			t->key.modulus_len * 8);
 


### PR DESCRIPTION
Fixes the warning:
 29659:  pkcs11_1000.c: In function ‘test_rsa_aes_wrap’:
 29660:  pkcs11_1000.c:8249:51: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 5 has type ‘size_t’ {aka ‘unsigned int’} [-Werror=format=]
 29661:   8249 |    "Test RSA AES wrap/unwrap of %lu %s key with %lu RSA",
 29662:        |                                                 ~~^
 29663:        |                                                   |
 29664:        |                                                   long unsigned int
 29665:        |                                                 %u
 29666:   8250 |    target_bits, (t->target_type == CKK_AES) ? "AES" : "RSA",
 29667:   8251 |    t->key.modulus_len * 8);
 29668:        |    ~~~~~~~~~~~~~~~~~~~~~~
 29669:        |                       |
 29670:        |                       size_t {aka unsigned int}

Fixes: 942159ad8611 ("xtest: pkcs11: Add test for RSA AES key wrap mechanism")
Signed-off-by: Jens Wiklander <jens.wiklander@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
