### PR TITLE
xtest: pkcs11: fix compile error with init_lib_and_find_token_slot()

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -8534,11 +8534,11 @@ static void xtest_pkcs11_test_1026(ADBG_Case_t *c)
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		return;
 
-	rv = init_test_token(slot);
+	rv = init_test_token_pin_auth(slot);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto close_lib;
 
-	rv = init_user_test_token(slot);
+	rv = init_user_test_token_pin_auth(slot);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto close_lib;
 

--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -8530,7 +8530,7 @@ static void xtest_pkcs11_test_1026(ADBG_Case_t *c)
 		  sizeof(ac_rsassa_vect2_prime2) },
 	};
 
-	rv = init_lib_and_find_token_slot(&slot);
+	rv = init_lib_and_find_token_slot(&slot, PIN_AUTH);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		return;
 


### PR DESCRIPTION
Commit b38e9e06fcbd ("xtest: pkcs11: add PKCS11 ACL auth test") added a new parameter to init_lib_and_find_token_slot() but omitted to update one call site. Fix that.

Fixes the following compile error:

 pkcs11_1000.c: In function ‘xtest_pkcs11_test_1026’:
 pkcs11_1000.c:8533:7: error: too few arguments to function ‘init_lib_and_find_token_slot’
  8533 |  rv = init_lib_and_find_token_slot(&slot);
       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
