### PR TITLE
xtest: pkcs11: fix false positive error report on CKR_HOST_MEMORY

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -1235,7 +1235,8 @@ static void test_create_destroy_session_objects(ADBG_Case_t *c)
 				    ARRAY_SIZE(cktest_session_object),
 				    obj_hdl + n);
 
-		if (rv == CKR_DEVICE_MEMORY || !ADBG_EXPECT_CK_OK(c, rv))
+		if (rv == CKR_DEVICE_MEMORY || rv == CKR_HOST_MEMORY ||
+		    !ADBG_EXPECT_CK_OK(c, rv))
 			break;
 	}
 
@@ -1654,13 +1655,13 @@ static CK_RV open_cipher_session(ADBG_Case_t *c,
 	}
 
 	rv = C_OpenSession(slot, session_flags, NULL, 0, session);
-	if (rv == CKR_DEVICE_MEMORY)
+	if (rv == CKR_DEVICE_MEMORY || rv == CKR_HOST_MEMORY)
 		return rv;
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		return rv;
 
 	rv = C_CreateObject(*session, attr_key, attr_count, &object);
-	if (rv == CKR_DEVICE_MEMORY)
+	if (rv == CKR_DEVICE_MEMORY || rv == CKR_HOST_MEMORY)
 		return rv;
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		return rv;
@@ -1670,7 +1671,7 @@ static CK_RV open_cipher_session(ADBG_Case_t *c,
 	if (mode == TEE_MODE_DECRYPT)
 		rv = C_DecryptInit(*session, mechanism, object);
 
-	if (rv == CKR_DEVICE_MEMORY)
+	if (rv == CKR_DEVICE_MEMORY || rv == CKR_HOST_MEMORY)
 		return rv;
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		return CKR_GENERAL_ERROR;
@@ -1701,7 +1702,7 @@ static void xtest_pkcs11_test_1007(ADBG_Case_t *c)
 					 TEE_MODE_ENCRYPT);
 
 		/* Failure due to memory allocation is not a error case */
-		if (rv == CKR_DEVICE_MEMORY)
+		if (rv == CKR_DEVICE_MEMORY || rv == CKR_HOST_MEMORY)
 			break;
 
 		if (!ADBG_EXPECT_CK_OK(c, rv))


### PR DESCRIPTION
Fix false positive error case in test pkcs11_1004 and pkcs11_1007.

In the pkcs11_1004 test, the client creates as many PKCS#11 objects as possible until the system fails on memory allocation error. In the pkcs11_1007 test, the client prepares as many cipher sessions as possible until the system fails on memory allocation error. Both test implementations consider only CKR_DEVICE_MEMORY return code as the condition for expected resource exhaustion while they should also consider the host resource exhaustion return code CKR_HOST_MEMORY.

Fixes: 2d6dc9312935 ("xtest: pkcs11: add symmetric cipher tests")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
