### PR TITLE
ta: cleanup trace messages in test TAs

### DIFF
--- a/ta/os_test/include/tb_macros.h
+++ b/ta/os_test/include/tb_macros.h
@@ -8,36 +8,35 @@
 
 #include <tee_internal_api_extensions.h>
 
-#define TB_HEADER(str)                               \
-	printf("\n*********** TESTBENCH ***********" \
-	       "\n***         RUNNING: <<< %s >>>"   \
-	       "\n*********************************\n\n", str)
+#define TB_HEADER(str)                            \
+	MSG("\n*********** TESTBENCH ***********" \
+	    "\n***         RUNNING: <<< %s >>>"   \
+	    "\n*********************************", str)
 
-#define TB_FOOTER(str)                               \
-	printf("\n*********** TESTBENCH ***********" \
-	       "\n***         PASSED:  <<< %s >>>"   \
-	       "\n*********************************\n\n", str)
+#define TB_FOOTER(str)                            \
+	MSG("\n*********** TESTBENCH ***********" \
+	    "\n***         PASSED:  <<< %s >>>"   \
+	    "\n*********************************", str)
 
-#define TB_INFO(str) printf("*** INFO : %s \n", (str))
+#define TB_INFO(str) MSG("*** INFO : %s \n", (str))
 
