### PR TITLE
xtest: remove ffa.h from SPMC test to resolve compiler error

### DIFF
--- a/host/xtest/ffa_spmc_1000.c
+++ b/host/xtest/ffa_spmc_1000.c
@@ -3,7 +3,6 @@
  * Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
  */
 #include <fcntl.h>
-#include <ffa.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>


### PR DESCRIPTION
`commit 5489e94f0566 ("core: ffa: add boot info structs and defines")` in optee_os causes the compiler error below in `ffa_spmc_1000.c`.
```
In file included from ffa_spmc_1000.c:6:
ffa.h:196:41: error: implicit declaration of function ‘U’ [-Werror=implicit-function-declaration]
  196 | #define FFA_BOOT_INFO_NAME_LEN          U(16)
      |                                         ^
ffa.h:319:19: note: in expansion of macro ‘FFA_BOOT_INFO_NAME_LEN’
  319 |         char name[FFA_BOOT_INFO_NAME_LEN];
      |                   ^~~~~~~~~~~~~~~~~~~~~~
ffa.h:319:14: error: variably modified ‘name’ at file scope
  319 |         char name[FFA_BOOT_INFO_NAME_LEN];
      |              ^~~~
```

`ffa.h` uses the `U` macro which is only part of OP-TEE's libc and not a standard macro. This causes a compiler error when compiling a host application and the libc is provided by the compiler.

The FF-A SPMC test in xtest relies on the `arm_ffa_user` Linux driver so it doesn't use any of the definitions of the `ffa.h`. This makes it safe to remove the include of this file which ultimately resolves the compiler error.

Related PR in optee_os: https://github.com/OP-TEE/optee_os/pull/6089

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
