### PR TITLE
[BugFix]: Add ruturn value check for fs_unlink and ta_storage_cmd_unlink

### DIFF
--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -466,7 +466,9 @@ static TEEC_Result check_storage_available(uint32_t id, bool *avail)
 	switch (res) {
 	case TEEC_SUCCESS:
 		*avail = true;
-		fs_unlink(&sess, obj);
+		res = fs_unlink(&sess, obj);
+		if (res != TEEC_SUCCESS)
+			Do_ADBG_Log("fs_unlink() failed");
 		break;
 	case TEE_ERROR_ITEM_NOT_FOUND:
 	case TEE_ERROR_STORAGE_NOT_AVAILABLE:

--- a/ta/storage/storage.c
+++ b/ta/storage/storage.c
@@ -243,9 +243,7 @@ TEE_Result ta_storage_cmd_unlink(uint32_t param_types, TEE_Param params[4])
 			  (TEE_PARAM_TYPE_VALUE_INPUT, TEE_PARAM_TYPE_NONE,
 			   TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE));
 
-	TEE_CloseAndDeletePersistentObject1(o);
-
-	return TEE_SUCCESS;
+	return TEE_CloseAndDeletePersistentObject1(o);
 }
 
 TEE_Result ta_storage_cmd_rename(uint32_t command, uint32_t param_types,


### PR DESCRIPTION
[Desc]:
1. check_storage_available should check fs_unlink's return value.
2. ta_storage_cmd_unlink should't always return TEE_SUCCESS.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