-#define HALT                                                             \
-	{                                                                \
-		printf("\n*** FAILED ***"                                \
-		       "\nTestbench halted at line %d in function %s\n", \
-			 __LINE__, __func__);                            \
-		printf("\nWaiting for keypress to enable debugging.\n"); \
-		TEE_Panic(0);                                            \
+#define HALT                                                           \
+	{                                                              \
+		EMSG("\n*** FAILED ***"                                \
+		     "\nTestbench halted at line %d in function %s";   \
+		MSG("\nWaiting for keypress to enable debugging.");    \
+		TEE_Panic(0);                                          \
 	}
 
-#define STARTING                                       \
-	printf("\n*********** TESTBENCH ***********"   \
-	       "\n*** For the GlobalPlatform Math API" \
-	       "\n*********************************\n\n")
+#define STARTING                                    \
+	MSG("\n*********** TESTBENCH ***********"   \
+	    "\n*** For the GlobalPlatform Math API" \
+	    "\n*********************************")
 
 #define ALL_PASSED \
-	printf("\n*********** TESTBENCH ***********" \
-	       "\n***     ALL TESTS PASSED      ***" \
-	       "\n*********************************\n\n")
+	MSG("\n*********** TESTBENCH ***********" \
+	    "\n***     ALL TESTS PASSED      ***" \
+	    "\n*********************************")
 
 /*
  * DEF_BIGINT defines and initialize a BigInt with name and size.
@@ -45,6 +44,7 @@
 #define DEF_BIGINT(name, size)                                                \
 	TEE_BigInt *name;                                                     \
 	size_t name##_size;                                                   \
+									      \
 	name##_size = TEE_BigIntSizeInU32(size);                              \
 	name = (TEE_BigInt *)TEE_Malloc(name##_size * sizeof(TEE_BigInt), 0); \
 	TEE_BigIntInit(name, name##_size)

--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -134,8 +134,7 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 
 		res = TEE_GetPropertyName(h, nbuf, &nblen);
 		if (res != TEE_SUCCESS) {
-			EMSG("TEE_GetPropertyName returned 0x%x",
-			     (unsigned int)res);
+			EMSG("TEE_GetPropertyName() returned %#"PRIx32, res);
 			return res;
 		}
 		if (nblen != strlen(nbuf) + 1) {
@@ -241,9 +240,8 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 					res =
 					    TEE_GetPropertyAsBool(h, NULL, &v);
 					if (res != TEE_SUCCESS) {
-						EMSG(
-						"TEE_GetPropertyAsBool(\"%s\") returned 0x%x",
-						nbuf, (unsigned int)res);
+						EMSG("TEE_GetPropertyAsBool(\"%s\") returned %#"PRIx32,
+						     nbuf, res);
 						return res;
 					}
 				}
@@ -255,9 +253,8 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 
 					res = TEE_GetPropertyAsU32(h, NULL, &v);
 					if (res != TEE_SUCCESS) {
-						EMSG(
-						"TEE_GetPropertyAsU32(\"%s\") returned 0x%x",
-						nbuf, (unsigned int)res);
+						EMSG("TEE_GetPropertyAsU32(\"%s\") returned %#"PRIx32,
+						     nbuf, res);
 						return res;
 					}
 				}
@@ -270,9 +267,8 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 					res =
 					    TEE_GetPropertyAsUUID(h, NULL, &v);
 					if (res != TEE_SUCCESS) {
-						EMSG(
-						"TEE_GetPropertyAsUUID(\"%s\") returned 0x%x",
-						nbuf, (unsigned int)res);
+						EMSG("TEE_GetPropertyAsUUID(\"%s\") returned %#"PRIx32,
+						     nbuf, res);
 						return res;
 					}
 				}
@@ -286,9 +282,8 @@ static TEE_Result print_properties(TEE_PropSetHandle h,
 					    TEE_GetPropertyAsIdentity(h, NULL,
 								      &v);
 					if (res != TEE_SUCCESS) {
-						EMSG(
-						"TEE_GetPropertyAsIdentity(\"%s\") returned 0x%x",
-						nbuf, (unsigned int)res);
+						EMSG("TEE_GetPropertyAsIdentity(\"%s\") returned %#"PRIx32,
+						     nbuf, res);
 						return res;
 					}
 				}
@@ -371,7 +366,7 @@ static TEE_Result test_malloc(void)
 	void *p = TEE_Malloc(4, 0);
 
 	if (p == NULL) {
-		EMSG("TEE_Malloc failed");
+		EMSG("TEE_Malloc() failed");
 		return TEE_ERROR_OUT_OF_MEMORY;
 	}
 	TEE_Free(p);
@@ -427,23 +422,22 @@ static TEE_Result test_properties(void)
 
 	res = TEE_AllocatePropertyEnumerator(&h);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_AllocatePropertyEnumerator: returned 0x%x",
-		     (unsigned int)res);
+		EMSG("TEE_AllocatePropertyEnumerator: returned %#"PRIx32, res);
 		return TEE_ERROR_GENERIC;
 	}
 
-	printf("Getting properties for current TA\n");
+	MSG("Getting properties for current TA");
 	res = print_properties(h, TEE_PROPSET_CURRENT_TA, p_attrs, num_p_attrs);
 	if (res != TEE_SUCCESS)
 		goto cleanup_return;
 
-	printf("Getting properties for current client\n");
+	MSG("Getting properties for current client");
 	res = print_properties(h, TEE_PROPSET_CURRENT_CLIENT, p_attrs,
 			       num_p_attrs);
 	if (res != TEE_SUCCESS)
 		goto cleanup_return;
 
-	printf("Getting properties for implementation\n");
+	MSG("Getting properties for implementation");
 	res = print_properties(h, TEE_PROPSET_TEE_IMPLEMENTATION, p_attrs,
 			       num_p_attrs);
 	if (res != TEE_SUCCESS)
@@ -534,7 +528,7 @@ static TEE_Result test_mem_access_right(uint32_t param_types,
 	res = TEE_OpenTASession(&test_uuid, TEE_TIMEOUT_INFINITE, 0, NULL,
 				&sess, &ret_orig);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_OpenTASession failed");
+		EMSG("TEE_OpenTASession() failed: %#"PRIx32, res);
 		return res;
 	}
 
@@ -548,7 +542,7 @@ static TEE_Result test_mem_access_right(uint32_t param_types,
 				  TA_OS_TEST_CMD_PARAMS_ACCESS,
 				  l_pts, l_params, &ret_orig);
 	if (res != TEE_SUCCESS)
-		EMSG("TEE_InvokeTACommand failed");
+		EMSG("TEE_InvokeTACommand() failed: %#"PRIx32, res);
 
 	TEE_CloseTASession(sess);
 	return res;
@@ -563,22 +557,19 @@ static TEE_Result test_time(void)
 	static const TEE_Time wrap_time = { UINT32_MAX, 999 };
 
 	TEE_GetSystemTime(&sys_t);
-	printf("system time %u.%03u\n", (unsigned int)sys_t.seconds,
-	       (unsigned int)sys_t.millis);
+	MSG("system time %"PRIu32".%03"PRIx32, sys_t.seconds, sys_t.millis);
 
 	TEE_GetREETime(&t);
-	printf("REE time %u.%03u\n", (unsigned int)t.seconds,
-	       (unsigned int)t.millis);
+	MSG("REE time %"PRIu32".%03"PRIu32, t.seconds, t.millis);
 
 	res = TEE_GetTAPersistentTime(&t);
 	switch (res) {
 	case TEE_SUCCESS:
-		printf("Stored TA time %u.%03u\n", (unsigned int)t.seconds,
-		       (unsigned int)t.millis);
+		MSG("Stored TA time %"PRIu32".%03"PRIu32, t.seconds, t.millis);
 		break;
 	case TEE_ERROR_OVERFLOW:
-		EMSG("Stored TA time overflowed %u.%03u",
-		     (unsigned int)t.seconds, (unsigned int)t.millis);
+		EMSG("Stored TA time overflowed %"PRIu32".%03"PRIu32,
+		     t.seconds, t.millis);
 		break;
 	case TEE_ERROR_TIME_NOT_SET:
 		EMSG("TA time not stored");
@@ -592,49 +583,49 @@ static TEE_Result test_time(void)
 
 	res = TEE_SetTAPersistentTime(&null_time);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_SetTAPersistentTime: failed");
+		EMSG("TEE_SetTAPersistentTime() failed%#"PRIx32, res);
 		return res;
 	}
 
 	res = TEE_GetTAPersistentTime(&t);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_GetTAPersistentTime null: failed");
+		EMSG("TEE_GetTAPersistentTime() for null time: failed %#"PRIx32,
+		     res);
 		return res;
 	}
-	printf("TA time %u.%03u\n", (unsigned int)t.seconds,
-	       (unsigned int)t.millis);
+	MSG("TA time %"PRIu32".%03"PRIu32, t.seconds, t.millis);
+
 	/*
 	 * The time between TEE_SetTAPersistentTime() and
 	 * TEE_GetTAPersistentTime() should be much less than 1 second, in fact
 	 * it's not even a millisecond.
 	 */
 	if (t.seconds > 1 || t.millis >= 1000) {
-		EMSG("Unexpected stored TA time %u.%03u",
-		     (unsigned int)t.seconds, (unsigned int)t.millis);
+		EMSG("Unexpected stored TA time %"PRIu32".%03"PRIu32, t.seconds,
+		     t.millis);
 		return TEE_ERROR_BAD_STATE;
 	}
 
 	res = TEE_SetTAPersistentTime(&wrap_time);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_SetTAPersistentTime wrap: failed");
+		EMSG("TEE_SetTAPersistentTime() wrap: failed %#"PRIx32, res);
 		return res;
 	}
 
 	res = TEE_Wait(1000);
 	if (res != TEE_SUCCESS)
-		EMSG("TEE_Wait wrap: failed");
+		EMSG("TEE_Wait() wrap: failed %#"PRIx32, res);
 
 	res = TEE_GetTAPersistentTime(&t);
 	if (res != TEE_ERROR_OVERFLOW) {
-		EMSG("TEE_GetTAPersistentTime: failed");
+		EMSG("TEE_GetTAPersistentTime(): failed %#"PRIx32, res);
 		return TEE_ERROR_BAD_STATE;
 	}
-	printf("TA time %u.%03u\n", (unsigned int)t.seconds,
-	       (unsigned int)t.millis);
+	MSG("TA time %"PRIu32".%03"PRIu32, t.seconds, t.millis);
 
 	if (t.seconds > 1) {
-		EMSG("Unexpected wrapped time %u.%03u",
-		     (unsigned int)t.seconds, (unsigned int)t.millis);
+		EMSG("Unexpected wrapped time %"PRIu32".%03"PRIu32, t.seconds,
+		     t.millis);
 		return TEE_ERROR_BAD_STATE;
 	}
 
@@ -815,7 +806,7 @@ TEE_Result ta_entry_basic(uint32_t param_types, TEE_Param params[4])
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 
-	printf("ta_entry_basic: enter\n");
+	MSG("enter");
 
 	res = test_malloc();
 	if (res != TEE_SUCCESS)
@@ -854,7 +845,7 @@ TEE_Result ta_entry_panic(uint32_t param_types, TEE_Param params[4])
 	(void)param_types;
 	(void)params;
 
-	printf("ta_entry_panic: enter\n");
+	MSG("enter");
 	/*
 	 * Somewhat clumsy way of avoiding compile errors if TEE_Panic() has
 	 * the __noreturn attribute.
@@ -888,7 +879,7 @@ TEE_Result ta_entry_client_with_timeout(uint32_t param_types,
 	res = TEE_OpenTASession(&os_test_uuid, TEE_TIMEOUT_INFINITE, 0, NULL,
 				&sess, &ret_orig);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_OpenTASession failed");
+		EMSG("TEE_OpenTASession() failed %#"PRIx32, res);
 		return res;
 	}
 
@@ -898,8 +889,8 @@ TEE_Result ta_entry_client_with_timeout(uint32_t param_types,
 				&ret_orig);
 
 	if (ret_orig != TEE_ORIGIN_TRUSTED_APP || res != TEE_ERROR_CANCEL) {
-		EMSG("TEE_InvokeTACommand: res 0x%x ret_orig 0x%x",
-		     (unsigned int)res, (unsigned int)ret_orig);
+		EMSG("TEE_InvokeTACommand(): res %#"PRIx32" ret_orig %#"PRIx32,
+		     res, ret_orig);
 		res = TEE_ERROR_GENERIC;
 	} else
 		res = TEE_SUCCESS;
@@ -930,7 +921,7 @@ TEE_Result ta_entry_client(uint32_t param_types, TEE_Param params[4])
 	(void)param_types;
 	(void)params;
 
-	printf("ta_entry_client: enter\n");
+	DMSG("ta_entry_client: enter");
 
 	in = TEE_Malloc(sizeof(sha256_in), 0);
 	if (in == NULL)
@@ -940,7 +931,7 @@ TEE_Result ta_entry_client(uint32_t param_types, TEE_Param params[4])
 	res = TEE_OpenTASession(&crypt_uuid, TEE_TIMEOUT_INFINITE, 0, NULL,
 				&sess, &ret_orig);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_OpenTASession failed");
+		EMSG("TEE_OpenTASession() failed %#"PRIx32, res);
 		goto cleanup_free;
 	}
 
@@ -955,7 +946,7 @@ TEE_Result ta_entry_client(uint32_t param_types, TEE_Param params[4])
 				  TA_CRYPT_CMD_SHA256, l_pts, l_params,
 				  &ret_orig);
 	if (res != TEE_SUCCESS) {
-		EMSG("TEE_InvokeTACommand failed");
+		EMSG("TEE_InvokeTACommand() failed %#"PRIx32, res);
 		goto cleanup_close_session;
 	}
 
@@ -1004,7 +995,7 @@ TEE_Result ta_entry_wait(uint32_t param_types, TEE_Param params[4])
 	TEE_Result res = TEE_SUCCESS;
 	(void)param_types;
 
-	printf("ta_entry_wait: waiting %d\n", (unsigned int)params[0].value.a);
+	MSG("waiting %"PRId32, params[0].value.a);
 	/* Wait */
 	res = TEE_Wait(params[0].value.a);
 

--- a/ta/rpc_test/ta_rpc.c
+++ b/ta/rpc_test/ta_rpc.c
@@ -29,8 +29,7 @@ static TEE_Result rpc_call_cryp(bool sec_mem, uint32_t nParamTypes,
 				params, &cryp_session, &origin);
 
 	if (res != TEE_SUCCESS) {
-		EMSG("rpc_sha256 - TEE_OpenTASession returned 0x%x",
-		     (unsigned int)res);
+		EMSG("TEE_OpenTASession() returned %#"PRIx32, res);
 		return res;
 	}
 
@@ -69,8 +68,7 @@ static TEE_Result rpc_call_cryp(bool sec_mem, uint32_t nParamTypes,
 	res = TEE_InvokeTACommand(cryp_session, TEE_TIMEOUT_INFINITE, cmd,
 				types, params, &origin);
 	if (res != TEE_SUCCESS) {
-		EMSG("rpc_call_cryp - TEE_InvokeTACommand returned 0x%x",
-		     (unsigned int)res);
+		EMSG("TEE_InvokeTACommand() returned %#"PRIx32, res);
 	}
 
 	TEE_CloseTASession(cryp_session);

--- a/ta/sdp_basic/ta_sdp_basic.c
+++ b/ta/sdp_basic/ta_sdp_basic.c
@@ -32,7 +32,7 @@ static TEE_Result cmd_inject(uint32_t types,
 				     TEE_PARAM_TYPE_MEMREF_OUTPUT,
 				     TEE_PARAM_TYPE_NONE,
 				     TEE_PARAM_TYPE_NONE)) {
-		EMSG("bad parameters %x", (unsigned)types);
+		EMSG("bad parameters %#"PRIx32, types);
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
@@ -53,7 +53,7 @@ static TEE_Result cmd_inject(uint32_t types,
 					 params[ns_idx].memref.buffer,
 					 params[ns_idx].memref.size);
 	if (rc != TEE_SUCCESS) {
-		EMSG("TEE_CheckMemoryAccessRights(nsec) failed %x", rc);
+		EMSG("TEE_CheckMemoryAccessRights(nsec) failed %#"PRIx32, rc);
 		return rc;
 	}
 
@@ -63,7 +63,7 @@ static TEE_Result cmd_inject(uint32_t types,
 					 params[sec_idx].memref.buffer,
 					 params[sec_idx].memref.size);
 	if (rc != TEE_SUCCESS) {
-		EMSG("TEE_CheckMemoryAccessRights(secure) failed %x", rc);
+		EMSG("TEE_CheckMemoryAccessRights(secure) failed %#"PRIx32, rc);
 		return rc;
 	}
 
@@ -78,9 +78,9 @@ static TEE_Result cmd_inject(uint32_t types,
 	rc = TEE_CacheFlush(params[sec_idx].memref.buffer,
 			    params[sec_idx].memref.size);
 	if (rc != TEE_SUCCESS) {
-		EMSG("TEE_CacheFlush(%p, %x) failed: 0x%x",
-					params[sec_idx].memref.buffer,
-					params[sec_idx].memref.size, rc);
+		EMSG("TEE_CacheFlush(%p, %zu) failed: %#"PRIx32,
+		     params[sec_idx].memref.buffer,
+		     params[sec_idx].memref.size, rc);
 		return rc;
 	}
 #endif /* CFG_CACHE_API */
@@ -94,9 +94,9 @@ static TEE_Result cmd_inject(uint32_t types,
 	rc = TEE_CacheFlush(params[sec_idx].memref.buffer,
 			    params[sec_idx].memref.size);
 	if (rc != TEE_SUCCESS) {
-		EMSG("TEE_CacheFlush(%p, %x) failed: 0x%x",
-					params[sec_idx].memref.buffer,
-					params[sec_idx].memref.size, rc);
+		EMSG("TEE_CacheFlush(%p, %zu) failed: %#"PRIx32,
+		     params[sec_idx].memref.buffer,
+		     params[sec_idx].memref.size, rc);
 		return rc;
 	}
 #endif /* CFG_CACHE_API */
@@ -132,7 +132,7 @@ static TEE_Result cmd_transform(uint32_t types,
 					 params[0].memref.buffer,
 					 params[0].memref.size);
 	if (rc != TEE_SUCCESS) {
-		EMSG("TEE_CheckMemoryAccessRights(secure) failed %x", rc);
+		EMSG("TEE_CheckMemoryAccessRights(secure) failed %#"PRIx32, rc);
 		return rc;
 	}
 
@@ -147,9 +147,8 @@ static TEE_Result cmd_transform(uint32_t types,
 	rc = TEE_CacheFlush(params[0].memref.buffer,
 			    params[0].memref.size);
 	if (rc != TEE_SUCCESS) {
-		EMSG("TEE_CacheFlush(%p, %x) failed: 0x%x",
-					params[0].memref.buffer,
-					params[0].memref.size, rc);
+		EMSG("TEE_CacheFlush(%p, %zu) failed: %#"PRIx32,
+		     params[0].memref.buffer, params[0].memref.size, rc);
 		return rc;
 	}
 #endif /* CFG_CACHE_API */
@@ -164,9 +163,8 @@ static TEE_Result cmd_transform(uint32_t types,
 	rc = TEE_CacheFlush(params[0].memref.buffer,
 			    params[0].memref.size);
 	if (rc != TEE_SUCCESS) {
-		EMSG("TEE_CacheFlush(%p, %x) failed: 0x%x",
-					params[0].memref.buffer,
-					params[0].memref.size, rc);
+		EMSG("TEE_CacheFlush(%p, %zu) failed: %#"PRIx32,
+		     params[0].memref.buffer, params[0].memref.size, rc);
 		return rc;
 	}
 #endif /* CFG_CACHE_API */
@@ -204,7 +202,7 @@ static TEE_Result cmd_dump(uint32_t types,
 					 params[ns_idx].memref.buffer,
 					 params[ns_idx].memref.size);
 	if (rc != TEE_SUCCESS) {
-		EMSG("TEE_CheckMemoryAccessRights(nsec) failed %x", rc);
+		EMSG("TEE_CheckMemoryAccessRights(nsec) failed %#"PRIx32, rc);
 		return rc;
 	}
 
@@ -214,7 +212,7 @@ static TEE_Result cmd_dump(uint32_t types,
 					 params[sec_idx].memref.buffer,
 					 params[sec_idx].memref.size);
 	if (rc != TEE_SUCCESS) {
-		EMSG("TEE_CheckMemoryAccessRights(secure) failed %x", rc);
+		EMSG("TEE_CheckMemoryAccessRights(secure) failed %#"PRIx32, rc);
 		return rc;
 	}
 
@@ -228,9 +226,9 @@ static TEE_Result cmd_dump(uint32_t types,
 	rc = TEE_CacheFlush(params[sec_idx].memref.buffer,
 			    params[sec_idx].memref.size);
 	if (rc != TEE_SUCCESS) {
-		EMSG("TEE_CacheFlush(%p, %x) failed: 0x%x",
-					params[sec_idx].memref.buffer,
-					params[sec_idx].memref.size, rc);
+		EMSG("TEE_CacheFlush(%p, %zu) failed: %#"PRIx32,
+		     params[sec_idx].memref.buffer,
+		     params[sec_idx].memref.size, rc);
 		return rc;
 	}
 #endif /* CFG_CACHE_API */
@@ -265,8 +263,8 @@ static TEE_Result cmd_invoke(uint32_t nParamTypes,
         res = TEE_InvokeTACommand(sess, TEE_TIMEOUT_INFINITE,
 				  nCommandID, nParamTypes, pParams, &ret_orig);
         if (res != TEE_SUCCESS) {
-                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED %x/%d",
-								res, ret_orig);
+                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED %#"PRIx32"/%"PRIu32,
+		     res, ret_orig);
         }
 
 cleanup_return:
@@ -299,8 +297,8 @@ static TEE_Result cmd_invoke_pta(uint32_t nParamTypes,
         res = TEE_InvokeTACommand(sess, TEE_TIMEOUT_INFINITE,
 				  nCommandID, nParamTypes, pParams, &ret_orig);
         if (res != TEE_SUCCESS) {
-                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED %x/%d",
-								res, ret_orig);
+                EMSG("SDP basic test TA: TEE_OpenTASession() FAILED %#"PRIx32"/%"PRIu32,
+		     res, ret_orig);
         }
 
 cleanup_return:

--- a/ta/storage_benchmark/benchmark.c
+++ b/ta/storage_benchmark/benchmark.c
@@ -76,8 +76,7 @@ static TEE_Result prepare_test_file(size_t data_size, uint8_t *chunk_buf,
 			TEE_DATA_FLAG_OVERWRITE,
 			NULL, NULL, 0, &object);
 	if (res != TEE_SUCCESS) {
-		EMSG("Failed to create persistent object, res=0x%08x",
-				res);
+		EMSG("Failed to create persistent object, res=%#"PRIx32, res);
 		goto exit;
 	}
 
@@ -90,7 +89,7 @@ static TEE_Result prepare_test_file(size_t data_size, uint8_t *chunk_buf,
 			write_size = chunk_size;
 		res = TEE_WriteObjectData(object, chunk_buf, write_size);
 		if (res != TEE_SUCCESS) {
-			EMSG("Failed to write data, res=0x%08x", res);
+			EMSG("Failed to write data, res=%#"PRIx32, res);
 			goto exit_close_object;
 		}
 		remain_bytes -= write_size;
@@ -122,7 +121,7 @@ static TEE_Result test_write(TEE_ObjectHandle object, size_t data_size,
 			write_size = chunk_size;
 		res = TEE_WriteObjectData(object, chunk_buf, write_size);
 		if (res != TEE_SUCCESS) {
-			EMSG("Failed to write data, res=0x%08x", res);
+			EMSG("Failed to write data, res=%#"PRIx32, res);
 			goto exit;
 		}
 		remain_bytes -= write_size;
@@ -132,10 +131,9 @@ static TEE_Result test_write(TEE_ObjectHandle object, size_t data_size,
 
 	*spent_time_in_ms = get_delta_time_in_ms(start_time, stop_time);
 
-	IMSG("start: %u.%u(s), stop: %u.%u(s), delta: %u(ms)",
-			start_time.seconds, start_time.millis,
-			stop_time.seconds, stop_time.millis,
-			*spent_time_in_ms);
+	IMSG("start: %"PRIu32".%"PRIu32"(s), stop: %"PRIu32".%"PRIu32"(s), delta: %"PRIu32"(ms)",
+	     start_time.seconds, start_time.millis,
+	     stop_time.seconds, stop_time.millis, *spent_time_in_ms);
 
 exit:
 	return res;
@@ -164,7 +162,7 @@ static TEE_Result test_read(TEE_ObjectHandle object, size_t data_size,
 		res = TEE_ReadObjectData(object, chunk_buf, read_size,
 				&read_bytes);
 		if (res != TEE_SUCCESS) {
-			EMSG("Failed to read data, res=0x%08x", res);
+			EMSG("Failed to read data, res=%#"PRIx32, res);
 			goto exit;
 		}
 
@@ -175,10 +173,9 @@ static TEE_Result test_read(TEE_ObjectHandle object, size_t data_size,
 
 	*spent_time_in_ms = get_delta_time_in_ms(start_time, stop_time);
 
-	IMSG("start: %u.%u(s), stop: %u.%u(s), delta: %u(ms)",
-			start_time.seconds, start_time.millis,
-			stop_time.seconds, stop_time.millis,
-			*spent_time_in_ms);
+	IMSG("start: %"PRIu32".%"PRIu32"(s), stop: %"PRIu32".%"PRIu32"(s), delta: %"PRIu32"(ms)",
+	     start_time.seconds, start_time.millis,
+	     stop_time.seconds, stop_time.millis, *spent_time_in_ms);
 
 exit:
 	return res;
@@ -210,7 +207,7 @@ static TEE_Result test_rewrite(TEE_ObjectHandle object, size_t data_size,
 		res = TEE_ReadObjectData(object, chunk_buf, write_size,
 				&read_bytes);
 		if (res != TEE_SUCCESS) {
-			EMSG("Failed to read data, res=0x%08x", res);
+			EMSG("Failed to read data, res=%#"PRIx32, res);
 			goto exit;
 		}
 
@@ -231,7 +228,7 @@ static TEE_Result test_rewrite(TEE_ObjectHandle object, size_t data_size,
 		/* Write a chunk*/
 		res = TEE_WriteObjectData(object, chunk_buf, write_size);
 		if (res != TEE_SUCCESS) {
-			EMSG("Failed to write data, res=0x%08x", res);
+			EMSG("Failed to write data, res=%#"PRIx32, res);
 			goto exit;
 		}
 
@@ -242,10 +239,9 @@ static TEE_Result test_rewrite(TEE_ObjectHandle object, size_t data_size,
 
 	*spent_time_in_ms = get_delta_time_in_ms(start_time, stop_time);
 
-	IMSG("start: %u.%u(s), stop: %u.%u(s), delta: %u(ms)",
-			start_time.seconds, start_time.millis,
-			stop_time.seconds, stop_time.millis,
-			*spent_time_in_ms);
+	IMSG("start: %"PRIu32".%"PRIu32"(s), stop: %"PRIu32".%"PRIu32"(s), delta: %"PRIu32"(ms)",
+	     start_time.seconds, start_time.millis,
+	     stop_time.seconds, stop_time.millis, *spent_time_in_ms);
 
 exit:
 	return res;
@@ -272,7 +268,7 @@ static TEE_Result verify_file_data(TEE_ObjectHandle object, size_t data_size,
 		res = TEE_ReadObjectData(object, chunk_buf, chunk_size,
 				&read_bytes);
 		if (res != TEE_SUCCESS) {
-			EMSG("Failed to read data, res=0x%08x", res);
+			EMSG("Failed to read data, res=%#"PRIx32, res);
 			goto exit;
 		}
 
@@ -284,7 +280,7 @@ static TEE_Result verify_file_data(TEE_ObjectHandle object, size_t data_size,
 
 		res = verify_buffer(chunk_buf, chunk_size);
 		if (res != TEE_SUCCESS) {
-			EMSG("Verify data failed, res=0x%08x", res);
+			EMSG("Verify data failed, res=%#"PRIx32, res);
 			goto exit;
 		}
 
@@ -323,7 +319,7 @@ static TEE_Result ta_stroage_benchmark_chunk_access_test(uint32_t nCommandID,
 		chunk_size = DEFAULT_CHUNK_SIZE;
 
 	IMSG("command id: %u, test data size: %zd, chunk size: %zd",
-			nCommandID, data_size, chunk_size);
+	     nCommandID, data_size, chunk_size);
 
 	chunk_buf = TEE_Malloc(chunk_size, TEE_MALLOC_FILL_ZERO);
 	if (!chunk_buf) {
@@ -335,8 +331,7 @@ static TEE_Result ta_stroage_benchmark_chunk_access_test(uint32_t nCommandID,
 	fill_buffer(chunk_buf, chunk_size);
 	res = prepare_test_file(data_size, chunk_buf, chunk_size);
 	if (res != TEE_SUCCESS) {
-		EMSG("Failed to create test file, res=0x%08x",
-				res);
+		EMSG("Failed to create test file, res=%#"PRIx32, res);
 		goto exit_free_chunk_buf;
 	}
 
@@ -347,8 +342,7 @@ static TEE_Result ta_stroage_benchmark_chunk_access_test(uint32_t nCommandID,
 			TEE_DATA_FLAG_ACCESS_WRITE_META,
 			&object);
 	if (res != TEE_SUCCESS) {
-		EMSG("Failed to open persistent object, res=0x%08x",
-				res);
+		EMSG("Failed to open persistent object, res=%#"PRIx32, res);
 		goto exit_remove_object;
 	}
 


### PR DESCRIPTION
This is a follow up of cleanup changes initiated in https://github.com/OP-TEE/optee_test/pull/708 and https://github.com/OP-TEE/optee_test/pull/709 to have TA trace messages implementation more consistent with OP-TEE coding style and trace resources.