### PR TITLE
regression_1025: use the imp field in TEEC_Context

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -2018,7 +2018,7 @@ static void xtest_tee_test_1025(ADBG_Case_t *c)
 
 	Do_ADBG_EndSubCase(c, "Invalid NULL buffer memref registration");
 
-	if (!xtest_teec_ctx.memref_null) {
+	if (!xtest_teec_ctx.imp.memref_null) {
 		Do_ADBG_Log("Skip subcases: MEMREF_NULL capability not supported");
 		return;
 	}


### PR DESCRIPTION
As the test xtest_tee_test_1025 uses a part of a struct from tee_client_api.h that is implementation defined, the test needed to be updated when the implementation defined parts of the structs in tee_client_api.h changed to use an imp field instead of separate fields.

Link: https://github.com/OP-TEE/optee_client/pull/349
Reported-by: Tom Hebb <tommyhebb@gmail.com>
Signed-off-by: Julianus Larson <julianus.larson@linaro.org>
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
