### PR TITLE
ci: avoid "No space left on device" error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     container: jforissier/optee_os_ci:qemuv8_check2
     steps:
+      - name: Remove /__t/*
+        run: rm -rf /__t/*
       - name: Restore build cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Remove unneeded files from the root filesystem to avoid a "No space left on device" error. A similar trick was committed to optee_os for the same reason [1].

Link: https://github.com/OP-TEE/optee_os/commit/fa1950059f4128a9b58558d4970c153595463ff3 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
