### PR TITLE
xtest: fix calling C_Finalize before lib is initialized

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -1054,7 +1054,7 @@ static void xtest_pkcs11_test_1003(ADBG_Case_t *c)
 	    !ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_SetPIN) ||
 	    !ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_Login) ||
 	    !ADBG_EXPECT_NOT_NULL(c, ckfunc_list->C_Logout))
-		goto out;
+		return;
 
 	rv = init_lib_and_find_token_slot(&slot, PIN_AUTH);
 	if (!ADBG_EXPECT_CK_OK(c, rv))


### PR DESCRIPTION
C_Finalize() is called from some places through close_lib() even before pkcs11 library is initialized. These needs to be replaced by return.

Signed-off-by: Matthew(Sukyoung) Chae <matthewc@axis.com>
