### PR TITLE
xtest: pkcs11: fix 64-bit xtest_pkcs11_1014 failed

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -3539,7 +3539,7 @@ static void xtest_pkcs11_test_1014(ADBG_Case_t *c)
 		{ CKA_DECRYPT, &g_decrypt, sizeof(CK_BBOOL) },
 		{ CKA_WRAP, &g_wrap, sizeof(CK_BBOOL) },
 		{ CKA_UNWRAP, &g_unwrap, sizeof(CK_BBOOL) },
-		{ CKA_VALUE_LEN, &g_len, sizeof(CK_ULONG) },
+		{ CKA_VALUE_LEN, &g_len, sizeof(g_len) },
 	};
 	CK_ATTRIBUTE set_template[] = {
 		{ CKA_LABEL, (CK_UTF8CHAR_PTR)new_label, strlen(new_label) },


### PR DESCRIPTION
64-bit xtest unsigned long is 8 bytes,while the
g_len is 4 bytes, crossing the bounds and causing
the contamination variable to g_decrypt

FAILED:
pkcs11_1000.c:3496: Expression "g_decrypt == CK_TRUE" (0 == 1) is false pkcs11_1014.1 FAILED

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
