### PR TITLE
cancellation: Unmask inside of invoke command

### DIFF
--- a/ta/os_test/ta_entry.c
+++ b/ta/os_test/ta_entry.c
@@ -36,7 +36,6 @@ TEE_Result TA_OpenSessionEntryPoint(uint32_t nParamTypes,
 	(void)pParams;
 	(void)ppSessionContext;
 	DMSG("TA_OpenSessionEntryPoint");
-	TEE_UnmaskCancellation();
 	return TEE_SUCCESS;
 }
 
@@ -63,6 +62,7 @@ TEE_Result TA_InvokeCommandEntryPoint(void *pSessionContext,
 				      TEE_Param pParams[4])
 {
 	(void)pSessionContext;
+	TEE_UnmaskCancellation();
 
 	switch (nCommandID) {
 	case TA_OS_TEST_CMD_INIT:


### PR DESCRIPTION
The specification seems to indicate (see https://github.com/OP-TEE/optee_test/issues/731)
that the cancellation mask is reset at the start of every entry point.
As a result, the TEE_UnmakCancellation() should not be called at the end of
TA_OpenSessionEntryPoint(), but at the start of TA_InvokeCommandEntryPoint().


Also, note that this patch should not break the current test.
Still, there is a test which could be written to test that unmasking cancellations
really does not affect subsequent entry points. There is no such test for now,
and if one were designed, then the current implementation would report a failure to this test,
until the implementation is fixed with respect to the Global Platform specification.
If you need such a test, I could consider writing one.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
