### PR TITLE
pkcs11: disable 1026 for se05x

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -8343,6 +8343,7 @@ out:
 	return rv;
 }
 
+#ifndef CFG_CRYPTO_SE05X
 static void xtest_pkcs11_test_1026(ADBG_Case_t *c)
 {
 	CK_RV rv = CKR_GENERAL_ERROR;
@@ -8467,3 +8468,4 @@ close_lib:
 
 ADBG_CASE_DEFINE(pkcs11, 1026, xtest_pkcs11_test_1026,
 		 "PKCS11: RSA AES Key Wrap/Unwrap tests");
+#endif


### PR DESCRIPTION
Disable RSA AES wrap/unwrap test when CFG_CRYPTO_SE05X=y, as it's currently not supported when SE050/1 secure elements are being used. When CFG_CRYPTO_SE05X=y this test fails:

pkcs11_1026.1 Test RSA AES wrap/unwrap of 128 AES key with 2048 RSA E/TC:? 0
E/TC:? 0 TA panicked with code 0xffff0009
E/LD:  Status of TA 7f10a757-4139-4eae-90c9-f2b2eb118139
E/LD:   arch: arm
E/LD:  region  0: va 0x40002000 pa 0x00000000 size 0x002000 flags rw-s (ldelf)
E/LD:  region  1: va 0x40004000 pa 0x00000000 size 0x006000 flags r-xs (ldelf)
E/LD:  region  2: va 0x4000a000 pa 0x00000000 size 0x001000 flags rw-s (ldelf)
E/LD:  region  3: va 0x4000b000 pa 0x00000000 size 0x004000 flags rw-s (ldelf)
E/LD:  region  4: va 0x4000f000 pa 0x00000000 size 0x001000 flags r--s
E/LD:  region  5: va 0x40010000 pa 0x00000000 size 0x002000 flags rw-s (stack)
E/LD:  region  6: va 0x40012000 pa 0xdceea000 size 0x001000 flags rw-- (param)
E/LD:  region  7: va 0x40013000 pa 0xc980f54c size 0x002000 flags rw-- (param)
E/LD:  region  8: va 0x40058000 pa 0x00001000 size 0x031000 flags r-xs [0]
E/LD:  region  9: va 0x40089000 pa 0x00032000 size 0x011000 flags rw-s [0]
E/LD:   [0] 7f10a757-4139-4eae-90c9-f2b2eb118139 @ 0x40058000

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
