### PR TITLE
Fix Storage TA ABI TEE_ObjectInfo

### DIFF
--- a/ta/include/ta_storage.h
+++ b/ta/include/ta_storage.h
@@ -12,6 +12,16 @@
 #define TA_STORAGE2_UUID { 0x731e279e, 0xaafb, 0x4575, \
 	{ 0xa7, 0x71, 0x38, 0xca, 0xa6, 0xf0, 0xcc, 0xa6 } }
 
+struct ta_storage_obj_info {
+	uint32_t object_type;
+	uint32_t object_size;
+	uint32_t max_object_size;
+	uint32_t object_usage;
+	uint32_t data_size;
+	uint32_t data_position;
+	uint32_t handle_flags;
+};
+
 #define TA_STORAGE_CMD_OPEN			0
 #define TA_STORAGE_CMD_CLOSE			1
 #define TA_STORAGE_CMD_READ			2

--- a/ta/storage/storage.c
+++ b/ta/storage/storage.c
@@ -636,6 +636,7 @@ TEE_Result ta_storage_cmd_get_obj_info(uint32_t param_types,
 					    TEE_Param params[4])
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
+	struct ta_storage_obj_info oi = { };
 	TEE_ObjectInfo info = { };
 	TEE_ObjectHandle o = VAL2HANDLE(params[0].value.a);
 
@@ -644,12 +645,19 @@ TEE_Result ta_storage_cmd_get_obj_info(uint32_t param_types,
 			   TEE_PARAM_TYPE_MEMREF_OUTPUT, TEE_PARAM_TYPE_NONE,
 			   TEE_PARAM_TYPE_NONE));
 
-	if (params[1].memref.size < sizeof(info))
+	if (params[1].memref.size < sizeof(oi))
 		return TEE_ERROR_SHORT_BUFFER;
 	res = TEE_GetObjectInfo1(o, &info);
 	if (!res) {
-		params[1].memref.size = sizeof(info);
-		TEE_MemMove(params[1].memref.buffer, &info, sizeof(info));
+		params[1].memref.size = sizeof(oi);
+		oi.object_type = info.objectType;
+		oi.object_size = info.objectSize;
+		oi.max_object_size = info.maxObjectSize;
+		oi.object_usage = info.objectUsage;
+		oi.data_size = info.dataSize;
+		oi.data_position = info.dataPosition;
+		oi.handle_flags = info.handleFlags;
+		TEE_MemMove(params[1].memref.buffer, &oi, sizeof(oi));
 	}
 
 	return res;


### PR DESCRIPTION
With the updated types for GP 1.3 TEE_ObjectInfo contains elements with the type size_t. If xtest is built for AArch64 while the storage TA is built for AArch32 the ABI will become incompatible. Fix this by adding struct ta_storage_obj_info with fixed width integers only and use that in the TA ABI used by xtest.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
