### PR TITLE
regression_4006: fix fuzzing shared memory content

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -3832,6 +3832,7 @@ static void xtest_tee_test_4006(ADBG_Case_t *c)
 	uint32_t pub_key_type = 0;
 	uint32_t priv_key_type = 0;
 	uint32_t hash_algo = 0;
+	uint32_t sha1_algo_id = TEE_ALG_SHA1;
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&session, &crypt_user_ta_uuid, NULL,
@@ -4132,9 +4133,9 @@ static void xtest_tee_test_4006(ADBG_Case_t *c)
 				algo_params[0].attributeID =
 					TEE_ATTR_RSA_OAEP_MGF_HASH;
 				algo_params[0].content.ref.length =
-					sizeof(uint32_t);
+					sizeof(sha1_algo_id);
 				algo_params[0].content.ref.buffer =
-					&(uint32_t){TEE_ALG_SHA1};
+					&sha1_algo_id;
 				num_algo_params = 1;
 			}
 


### PR DESCRIPTION
Explicit uses the stack to refer to attribute TEE_ATTR_RSA_OAEP_MGF_HASH passed to the crypt TA in tests regression 4006.37 and 4006.38 as the current implementation makes to TA to see an uninitialized buffer reference.

Fixes: https://github.com/OP-TEE/optee_os/issues/6143
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
