### PR TITLE
ta: os_test: fetch system time after the one second delay for proper comparaison

### DIFF
--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -635,10 +635,9 @@ static TEE_Result test_time(void)
 	printf("TA time %u.%03u\n", (unsigned int)t.seconds,
 	       (unsigned int)t.millis);
 
-	if (t.seconds > sys_t.seconds) {
-		EMSG("Unexpected wrapped time %u.%03u (sys_t %u.%03u)\n",
-		     (unsigned int)t.seconds, (unsigned int)t.millis,
-		     (unsigned int)sys_t.seconds, (unsigned int)sys_t.millis);
+	if (t.seconds > 1) {
+		EMSG("Unexpected wrapped time %u.%03u\n",
+		     (unsigned int)t.seconds, (unsigned int)t.millis);
 		return TEE_ERROR_BAD_STATE;
 	}
 


### PR DESCRIPTION
…time comparaison

In the regression_1006 test, the wrapped TA time is compared to the system time. The time delay for this test is one second. The system time is fetched at the very begining of the test function.

For this test to pass, it is assumed that the system time fetched is at least one second. That might not be the case in a system where the test is started right after a deep sleep state where the system counter gets reset.

To solve this issue, fetch the system counter after the one second delay.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
