### PR TITLE
regression_1034: fix Segmentation fault when large TA not found

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2572,10 +2572,11 @@ static void xtest_tee_test_1034(ADBG_Case_t *c)
 				      &ret_orig);
 	if (res == TEEC_ERROR_OUT_OF_MEMORY) {
 		Do_ADBG_Log("TEEC_ERROR_OUT_OF_MEMORY - ignored");
-	} else {
-		ADBG_EXPECT_TEEC_SUCCESS(c, res);
-		TEEC_CloseSession(&session);
+		return;
 	}
+	ADBG_EXPECT_TEEC_SUCCESS(c, res);
+	if (!res)
+		TEEC_CloseSession(&session);
 }
 ADBG_CASE_DEFINE(regression, 1034, xtest_tee_test_1034,
 		 "Test loading a large TA");


### PR DESCRIPTION
Symptom:
Run xtest test cannot finish all test cases due to there is Segmentation faultthat stop at regression 1034 test case.

Snapshot log as below:
* regression_1034 Test loading a large TA /usr/src/debug/optee-test/3.20.0-r0/host/xtest/
regression_1000.c:2524:res has an unexpected value: 0xffff0008 = TEEC_ERROR_ITEM_NOT_FOUND, expected 0x0 = TEEC_SUCCESS Segmentation fault (core dumped)

Root cause:
In regression 1034 test function, when opening session for large TA got failed because response that large TA not found. However, this function still call TEEC_CloseSession then cause Segmentation fault. According the log, the ADBG_EXPECT_TEEC_SUCCESS(c, res) function response with TEEC_ERROR_ITEM_NOT_FOUND this error message.

Solution:
Add additional check if response with TEEC_ERROR_ITEM_NOT_FOUND then return directly to avoid segmentation fault and cause test cannot done.

How to repo this issue:
Set CFG_REE_FS_TA=n then run xtest 1034 that can 100% repoduce issue.

Tested:
root@evb-npcm845:~# xtest 1034
Test ID: 1034E/LD:
init_elf:486 sys_open_ta_bin(25497083-a58a-4fc5-8a72-1ad7b69b8562)

Run test suiteE/TC:? 0 ldelf_init_with_ldelf:151 ldelf failed with res: 0xffff0008 with level=0

* regression_1034 Test loading a large TA skip test, large TA not found regression_1034 OK +----------------------------------------------------- Result of testsuite regression filtered by "1034": regression_1034 OK
+----------------------------------------------------- 0 subtests of which 0 failed
1 test case of which 0 failed
100 test cases were skipped
TEE test application done!