### PR TITLE
xtest: pkcs11_1000.c: Add tests for AES-GCM Encryption/Decryption

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -27,6 +27,9 @@
 
 #include <regression_4000_data.h>
 
+/* AES GCM tag size in bytes */
+#define AES_GCM_TAG_SIZE 16
+
 /*
  * auth_type enumerates the types of user authentication
  *
@@ -45,7 +48,11 @@ static const CK_BYTE cktest_aes128_iv[16];
 static const CK_AES_CTR_PARAMS cktest_aes_ctr_params = {
 	.ulCounterBits = 1,
 };
-
+static const CK_GCM_PARAMS cktest_aes_gcm_params = {
+	.pIv = (CK_BYTE_PTR)cktest_aes128_iv,
+	.ulIvLen = sizeof(cktest_aes128_iv),
+	.ulTagBits = AES_GCM_TAG_SIZE * 8,
+};
 static CK_MECHANISM cktest_aes_ecb_mechanism = {
 	CKM_AES_ECB,
 	NULL, 0,
@@ -61,6 +68,10 @@ static CK_MECHANISM cktest_aes_ctr_mechanism = {
 static CK_MECHANISM cktest_aes_cts_mechanism = {
 	CKM_AES_CTS,
 	(CK_BYTE_PTR)cktest_aes128_iv, sizeof(cktest_aes128_iv),
+};
+static CK_MECHANISM cktest_aes_gcm_mechanism = {
+	CKM_AES_GCM,
+	(CK_BYTE_PTR)&cktest_aes_gcm_params, sizeof(cktest_aes_gcm_params),
 };
 static CK_MECHANISM cktest_aes_cmac_mechanism = {
 	CKM_AES_CMAC, NULL, 0,
@@ -1372,6 +1383,13 @@ static const CK_MECHANISM_TYPE allowed_not_aes_cts[] = {
 	CKM_AES_ECB, CKM_AES_CBC, CKM_AES_CBC_PAD, CKM_AES_CTR,
 	CKM_AES_GCM, CKM_AES_CCM,
 };
+static const CK_MECHANISM_TYPE allowed_only_aes_gcm[] = {
+	CKM_AES_GCM,
+};
+static const CK_MECHANISM_TYPE allowed_not_aes_gcm[] = {
+	CKM_AES_ECB, CKM_AES_CBC, CKM_AES_CBC_PAD, CKM_AES_CTS,
+	CKM_AES_CTR, CKM_AES_CCM,
+};
 
 #define CKTEST_AES_KEY \
 	{ CKA_CLASS,	&(CK_OBJECT_CLASS){CKO_SECRET_KEY},	\
@@ -1413,6 +1431,8 @@ CK_KEY_ALLOWED_AES_TEST(cktest_aes_only_cts, allowed_only_aes_cts);
 CK_KEY_ALLOWED_AES_TEST(cktest_aes_not_cts, allowed_not_aes_cts);
 CK_KEY_ALLOWED_AES_TEST(cktest_aes_only_ctr, allowed_only_aes_ctr);
 CK_KEY_ALLOWED_AES_TEST(cktest_aes_not_ctr, allowed_not_aes_ctr);
+CK_KEY_ALLOWED_AES_TEST(cktest_aes_only_gcm, allowed_only_aes_gcm);
+CK_KEY_ALLOWED_AES_TEST(cktest_aes_not_gcm, allowed_not_aes_gcm);
 
 struct cktest_allowed_test {
 	CK_ATTRIBUTE_PTR attr_key;
@@ -1431,6 +1451,7 @@ static const struct cktest_allowed_test cktest_allowed_valid[] = {
 	CKTEST_KEY_MECHA(cktest_aes_only_cbcnopad, &cktest_aes_cbc_mechanism),
 	CKTEST_KEY_MECHA(cktest_aes_only_cts, &cktest_aes_cts_mechanism),
 	CKTEST_KEY_MECHA(cktest_aes_only_ctr, &cktest_aes_ctr_mechanism),
+	CKTEST_KEY_MECHA(cktest_aes_only_gcm, &cktest_aes_gcm_mechanism),
 };
 
 static const struct cktest_allowed_test cktest_allowed_invalid[] = {
@@ -1438,6 +1459,7 @@ static const struct cktest_allowed_test cktest_allowed_invalid[] = {
 	CKTEST_KEY_MECHA(cktest_aes_not_cbcnopad, &cktest_aes_cbc_mechanism),
 	CKTEST_KEY_MECHA(cktest_aes_not_cts, &cktest_aes_cts_mechanism),
 	CKTEST_KEY_MECHA(cktest_aes_not_ctr, &cktest_aes_ctr_mechanism),
+	CKTEST_KEY_MECHA(cktest_aes_not_gcm, &cktest_aes_gcm_mechanism),
 };
 
 /* Create session object and token object from a session */

