### PR TITLE
No newline in *MSG() macros

### DIFF
--- a/ta/os_test/include/tb_asserts.h
+++ b/ta/os_test/include/tb_asserts.h
@@ -16,9 +16,9 @@
 #define TB_ASSERT_MSG(cond, str)                                   \
 do {                                                               \
 	if (!(cond)) {                                             \
-		EMSG("Assertion failed at line %d in file:\n%s\n", \
+		EMSG("Assertion failed at line %d in file:\n%s",   \
 			__LINE__, __FILE__);                       \
-		EMSG("Message: %s\n", str);                        \
+		EMSG("Message: %s", str);                          \
 		HALT;                                              \
 	}; \
 } while (0)
@@ -29,7 +29,7 @@ do {                                                               \
 #define TB_ASSERT(cond)                                            \
 do {                                                               \
 	if (!(cond)) {                                             \
-		EMSG("Assertion failed at line %d in file:\n%s\n", \
+		EMSG("Assertion failed at line %d in file:\n%s",   \
 			__LINE__, __FILE__);                       \
 		HALT;                                              \
 	};                                                         \
@@ -41,21 +41,21 @@ do {                                                               \
 #define TB_ASSERT_EQ_SHORT(src, short)                                         \
 do {                                                                           \
 	if (((short) == 0) && (__mpanum_size((mpanum)src) != 0)) {             \
-		EMSG("Assertion failed at line %d in file:\n%s\n",             \
+		EMSG("Assertion failed at line %d in file:\n%s",               \
 			__LINE__, __FILE__);                                   \
-		EMSG("short == 0, but size != 0\n");                           \
+		EMSG("short == 0, but size != 0");                             \
 		HALT;                                                          \
 	} else if (__mpanum_size((mpanum)src) > 1) {                           \
-		EMSG("Assertion failed at line %d in file:\n%s\n",             \
+		EMSG("Assertion failed at line %d in file:\n%s",               \
 			__LINE__, __FILE__);                                   \
-		EMSG("size > 1, cannot be equal to a short.\n");               \
+		EMSG("size > 1, cannot be equal to a short.");                 \
 		HALT;                                                          \
 	} else if (                                                            \
 		(int)(__mpanum_lsw((mpanum)src)*__mpanum_sign((mpanum)src)) != \
 			(int)(short)) {                                        \
-		EMSG("Assertion failed at line %d in file:\n%s\n",             \
+		EMSG("Assertion failed at line %d in file:\n%s",               \
 				__LINE__, __FILE__);                           \
-		EMSG("short == %d, but src == %d\n", (short),                  \
+		EMSG("short == %d, but src == %d", (short),                    \
 			(int)(__mpanum_lsw((mpanum)src)                        \
 			*__mpanum_sign((mpanum)src)));                         \
 		HALT;                                                          \
@@ -68,7 +68,7 @@ do {                                                                           \
 #define TB_ASSERT_STR_EQ(a, b)                                  \
 do {                                                            \
 	if (my_strcmp((a), (b)) != 0) {                         \
-		EMSG("Assertion failed %s != %s\n", (a), (b));  \
+		EMSG("Assertion failed %s != %s", (a), (b));    \
 		HALT;                                           \
 	};                                                      \
 } while (0)
@@ -79,7 +79,7 @@ do {                                                            \
 #define TB_ASSERT_POINTER_NULL(p)                                  \
 do {                                                               \
 	if ((p) != 0) {                                            \
-		EMSG("Assertion failed, pointer was not null.\n"); \
+		EMSG("Assertion failed, pointer was not null.");   \
 		HALT;                                              \
 	};                                                         \
 } while (0)
@@ -90,7 +90,7 @@ do {                                                               \
 #define TB_ASSERT_POINTERS_EQ(p, q)                                  \
 do {                                                                 \
 	if ((p) != (q)) {                                            \
-		EMSG("Assertion failed, pointers are not equal.\n"); \
+		EMSG("Assertion failed, pointers are not equal.");   \
 		HALT;                                                \
 	};                                                           \
 } while (0)
@@ -101,7 +101,7 @@ do {                                                                 \
 #define TB_ASSERT_POINTERS_NEQ(p, q)                             \
 do {                                                             \
 	if ((p) == (q)) {                                        \
-		EMSG("Assertion failed, pointers are equal.\n"); \
+		EMSG("Assertion failed, pointers are equal.");   \
 		HALT;                                            \
 	};                                                       \
 } while (0)
@@ -112,7 +112,7 @@ do {                                                             \
 #define TB_ASSERT_BIGINT_EQ(a, b)                                   \
 do {                                                                \
 	if (TEE_BigIntCmp((a), (b)) != 0) {                         \
-		EMSG("Assertion failed, numbers are not equal.\n"); \
+		EMSG("Assertion failed, numbers are not equal.");   \
 		HALT;                                               \
 	};                                                          \
 } while (0)
@@ -123,7 +123,7 @@ do {                                                                \
 #define TB_ASSERT_BIGINT_NEQ(a, b)                              \
 do {                                                            \
 	if (TEE_BigIntCmp((a), (b)) == 0) {                     \
-		EMSG("Assertion failed, numbers are equal.\n"); \
+		EMSG("Assertion failed, numbers are equal.");   \
 		HALT;                                           \
 	};                                                      \
 } while (0)
@@ -134,7 +134,7 @@ do {                                                            \
 #define TB_ASSERT_BIGINT_LESS(a, b)                                         \
 do {                                                                        \
 	if (TEE_BigIntCmp((a), (b)) >= 0) {                                 \
-		EMSG("Assertion failed, first is not less than second.\n"); \
+		EMSG("Assertion failed, first is not less than second.");   \
 		HALT;                                                       \
 	}; \
 } while (0)
@@ -145,7 +145,7 @@ do {                                                                        \
 #define TB_ASSERT_INT_EQ(a, b)                                      \
 do {                                                                \
 	if ((a) != (b)) {                                           \
-		EMSG("Assertion failed, numbers are not equal.\n"); \
+		EMSG("Assertion failed, numbers are not equal.");   \
 		HALT;                                               \
 	};                                                          \
 } while (0)

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -134,7 +134,7 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 
 		res = TEE_GetPropertyName(h, nbuf, &nblen);
 		if (res != TEE_SUCCESS) {
-			EMSG("TEE_GetPropertyName returned 0x%x\n",
+			EMSG("TEE_GetPropertyName returned 0x%x",
 			     (unsigned int)res);
 			return res;
 		}
@@ -182,7 +182,7 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 			return res;
 
 		if (strcmp(vbuf, vbuf2) != 0) {
-			EMSG("String of \"%s\" differs\n", nbuf);
+			EMSG("String of \"%s\" differs", nbuf);
 			return TEE_ERROR_GENERIC;
 		}
 
@@ -215,19 +215,19 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 		/* check specific myprop.hello property, which is larger than 80 */
 		if (!strcmp("myprop.hello", nbuf) &&
 		    vblen2 != 1 + strlen("hello property, larger than 80 characters, so that it checks that it is not truncated by anything in the source code which may be wrong")) {
-			EMSG("TEE_GetPropertyAsString(\"%s\") is truncated - returned \"%s\"\n",
+			EMSG("TEE_GetPropertyAsString(\"%s\") is truncated - returned \"%s\"",
 			     nbuf, vbuf);
 			return TEE_ERROR_GENERIC;
 		}
 
-		DMSG("Found \"%s\" value \"%s\"\n", nbuf, vbuf);
+		DMSG("Found \"%s\" value \"%s\"", nbuf, vbuf);
 
 		for (n = 0; n < num_p_attrs; n++) {
 			if (strcmp(nbuf, p_attrs[n].str) != 0)
 				continue;
 
 			if (p_attrs[n].retrieved) {
-				EMSG("Value \"%s\" already retrieved\n",
+				EMSG("Value \"%s\" already retrieved",
 				     p_attrs[n].str);
 				return TEE_ERROR_GENERIC;
 			}
@@ -242,7 +242,7 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 					    TEE_GetPropertyAsBool(h, NULL, &v);
 					if (res != TEE_SUCCESS) {
 						EMSG(
-						"TEE_GetPropertyAsBool(\"%s\") returned 0x%x\n",
+						"TEE_GetPropertyAsBool(\"%s\") returned 0x%x",
 						nbuf, (unsigned int)res);
 						return res;
 					}
@@ -256,7 +256,7 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 					res = TEE_GetPropertyAsU32(h, NULL, &v);
 					if (res != TEE_SUCCESS) {
 						EMSG(
-						"TEE_GetPropertyAsU32(\"%s\") returned 0x%x\n",
+						"TEE_GetPropertyAsU32(\"%s\") returned 0x%x",
 						nbuf, (unsigned int)res);
 						return res;
 					}
@@ -271,7 +271,7 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 					    TEE_GetPropertyAsUUID(h, NULL, &v);
 					if (res != TEE_SUCCESS) {
 						EMSG(
-						"TEE_GetPropertyAsUUID(\"%s\") returned 0x%x\n",
+						"TEE_GetPropertyAsUUID(\"%s\") returned 0x%x",
 						nbuf, (unsigned int)res);
 						return res;
 					}
@@ -287,7 +287,7 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 								      &v);
 					if (res != TEE_SUCCESS) {
 						EMSG(
-						"TEE_GetPropertyAsIdentity(\"%s\") returned 0x%x\n",
+						"TEE_GetPropertyAsIdentity(\"%s\") returned 0x%x",
 						nbuf, (unsigned int)res);
 						return res;
 					}
@@ -351,7 +351,7 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 				break;
 
 			default:
-				EMSG("Unknown type (%d) for \"%s\"\n",
+				EMSG("Unknown type (%d) for \"%s\"",
 				     p_attrs[n].type, p_attrs[n].str);
 				return TEE_ERROR_GENERIC;
 			}
@@ -371,7 +371,7 @@ static TEE_Result test_malloc(void)
 	void *p = TEE_Malloc(4, 0);
 
 	if (p == NULL) {
-		EMSG("TEE_Malloc failed\n");
+		EMSG("TEE_Malloc failed");
 		return TEE_ERROR_OUT_OF_MEMORY;
 	}
 	TEE_Free(p);
@@ -427,7 +427,7 @@ static TEE_Result test_properties(void)
 
 	res = TEE_AllocatePropertyEnumerator(&h);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_AllocatePropertyEnumerator: returned 0x%x\n",
+		EMSG("TEE_AllocatePropertyEnumerator: returned 0x%x",
 		     (unsigned int)res);
 		return TEE_ERROR_GENERIC;
 	}
@@ -451,7 +451,7 @@ static TEE_Result test_properties(void)
 
 	for (n = 0; n < num_p_attrs; n++) {
 		if (!p_attrs[n].retrieved) {
-			EMSG("\"%s\" not retrieved\n", p_attrs[n].str);
+			EMSG("\"%s\" not retrieved", p_attrs[n].str);
 			res = TEE_ERROR_GENERIC;
 			goto cleanup_return;
 		}
@@ -534,7 +534,7 @@ static TEE_Result test_mem_access_right(uint32_t param_types,
 	res = TEE_OpenTASession(&test_uuid, TEE_TIMEOUT_INFINITE, 0, NULL,
 				&sess, &ret_orig);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_OpenTASession failed\n");
+		EMSG("TEE_OpenTASession failed");
 		return res;
 	}
 
@@ -548,7 +548,7 @@ static TEE_Result test_mem_access_right(uint32_t param_types,
 				  TA_OS_TEST_CMD_PARAMS_ACCESS,
 				  l_pts, l_params, &ret_orig);
 	if (res != TEE_SUCCESS)
-		EMSG("TEE_InvokeTACommand failed\n");
+		EMSG("TEE_InvokeTACommand failed");
 
 	TEE_CloseTASession(sess);
 	return res;
@@ -577,14 +577,14 @@ static TEE_Result test_time(void)
 		       (unsigned int)t.millis);
 		break;
 	case TEE_ERROR_OVERFLOW:
-		EMSG("Stored TA time overflowed %u.%03u\n",
+		EMSG("Stored TA time overflowed %u.%03u",
 		     (unsigned int)t.seconds, (unsigned int)t.millis);
 		break;
 	case TEE_ERROR_TIME_NOT_SET:
-		EMSG("TA time not stored\n");
+		EMSG("TA time not stored");
 		break;
 	case TEE_ERROR_TIME_NEEDS_RESET:
-		EMSG("TA time needs reset\n");
+		EMSG("TA time needs reset");
 		break;
 	default:
 		return res;
@@ -592,13 +592,13 @@ static TEE_Result test_time(void)
 
 	res = TEE_SetTAPersistentTime(&null_time);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_SetTAPersistentTime: failed\n");
+		EMSG("TEE_SetTAPersistentTime: failed");
 		return res;
 	}
 
 	res = TEE_GetTAPersistentTime(&t);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_GetTAPersistentTime null: failed\n");
+		EMSG("TEE_GetTAPersistentTime null: failed");
 		return res;
 	}
 	printf("TA time %u.%03u\n", (unsigned int)t.seconds,
@@ -609,31 +609,31 @@ static TEE_Result test_time(void)
 	 * it's not even a millisecond.
 	 */
 	if (t.seconds > 1 || t.millis >= 1000) {
-		EMSG("Unexpected stored TA time %u.%03u\n",
+		EMSG("Unexpected stored TA time %u.%03u",
 		     (unsigned int)t.seconds, (unsigned int)t.millis);
 		return TEE_ERROR_BAD_STATE;
 	}
 
 	res = TEE_SetTAPersistentTime(&wrap_time);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_SetTAPersistentTime wrap: failed\n");
+		EMSG("TEE_SetTAPersistentTime wrap: failed");
 		return res;
 	}
 
 	res = TEE_Wait(1000);
 	if (res != TEE_SUCCESS)
-		EMSG("TEE_Wait wrap: failed\n");
+		EMSG("TEE_Wait wrap: failed");
 
 	res = TEE_GetTAPersistentTime(&t);
 	if (res != TEE_ERROR_OVERFLOW) {
-		EMSG("TEE_GetTAPersistentTime: failed\n");
+		EMSG("TEE_GetTAPersistentTime: failed");
 		return TEE_ERROR_BAD_STATE;
 	}
 	printf("TA time %u.%03u\n", (unsigned int)t.seconds,
 	       (unsigned int)t.millis);
 
 	if (t.seconds > 1) {
-		EMSG("Unexpected wrapped time %u.%03u\n",
+		EMSG("Unexpected wrapped time %u.%03u",
 		     (unsigned int)t.seconds, (unsigned int)t.millis);
 		return TEE_ERROR_BAD_STATE;
 	}
@@ -881,14 +881,14 @@ TEE_Result ta_entry_client_with_timeout(uint32_t param_types,
 					   TEE_PARAM_TYPE_NONE,
 					   TEE_PARAM_TYPE_NONE,
 					   TEE_PARAM_TYPE_NONE)) {
-		EMSG("bad parameters\n");
+		EMSG("bad parameters");
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
 	res = TEE_OpenTASession(&os_test_uuid, TEE_TIMEOUT_INFINITE, 0, NULL,
 				&sess, &ret_orig);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_OpenTASession failed\n");
+		EMSG("TEE_OpenTASession failed");
 		return res;
 	}
 
@@ -898,7 +898,7 @@ TEE_Result ta_entry_client_with_timeout(uint32_t param_types,
 				&ret_orig);
 
 	if (ret_orig != TEE_ORIGIN_TRUSTED_APP || res != TEE_ERROR_CANCEL) {
-		EMSG("TEE_InvokeTACommand: res 0x%x ret_orig 0x%x\n",
+		EMSG("TEE_InvokeTACommand: res 0x%x ret_orig 0x%x",
 		     (unsigned int)res, (unsigned int)ret_orig);
 		res = TEE_ERROR_GENERIC;
 	} else
@@ -940,7 +940,7 @@ TEE_Result ta_entry_client(uint32_t param_types, TEE_Param params[4])
 	res = TEE_OpenTASession(&crypt_uuid, TEE_TIMEOUT_INFINITE, 0, NULL,
 				&sess, &ret_orig);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_OpenTASession failed\n");
+		EMSG("TEE_OpenTASession failed");
 		goto cleanup_free;
 	}
 
@@ -955,12 +955,12 @@ TEE_Result ta_entry_client(uint32_t param_types, TEE_Param params[4])
 				  TA_CRYPT_CMD_SHA256, l_pts, l_params,
 				  &ret_orig);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_InvokeTACommand failed\n");
+		EMSG("TEE_InvokeTACommand failed");
 		goto cleanup_close_session;
 	}
 
 	if (TEE_MemCompare(sha256_out, out, sizeof(sha256_out)) != 0) {
-		EMSG("out parameter failed\n");
+		EMSG("out parameter failed");
 		res = TEE_ERROR_GENERIC;
 		goto cleanup_close_session;
 	}

--- a/ta/rpc_test/ta_rpc.c
+++ b/ta/rpc_test/ta_rpc.c
@@ -29,7 +29,7 @@ static TEE_Result rpc_call_cryp(bool sec_mem, uint32_t nParamTypes,
 				params, &cryp_session, &origin);
 
 	if (res != TEE_SUCCESS) {
-		EMSG("rpc_sha256 - TEE_OpenTASession returned 0x%x\n",
+		EMSG("rpc_sha256 - TEE_OpenTASession returned 0x%x",
 		     (unsigned int)res);
 		return res;
 	}
@@ -69,7 +69,7 @@ static TEE_Result rpc_call_cryp(bool sec_mem, uint32_t nParamTypes,
 	res = TEE_InvokeTACommand(cryp_session, TEE_TIMEOUT_INFINITE, cmd,
 				types, params, &origin);
 	if (res != TEE_SUCCESS) {
-		EMSG("rpc_call_cryp - TEE_InvokeTACommand returned 0x%x\n",
+		EMSG("rpc_call_cryp - TEE_InvokeTACommand returned 0x%x",
 		     (unsigned int)res);
 	}
 

--- a/ta/sdp_basic/ta_sdp_basic.c
+++ b/ta/sdp_basic/ta_sdp_basic.c
@@ -256,7 +256,7 @@ static TEE_Result cmd_invoke(uint32_t nParamTypes,
 	        res = TEE_OpenTASession(&uuid, TEE_TIMEOUT_INFINITE, 0, NULL,
 					&sess, &ret_orig);
 		if (res != TEE_SUCCESS) {
-	                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED \n");
+	                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED");
 	                goto cleanup_return;
 		}
 
@@ -265,7 +265,7 @@ static TEE_Result cmd_invoke(uint32_t nParamTypes,
         res = TEE_InvokeTACommand(sess, TEE_TIMEOUT_INFINITE,
 				  nCommandID, nParamTypes, pParams, &ret_orig);
         if (res != TEE_SUCCESS) {
-                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED %x/%d\n",
+                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED %x/%d",
 								res, ret_orig);
         }
 
@@ -290,7 +290,7 @@ static TEE_Result cmd_invoke_pta(uint32_t nParamTypes,
 	        res = TEE_OpenTASession(&uuid, TEE_TIMEOUT_INFINITE, 0, NULL,
 					&sess, &ret_orig);
 		if (res != TEE_SUCCESS) {
-	                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED \n");
+	                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED");
 	                goto cleanup_return;
 		}
 
@@ -299,7 +299,7 @@ static TEE_Result cmd_invoke_pta(uint32_t nParamTypes,
         res = TEE_InvokeTACommand(sess, TEE_TIMEOUT_INFINITE,
 				  nCommandID, nParamTypes, pParams, &ret_orig);
         if (res != TEE_SUCCESS) {
-                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED %x/%d\n",
+                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED %x/%d",
 								res, ret_orig);
         }
 

--- a/ta/storage_benchmark/benchmark.c
+++ b/ta/storage_benchmark/benchmark.c
@@ -322,7 +322,7 @@ static TEE_Result ta_stroage_benchmark_chunk_access_test(uint32_t nCommandID,
 	if (chunk_size == 0)
 		chunk_size = DEFAULT_CHUNK_SIZE;
 
-	IMSG("command id: %u, test data size: %zd, chunk size: %zd\n",
+	IMSG("command id: %u, test data size: %zd, chunk size: %zd",
 			nCommandID, data_size, chunk_size);
 
 	chunk_buf = TEE_Malloc(chunk_size, TEE_MALLOC_FILL_ZERO);


### PR DESCRIPTION
This is a tree wide fix to remove all the trailing newlines in the `*MSG()` macros.