### PR TITLE
xtest: regression_6016: use 3 threads instead of 4

### DIFF
--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -1770,7 +1770,7 @@ exit:
 }
 
 
-#define NUM_THREADS 4
+#define NUM_THREADS 3
 static void xtest_tee_test_6016_loop(ADBG_Case_t *c, uint32_t storage_id)
 {
 	struct test_6016_thread_arg arg[NUM_THREADS] = { };


### PR DESCRIPTION
Since OP-TEE commit cda03b63cf30 ("Enable SHA-3 support by default") [1] regression_6016 fails when OP-TEE OS is compiled for QEMUv8 with "make CFG_ULIBS_SHARED=y CFG_WITH_PAGER=y":

 * regression_6016 Storage concurency o regression_6016.1 Storage id: 00000001 threads: 4, loops: 8 regression_6000.c:1784: xtest_teec_open_session(&arg[m].session, &storage_ta_uuid, ((void *)0), &orig) has an unexpected value: 0xffff000c = TEEC_ERROR_OUT_OF_MEMORY, expected 0x0 = TEEC_SUCCESS

Use 3 threads instead of 4 to reduce the memory footprint.

Link: [1] https://github.com/OP-TEE/optee_os/commit/cda03b63cf304472adce7688a07168f4c66af5c7

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
