### PR TITLE
xtest: fix xtest tool name in usage trace messages

### DIFF
--- a/host/xtest/aes_perf.c
+++ b/host/xtest/aes_perf.c
@@ -23,6 +23,7 @@
 
 #include "crypto_common.h"
 #include "xtest_helpers.h"
+#include "xtest_test.h"
 
 #ifdef CFG_SECURE_DATA_PATH
 #include "sdp_basic.h"
@@ -182,11 +183,12 @@ static const char *mode_str(uint32_t mode)
 #define _TO_STR(x) #x
 #define TO_STR(x) _TO_STR(x)
 
-static void usage(const char *progname, int keysize, int mode, size_t size,
-		  size_t unit, int warmup, unsigned int l, unsigned int n)
+static void usage(const char *applet_optname, int keysize, int mode,
+		  size_t size, size_t unit, int warmup, unsigned int l,
+		  unsigned int n)
 {
-	fprintf(stderr, "Usage: %s [-h]\n", progname);
-	fprintf(stderr, "Usage: %s [-d] [-i] [-k SIZE]", progname);
+	fprintf(stderr, "Usage: %s %s [-h]\n", xtest_progname, applet_optname);
+	fprintf(stderr, "Usage: %s %s [-d] [-i] [-k SIZE]", xtest_progname, applet_optname);
 	fprintf(stderr, " [-l LOOP] [-m MODE] [-n LOOP] [-r|--no-inited] [-s SIZE]");
 	fprintf(stderr, " [-v [-v]] [-w SEC]");
 #ifdef CFG_SECURE_DATA_PATH
@@ -531,8 +533,8 @@ void aes_perf_run_test(int mode, int keysize, int decrypt, size_t size, size_t u
 #define NEXT_ARG(i) \
 	do { \
 		if (++i == argc) { \
-			fprintf(stderr, "%s: %s: missing argument\n", \
-				argv[0], argv[i - 1]); \
+			fprintf(stderr, "%s %s: %s: missing argument\n", \
+				xtest_progname, argv[0], argv[i - 1]); \
 			return 1; \
 		} \
 	} while (0);
@@ -577,8 +579,8 @@ int aes_perf_runner_cmd_parser(int argc, char *argv[])
 			keysize = atoi(argv[i]);
 			if (keysize != AES_128 && keysize != AES_192 &&
 				keysize != AES_256) {
-				fprintf(stderr, "%s: invalid key size\n",
-					argv[0]);
+				fprintf(stderr, "%s %s: invalid key size\n",
+					xtest_progname, argv[0]);
 				USAGE();
 				return 1;
 			}
@@ -598,8 +600,8 @@ int aes_perf_runner_cmd_parser(int argc, char *argv[])
 			else if (!strcasecmp(argv[i], "GCM"))
 				mode = TA_AES_GCM;
 			else {
-				fprintf(stderr, "%s, invalid mode\n",
-					argv[0]);
+				fprintf(stderr, "%s %s, invalid mode\n",
+					xtest_progname, argv[0]);
 				USAGE();
 				return 1;
 			}
@@ -653,8 +655,8 @@ int aes_perf_runner_cmd_parser(int argc, char *argv[])
 			NEXT_ARG(i);
 			warmup = atoi(argv[i]);
 		} else {
-			fprintf(stderr, "%s: invalid argument: %s\n",
-				argv[0], argv[i]);
+			fprintf(stderr, "%s %s: invalid argument: %s\n",
+				xtest_progname, argv[0], argv[i]);
 			USAGE();
 			return 1;
 		}

--- a/host/xtest/hash_perf.c
+++ b/host/xtest/hash_perf.c
@@ -20,6 +20,7 @@
 
 #include "crypto_common.h"
 #include "xtest_helpers.h"
+#include "xtest_test.h"
 
 /*
  * TEE client stuff
@@ -371,12 +372,13 @@ extern void hash_perf_run_test(int algo, size_t size, unsigned int n,
 	free_shm();
 }
 
-static void usage(const char *progname,
+static void usage(const char *applet_optname,
 				/* Default params */
 				int algo, size_t size, int warmup, int l, int n)
 {
-	fprintf(stderr, "Usage: %s [-h]\n", progname);
-	fprintf(stderr, "Usage: %s [-a ALGO] [-l LOOP] [-n LOOP] [-r] [-s SIZE]", progname);
+	fprintf(stderr, "Usage: %s %s [-h]\n", xtest_progname, applet_optname);
+	fprintf(stderr, "Usage: %s %s [-a ALGO] [-l LOOP] [-n LOOP] [-r] [-s SIZE]",
+		xtest_progname, applet_optname);
 	fprintf(stderr, " [-v [-v]] [-w SEC]\n");
 	fprintf(stderr, "Hash performance testing tool for OP-TEE\n");
 	fprintf(stderr, "\n");
@@ -398,8 +400,8 @@ static void usage(const char *progname,
 #define NEXT_ARG(i) \
 	do { \
 		if (++i == argc) { \
-			fprintf(stderr, "%s: %s: missing argument\n", \
-				argv[0], argv[i - 1]); \
+			fprintf(stderr, "%s %s: %s: missing argument\n", \
+				xtest_progname, argv[0], argv[i - 1]); \
 			return 1; \
 		} \
 	} while (0);
@@ -457,8 +459,8 @@ extern int hash_perf_runner_cmd_parser(int argc, char *argv[])
 			else if (!strcasecmp(argv[i], "HMAC_SM3"))
 				algo = TA_HMAC_SM3;
 			else {
-				fprintf(stderr, "%s, invalid algorithm\n",
-					argv[0]);
+				fprintf(stderr, "%s %s, invalid algorithm\n",
+					xtest_progname, argv[0]);
 				usage(argv[0], algo, size, warmup, l, n);
 				return 1;
 			}
@@ -481,8 +483,8 @@ extern int hash_perf_runner_cmd_parser(int argc, char *argv[])
 			NEXT_ARG(i);
 			warmup = atoi(argv[i]);
 		} else {
-			fprintf(stderr, "%s: invalid argument: %s\n",
-				argv[0], argv[i]);
+			fprintf(stderr, "%s %s: invalid argument: %s\n",
+				xtest_progname, argv[0], argv[i]);
 			usage(argv[0], algo, size, warmup, l, n);
 			return 1;
 		}

--- a/host/xtest/sdp_basic.c
+++ b/host/xtest/sdp_basic.c
@@ -590,9 +590,10 @@ bail:
 #define _TO_STR(x) #x
 #define TO_STR(x) _TO_STR(x)
 
-static void usage(const char *progname, size_t size, int loop, const char *heap_name)
+static void usage(const char *applet_optname, size_t size, int loop,
+		  const char *heap_name)
 {
-	fprintf(stderr, "Usage: %s [OPTION]\n", progname);
+	fprintf(stderr, "Usage: %s %s [OPTION]\n", xtest_progname, applet_optname);
 	fprintf(stderr,
 		"Testing basic accesses to secure buffer (SDP) on OP-TEE.\n"
 		"Allocates a secure buffer and invoke a TA to access it.\n"
@@ -611,8 +612,8 @@ static void usage(const char *progname, size_t size, int loop, const char *heap_
 #define NEXT_ARG(i) \
 	do { \
 		if (++i == argc) { \
-			fprintf(stderr, "%s: %s: missing argument\n", \
-				argv[0], argv[i-1]); \
+			fprintf(stderr, "%s %s: %s: missing argument\n", \
+				xtest_progname, argv[0], argv[i-1]); \
 			return 1; \
 		} \
 	} while (0);
@@ -657,8 +658,8 @@ int sdp_basic_runner_cmd_parser(int argc, char *argv[])
 		} else if (!strcmp(argv[i], "--no-offset")) {
 			rnd_offset = 0;
 		} else {
-			fprintf(stderr, "%s: invalid argument: %s\n",
-				argv[0], argv[i]);
+			fprintf(stderr, "%s %s: invalid argument: %s\n",
+				xtest_progname, argv[0], argv[i]);
 			usage(argv[0], test_size, test_loop, heap_name);
 			return 1;
 		}

--- a/host/xtest/stats.c
+++ b/host/xtest/stats.c
@@ -47,11 +47,9 @@ struct ta_dump_stats {
 	struct malloc_stats heap;
 };
 
-static const char *stats_progname = "xtest --stats";
-
 static int usage(void)
 {
-	fprintf(stderr, "Usage: %s [OPTION]\n", stats_progname);
+	fprintf(stderr, "Usage: %s --stats [OPTION]\n", xtest_progname);
 	fprintf(stderr, "Displays statistics from OP-TEE\n");
 	fprintf(stderr, "Options:\n");
 	fprintf(stderr, " -h|--help      Print this help and exit\n");


### PR DESCRIPTION
Fixes the xtest program name printed in applets usage and error trace messages. Stats applet assumes it is named xtest instead of using caller argv[0]. Other applets simply print the applet option name instead of xtest tool name followed by applet option name.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
