### PR TITLE
ta: storage: maybe usued TA UUID in clear_storage()

### DIFF
--- a/ta/storage/storage.c
+++ b/ta/storage/storage.c
@@ -671,7 +671,7 @@ static TEE_Result clear_storage(uint32_t storage_id)
 	TEE_Result enum_res = TEE_ERROR_GENERIC;
 	TEE_ObjectHandle o = TEE_HANDLE_NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
-	TEE_UUID uuid = TA_UUID;
+	TEE_UUID __maybe_unused uuid = TA_UUID;
 	TEE_ObjectInfo oi = { };
 	size_t obj_id_sz = 0;
 	void *obj_id = NULL;


### PR DESCRIPTION
Adds __maybe_unused attribute to local variable hold the TA UUID to fix build warning reported by GCC with the below trace:

../storage/storage.c: In function ‘clear_storage’: ../storage/storage.c:674:18: error: unused variable ‘uuid’ [-Werror=unused-variable]
  674 |         TEE_UUID uuid = TA_UUID;
      |                  ^~~~

Fixes: aa43c9084e21 ("xtest: add --clear-storage option")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
