### PR TITLE
ta: os_test: remove deprecated macro related to libmpa

### DIFF
--- a/ta/os_test/include/tb_asserts.h
+++ b/ta/os_test/include/tb_asserts.h
@@ -74,18 +74,6 @@ do {                                                            \
 } while (0)
 
 /*
- * TB_ASSERT_HEX_VALUE checks that a prints to the string v in hex.
- */
-#define TB_ASSERT_HEX_PRINT_VALUE(a, v)                \
-do {                                                   \
-	char *_str_;                                   \
-	_str_ = TEE_BigIntConvertToString(NULL,        \
-		TEE_STRING_MODE_HEX_UC, (a));          \
-	TB_ASSERT_STR_EQ(_str_, (v));                  \
-	TEE_Free(_str_);                               \
-} while (0)
-
-/*
  * TB_ASSERT_POINTER_NULL(p) checks that p is null
  */
 #define TB_ASSERT_POINTER_NULL(p)                                  \

--- a/ta/os_test/include/tb_macros.h
+++ b/ta/os_test/include/tb_macros.h
@@ -54,15 +54,4 @@
  */
 #define DEL_BIGINT(name) TEE_Free(name)
 
-/*
- * TB_PRINT_BIGINT prints the mpanum in base 16.
- */
-#define TB_PRINT_BIGINT(n)                                                     \
-do {                                                                           \
-	char *str;                                                             \
-	str = TEE_BigIntConvertToString(NULL, TEE_STRING_MODE_HEX_UC, 0, (n)); \
-	printf("%s\n", str);                                                   \
-	TEE_Free(str);                                                         \
-} while (0)
-
 #endif


### PR DESCRIPTION
Removes macros TB_PRINT_BIGINT() and TB_ASSERT_HEX_PRINT_VALUE() that are never used. These macros depend in TEE_STRING_MODE_HEX_UC which has been removed from optee_os. It was removed from OP-TEE because it was related to libmpa removed from OP-TEE OS since release tag 3.9.0, by commit 7fb525f1f8a6 ("Remove libmpa in favor of libmbedtls").

Link: https://github.com/OP-TEE/optee_os/pull/6451

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