--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -8931,3 +8931,507 @@ out_lib:
 }
 ADBG_CASE_DEFINE(pkcs11, 1028, xtest_pkcs11_test_1028,
 		 "PKCS11: destroy PKCS#11 objects handled by another session");
+
+struct aes_gcm_test {
+	CK_ATTRIBUTE_PTR attr_key;
+	CK_ULONG attr_count;
+	CK_MECHANISM_PTR mechanism;
+	const uint8_t *ctx;
+	size_t ctx_len;
+	const uint8_t *ptx;
+	size_t ptx_len;
+	const uint8_t *tag;
+	size_t tag_len;
+};
+
+#define MAKE_AES_GCM_TEST_CASE(vect)                                    \
+	CK_GCM_PARAMS cktest_aes_gcm_params##vect = {                   \
+		.pIv = (CK_BYTE_PTR)ae_data_aes_gcm_vect##vect##_nonce, \
+		.ulIvLen = sizeof(ae_data_aes_gcm_vect##vect##_nonce),  \
+		.ulIvBits = 0,                                          \
+		.pAAD = (CK_BYTE_PTR)ae_data_aes_gcm_vect##vect##_aad,  \
+		.ulAADLen = sizeof(ae_data_aes_gcm_vect##vect##_aad),   \
+		.ulTagBits = AES_GCM_TAG_SIZE * 8                       \
+		};                                                      \
+static CK_MECHANISM cktest_aes_gcm_mechanism##vect = { \
+	CKM_AES_GCM,                                   \
+	(CK_BYTE_PTR)&cktest_aes_gcm_params##vect,     \
+	sizeof(cktest_aes_gcm_params##vect),           \
+}; \
+\
+static CK_ATTRIBUTE cktest_aes_gcm_key##vect[] =                            \
+	{								    \
+		{ CKA_ENCRYPT,	&(CK_BBOOL) {CK_TRUE},			    \
+				sizeof(CK_BBOOL) },			    \
+		{ CKA_DECRYPT,	&(CK_BBOOL) {CK_TRUE},			    \
+				sizeof(CK_BBOOL) },			    \
+		{ CKA_CLASS,	&(CK_OBJECT_CLASS) {CKO_SECRET_KEY},	    \
+				sizeof(CK_OBJECT_CLASS) },		    \
+		{ CKA_KEY_TYPE,	&(CK_KEY_TYPE) {CKK_AES},		    \
+				sizeof(CK_KEY_TYPE) },			    \
+		{ CKA_VALUE,	(void *)(ae_data_aes_gcm_vect##vect##_key), \
+				sizeof(ae_data_aes_gcm_vect##vect##_key) }, \
+	}; \
+\
+static const struct aes_gcm_test AES_GCM_TEST_CASE##vect = {         \
+		.attr_key = cktest_aes_gcm_key##vect,		     \
+		.attr_count = ARRAY_SIZE(cktest_aes_gcm_key##vect),  \
+		.mechanism = &cktest_aes_gcm_mechanism##vect,	     \
+		.ctx = ae_data_aes_gcm_vect##vect##_ctx,             \
+		.ctx_len = sizeof(ae_data_aes_gcm_vect##vect##_ctx), \
+		.ptx = ae_data_aes_gcm_vect##vect##_ptx,             \
+		.ptx_len = sizeof(ae_data_aes_gcm_vect##vect##_ptx), \
+		.tag = ae_data_aes_gcm_vect##vect##_tag,             \
+		.tag_len = sizeof(ae_data_aes_gcm_vect##vect##_tag)  \
+}
+
+MAKE_AES_GCM_TEST_CASE(1);
+MAKE_AES_GCM_TEST_CASE(2);
+MAKE_AES_GCM_TEST_CASE(3);
+MAKE_AES_GCM_TEST_CASE(4);
+MAKE_AES_GCM_TEST_CASE(5);
+MAKE_AES_GCM_TEST_CASE(6);
+MAKE_AES_GCM_TEST_CASE(7);
+MAKE_AES_GCM_TEST_CASE(8);
+MAKE_AES_GCM_TEST_CASE(9);
+MAKE_AES_GCM_TEST_CASE(10);
+MAKE_AES_GCM_TEST_CASE(11);
+MAKE_AES_GCM_TEST_CASE(12);
+MAKE_AES_GCM_TEST_CASE(13);
+MAKE_AES_GCM_TEST_CASE(14);
+MAKE_AES_GCM_TEST_CASE(15);
+MAKE_AES_GCM_TEST_CASE(16);
+MAKE_AES_GCM_TEST_CASE(17);
+MAKE_AES_GCM_TEST_CASE(18);
+
+
+static const struct aes_gcm_test cktest_aes_gcm_cases[] = {
+	AES_GCM_TEST_CASE1, AES_GCM_TEST_CASE2,  AES_GCM_TEST_CASE3,
+	AES_GCM_TEST_CASE4, AES_GCM_TEST_CASE5, AES_GCM_TEST_CASE6,
+	AES_GCM_TEST_CASE7, AES_GCM_TEST_CASE8, AES_GCM_TEST_CASE9,
+	AES_GCM_TEST_CASE10, AES_GCM_TEST_CASE11, AES_GCM_TEST_CASE12,
+	AES_GCM_TEST_CASE13, AES_GCM_TEST_CASE14, AES_GCM_TEST_CASE15,
+	AES_GCM_TEST_CASE16, AES_GCM_TEST_CASE17, AES_GCM_TEST_CASE18,
+};
+
+#define CHUNK_SIZE 8
+
+static void xtest_pkcs11_test_1030(ADBG_Case_t *c)
+{
+	CK_RV rv = CKR_GENERAL_ERROR;
+	CK_SLOT_ID slot = 0;
+	CK_SESSION_HANDLE session = CK_INVALID_HANDLE;
+	CK_FLAGS session_flags = CKF_SERIAL_SESSION;
+	CK_OBJECT_HANDLE key_handle = CK_INVALID_HANDLE;
+	uint8_t in[512] = { 0 };
+	CK_ULONG in_size = 0;
+	uint8_t out[512] = { 0 };
+	CK_ULONG out_size = 0;
+	const struct aes_gcm_test *test = NULL;
+	size_t n = 0;
+	size_t proc_len = 0;
+	size_t total_len = 0;
+	uint8_t chunk[CHUNK_SIZE] = { 0 };
+	size_t chunk_len = 0;
+
+	rv = init_lib_and_find_token_slot(&slot, PIN_AUTH);
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		return;
+
+	rv = C_OpenSession(slot, session_flags, NULL, 0, &session);
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto err_close_lib;
+
+	for (n = 0; n < ARRAY_SIZE(cktest_aes_gcm_cases); n++) {
+		test = cktest_aes_gcm_cases + n;
+		Do_ADBG_BeginSubCase(c, "AES-GCM case %zu)", n);
+
+		rv = C_CreateObject(session, test->attr_key, test->attr_count,
+				    &key_handle);
+		if (!ADBG_EXPECT_CK_OK(c, rv))
+			goto err_subcase;
+
+		/* Test 1 encrypt in 1 step */
+		if (test->ptx != NULL) {
+			rv = C_EncryptInit(session, test->mechanism,
+					   key_handle);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/* Get output buffer length for update */
+			out_size = 0;
+			rv = C_EncryptUpdate(session, (void *)test->ptx,
+					     test->ptx_len, NULL, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/* Encrypt chunk */
+			total_len = 0;
+			memset(out, 0, out_size);
+			rv = C_EncryptUpdate(session, (void *)test->ptx,
+					     test->ptx_len, out, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			total_len += out_size;
+
+			/* Finalize to get MAC */
+			rv = C_EncryptFinal(session, out + out_size, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			total_len += out_size;
+
+			/* Check ciphertext and tag */
+			if (!ADBG_EXPECT_COMPARE_UNSIGNED(c,
+				test->ctx_len + test->tag_len, ==, total_len))
+				goto err_destr_obj;
+
+			if (!ADBG_EXPECT_BUFFER(c, test->tag,
+						 test->tag_len,
+						 out + test->ctx_len,
+						 test->tag_len))
+				goto err_destr_obj;
+
+			if (!ADBG_EXPECT_BUFFER(c, test->ctx,
+						test->ctx_len,
+						out, test->ctx_len))
+				goto err_destr_obj;
+		}
+
+		/* Test 2 decrypt in 1 step */
+		if (test->ptx != NULL) {
+			rv = C_DecryptInit(session, test->mechanism,
+					   key_handle);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/* Concat ciphertext and tag */
+			memcpy(in, test->ctx, test->ctx_len);
+			memcpy(in + test->ctx_len, test->tag, test->tag_len);
+			in_size = test->ctx_len + test->tag_len;
+			total_len = 0;
+
+			/* Get output buffer length for update */
+			out_size = 0;
+			rv = C_DecryptUpdate(session, (void *)in, in_size,
+					     NULL, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv) ||
+			    !ADBG_EXPECT_COMPARE_UNSIGNED(c, out_size, ==, 0))
+				goto err_destr_obj;
+
+			/* Decrypt chunk */
+			total_len = 0;
+			memset(out, 0, out_size);
+			rv = C_DecryptUpdate(session, (void *)in, in_size,
+					     out, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			total_len += out_size;
+
+			/* Finalize and check MAC (get size then get data) */
+			out_size = 0;
+			rv = C_DecryptFinal(session, NULL, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv) ||
+			    !ADBG_EXPECT_COMPARE_UNSIGNED(c, out_size, ==,
+							  test->ptx_len))
+				goto err_destr_obj;
+
+			rv = C_DecryptFinal(session, out, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			if (!ADBG_EXPECT_BUFFER(c, test->ptx, test->ptx_len,
+						out, out_size))
+				goto err_destr_obj;
+		}
+
+		/* Test 3 encrypt in chunks of 8 bytes */
+		if (test->ptx != NULL) {
+			rv = C_EncryptInit(session, test->mechanism,
+					   key_handle);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+			proc_len = 0;
+			total_len = 0;
+			chunk_len = 0;
+			memset(chunk, 0, CHUNK_SIZE);
+			/* Process ptx in 8-byte chunks */
+			while (proc_len < test->ptx_len) {
+				if (test->ptx_len - proc_len > CHUNK_SIZE)
+					chunk_len = CHUNK_SIZE;
+				else
+					chunk_len = test->ptx_len - proc_len;
+				memcpy(chunk, test->ptx + proc_len,
+				       chunk_len);
+
+				/* Encrypt the chunk */
+				rv = C_EncryptUpdate(session, chunk, chunk_len,
+						     out + total_len,
+						     &out_size);
+				if (!ADBG_EXPECT_CK_OK(c, rv))
+					goto err_destr_obj;
+
+				proc_len += chunk_len;
+				total_len += out_size;
+			}
+
+			/* Check Ciphertext and Tag */
+			out_size = 0;
+			rv = C_EncryptFinal(session, out + total_len,
+					    &out_size);
+			if (!ADBG_EXPECT_CK_RESULT(c, CKR_BUFFER_TOO_SMALL, rv))
+				goto err_destr_obj;
+
+			rv = C_EncryptFinal(session, out + total_len,
+					    &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			total_len += out_size;
+
+			/* Check ciphertext and tag */
+			if (!ADBG_EXPECT_COMPARE_UNSIGNED(c,
+				test->ctx_len + test->tag_len, ==, total_len))
+				goto err_destr_obj;
+
+			if (!ADBG_EXPECT_BUFFER(c, test->tag,
+						 test->tag_len,
+						 out + test->ctx_len,
+						 test->tag_len))
+				goto err_destr_obj;
+
+			if (!ADBG_EXPECT_BUFFER(c, test->ctx,
+						test->ctx_len,
+						out, test->ctx_len))
+				goto err_destr_obj;
+		}
+
+		/* Test 4 decrypt in chunks of 8 bytes */
+		if (test->ctx != NULL) {
+			rv = C_DecryptInit(session, test->mechanism,
+					   key_handle);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+			proc_len = 0;
+			total_len = 0;
+			chunk_len = 0;
+			memset(chunk, 0, CHUNK_SIZE);
+			/* Process ptx in 8-byte chunks */
+			while (proc_len < test->ctx_len) {
+				if (test->ctx_len - proc_len > CHUNK_SIZE)
+					chunk_len = CHUNK_SIZE;
+				else
+					chunk_len = test->ctx_len - proc_len;
+				memcpy(chunk, test->ptx + proc_len,
+				       chunk_len);
+
+				/* Decrypt the chunk */
+				rv = C_DecryptUpdate(session, chunk, chunk_len,
+						     out + total_len,
+						     &out_size);
+				if (!ADBG_EXPECT_CK_OK(c, rv))
+					goto err_destr_obj;
+
+				proc_len += chunk_len;
+				total_len += out_size;
+			}
+
+			/* Decrypt the tag */
+			rv = C_DecryptUpdate(session, (void *)test->tag,
+					     test->tag_len, out + total_len,
+					     &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+					goto err_destr_obj;
+			total_len += out_size;
+
+			/* Check Plaintext (get size then data) */
+			out_size = 0;
+			rv = C_DecryptFinal(session, out + total_len,
+					    &out_size);
+			if (!ADBG_EXPECT_CK_RESULT(c, CKR_BUFFER_TOO_SMALL, rv))
+				goto err_destr_obj;
+
+			rv = C_DecryptFinal(session, out + total_len,
+					    &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			total_len += out_size;
+
+			/* Check output is expected plaintext */
+			if (!ADBG_EXPECT_BUFFER(c, test->ptx, test->ptx_len,
+						out, total_len))
+				goto err_destr_obj;
+		}
+
+		/* Test 5 encrypt in one shot */
+		if (test->ptx != NULL) {
+			rv = C_EncryptInit(session, test->mechanism,
+					   key_handle);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/* Test too short buffer case */
+			out_size = 1;
+			rv = C_Encrypt(session, (void *)test->ptx,
+				       test->ptx_len, out, &out_size);
+			if (!ADBG_EXPECT_CK_RESULT(c, CKR_BUFFER_TOO_SMALL, rv))
+				goto err_destr_obj;
+
+			/*
+			 * Test NULL buffer case with size as 0
+			 * to get the out_size
+			 */
+			out_size = 0;
+			rv = C_Encrypt(session, (void *)test->ptx,
+				       test->ptx_len, NULL, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/*
+			 * Test NULL buffer case with size as non-zero
+			 * to get the out_size
+			 */
+			out_size = 42;
+			rv = C_Encrypt(session, (void *)test->ptx,
+				       test->ptx_len, NULL, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/* Get to full output */
+			memset(out, 0, out_size);
+			rv = C_Encrypt(session, (void *)test->ptx,
+				       test->ptx_len, out, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/* Check Ciphertext + tag */
+			if (!ADBG_EXPECT_COMPARE_UNSIGNED(c,
+				test->ctx_len + test->tag_len, ==, out_size))
+				goto err_destr_obj;
+
+			if (!ADBG_EXPECT_BUFFER(c, test->ctx,
+						test->ctx_len,
+						out, test->ctx_len))
+				goto err_destr_obj;
+
+			if (!ADBG_EXPECT_BUFFER(c, test->tag,
+						test->tag_len,
+						out + test->ctx_len,
+						test->tag_len))
+				goto err_destr_obj;
+		}
+
+		/* Test 6 decrypt in one shot */
+		if (test->ctx != NULL) {
+			rv = C_DecryptInit(session, test->mechanism,
+					   key_handle);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/* Concat ciphertext and tag */
+			memcpy(in, test->ctx, test->ctx_len);
+			memcpy(in + test->ctx_len, test->tag, test->tag_len);
+			in_size = test->ctx_len + test->tag_len;
+			total_len = 0;
+
+			/* Test too short buffer case */
+			out_size = 1;
+			rv = C_Decrypt(session, (void *)in, in_size,
+				       out, &out_size);
+			if (!ADBG_EXPECT_CK_RESULT(c, CKR_BUFFER_TOO_SMALL, rv))
+				goto err_destr_obj;
+
+			/*
+			 * Test NULL buffer case with size as 0
+			 * to get the out_size
+			 */
+			out_size = 0;
+			rv = C_Decrypt(session, (void *)in, in_size,
+				       NULL, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/*
+			 * Test NULL buffer case with size as non-zero
+			 * to get the out_size
+			 */
+			out_size = 42;
+			rv = C_Decrypt(session, (void *)in, in_size,
+				       NULL, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/* Get to full output */
+			memset(out, 0, out_size);
+			rv = C_Decrypt(session, (void *)in, in_size,
+				       out, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/* Check Plaintext */
+			if (!ADBG_EXPECT_BUFFER(c, test->ptx,
+						test->ptx_len, out, out_size))
+				goto err_destr_obj;
+		}
+
+		/* Test 7 decrypt altered data  */
+		if (test->ctx != NULL) {
+			rv = C_DecryptInit(session, test->mechanism,
+					   key_handle);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+			/* Concat ciphertext and tag */
+			memcpy(in, test->ctx, test->ctx_len);
+			memcpy(in + test->ctx_len, test->tag, test->tag_len);
+			in_size = test->ctx_len + test->tag_len;
+			/* Determine output buffer length */
+			out_size = 0;
+			rv = C_Decrypt(session, (void *)in, in_size,
+				       NULL, &out_size);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+
+			/* Alter ciphertext */
+			in[0] ^= 1;
+			rv = C_Decrypt(session, (void *)in, in_size,
+				       out, &out_size);
+			if (!ADBG_EXPECT_CK_RESULT(c,
+						   CKR_SIGNATURE_INVALID, rv))
+				goto err_destr_obj;
+
+			/* Alter tag */
+			rv = C_DecryptInit(session, test->mechanism,
+					   key_handle);
+			if (!ADBG_EXPECT_CK_OK(c, rv))
+				goto err_destr_obj;
+			in[0] ^= 1;
+			in[test->ctx_len] ^= 1;
+			rv = C_Decrypt(session, (void *)in, in_size,
+				       out, &out_size);
+			if (!ADBG_EXPECT_CK_RESULT(c,
+						   CKR_SIGNATURE_INVALID, rv))
+				goto err_destr_obj;
+		}
+
+		rv = C_DestroyObject(session, key_handle);
+		if (!ADBG_EXPECT_CK_OK(c, rv))
+			goto err_subcase;
+
+		Do_ADBG_EndSubCase(c, NULL);
+	}
+	goto out;
+
+err_destr_obj:
+	ADBG_EXPECT_CK_OK(c, C_DestroyObject(session, key_handle));
+err_subcase:
+	Do_ADBG_EndSubCase(c, NULL);
+out:
+	ADBG_EXPECT_CK_OK(c, C_CloseSession(session));
+err_close_lib:
+	ADBG_EXPECT_CK_OK(c, close_lib());
+}
+ADBG_CASE_DEFINE(pkcs11, 1030, xtest_pkcs11_test_1030,
+		 "PKCS11: Test AES-GCM Encryption/Decryption");

--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -1532,6 +1532,8 @@ CK_KEY_ALLOWED_AES_ENC_TEST(cktest_aes_enc_only_cts, allowed_only_aes_cts);
 
 CK_KEY_ALLOWED_AES_DEC_TEST(cktest_aes_dec_only_ctr, allowed_only_aes_ctr);
 
+CK_KEY_ALLOWED_AES_ENC_TEST(cktest_aes_enc_only_gcm, allowed_only_aes_gcm);
+
 static void xtest_pkcs11_test_1005(ADBG_Case_t *c)
 {
 	CK_RV rv = CKR_GENERAL_ERROR;
@@ -1644,6 +1646,25 @@ static void xtest_pkcs11_test_1006(ADBG_Case_t *c)
 				ARRAY_SIZE(cktest_aes_dec_only_ctr),
 				&cktest_aes_ctr_mechanism,
 				TEE_MODE_ENCRYPT,
+				CKR_KEY_FUNCTION_NOT_PERMITTED);
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto out;
+
+	/* Encrypt only AES GCM key */
+	rv = cipher_init_final(c, session,
+				cktest_aes_enc_only_gcm,
+				ARRAY_SIZE(cktest_aes_enc_only_gcm),
+				&cktest_aes_gcm_mechanism,
+				TEE_MODE_ENCRYPT,
+				CKR_OK);
+	if (!ADBG_EXPECT_CK_OK(c, rv))
+		goto out;
+
+	rv = cipher_init_final(c, session,
+				cktest_aes_enc_only_gcm,
+				ARRAY_SIZE(cktest_aes_enc_only_gcm),
+				&cktest_aes_gcm_mechanism,
+				TEE_MODE_DECRYPT,
 				CKR_KEY_FUNCTION_NOT_PERMITTED);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto out;


### PR DESCRIPTION
This commit:
- Adds Test ID 1030 for CKM_AES_GCM encryption/decryption.
- Utilizes test vectors from regression_4000_data.h.
- Implements encryption and decryption tests in two formats:
  - Incremental methods using C_EncryptUpdate(), C_DecryptUpdate(), C_EncryptFinal(), and C_DecryptFinal().
  - One-shot methods using C_Encrypt() and C_Decrypt().
- Extends Test 1006 to include checks for AES-GCM ciphering with both valid and invalid keys.
- Includes additional testing against altered data:
   - Tests cases where the cipher text is modified.
   - Tests cases where the authentication tag is modified.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
