### PR TITLE
xtest: pkcs11: Add check that CK_TOKEN_INFO outputs correct CK_ULONG's

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -309,6 +309,36 @@ static void xtest_pkcs11_test_1001(ADBG_Case_t *c)
 		if (!ADBG_EXPECT_CK_OK(c, rv))
 			goto out;
 
+		/**
+		 * OP-TEE's PKCS#11 implementaion always responds with
+		 * CK_UNAVAILABLE_INFORMATION for fields:
+		 *
+		 * - ulMaxSessionCount
+		 * - ulMaxRwSessionCount
+		 * - ulTotalPublicMemory
+		 * - ulFreePublicMemory
+		 *
+		 * Verify that CK_UNAVAILABLE_INFORMATION is correctly
+		 * translated (32 bit vs 64 bit difference).
+		 */
+
+		if (!ADBG_EXPECT_COMPARE_UNSIGNED(c,
+				token_info.ulMaxSessionCount, ==,
+				CK_UNAVAILABLE_INFORMATION))
+			goto out;
+		if (!ADBG_EXPECT_COMPARE_UNSIGNED(c,
+				token_info.ulMaxRwSessionCount, ==,
+				CK_UNAVAILABLE_INFORMATION))
+			goto out;
+		if (!ADBG_EXPECT_COMPARE_UNSIGNED(c,
+				token_info.ulTotalPublicMemory, ==,
+				CK_UNAVAILABLE_INFORMATION))
+			goto out;
+		if (!ADBG_EXPECT_COMPARE_UNSIGNED(c,
+				token_info.ulFreePublicMemory, ==,
+				CK_UNAVAILABLE_INFORMATION))
+			goto out;
+
 		if (max_slot_id < slot)
 			max_slot_id = slot;
 	}


### PR DESCRIPTION
OP-TEE's PKCS#11 TA TEE<->REE interface treats `CK_ULONG`'s as 32 bit.

In 64 bit machines this creates a problem for `CK_ULONG` values that are architecture dependent.

One of those defines is `CK_UNAVAILABLE_INFORMATION`.

This adds test case to make sure that when OP-TEE's PKCS#11 TA should give `CK_UNAVAILABLE_INFORMATION` it actually does that.

Depends on:
- https://github.com/OP-TEE/optee_client/pull/367
<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
