### PR TITLE
xtest: regression_6000.c: decrease NUM_THREADS to 3

### DIFF
--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -1757,7 +1757,7 @@ exit:
 }
 
 
-#define NUM_THREADS 4
+#define NUM_THREADS 3
 static void xtest_tee_test_6016_loop(ADBG_Case_t *c, uint32_t storage_id)
 {
 	struct test_6016_thread_arg arg[NUM_THREADS] = { };


### PR DESCRIPTION
As per the other regression tests implying concurrency, decrease the number of threads to 3 to satisfy other platforms limitation.
Discussion https://github.com/OP-TEE/optee_test/pull/47

Signed-off-by: Marouene Boubakri <marouene.boubakri@nxp.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
