### PR TITLE
Android.mk: add -Wno-unused-parameter CFLAGS for xtest

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -124,6 +124,7 @@ LOCAL_CFLAGS += -I $(TA_DEV_KIT_DIR)/host_include -include conf.h
 LOCAL_CFLAGS += -pthread
 LOCAL_CFLAGS += -g3
 LOCAL_CFLAGS += -Wno-missing-field-initializers -Wno-format-zero-length
+LOCAL_CFLAGS += -Wno-unused-parameter
 
 ifneq ($(TA_DIR),)
 LOCAL_CFLAGS += -DTA_DIR=\"$(TA_DIR)\"


### PR DESCRIPTION
Commit bcd55831e1f7 ("xtest: add asymmetric cipher perf test") introduces a build error for xtest on AOSP 14:

```
external/optee_test/host/xtest/asym_perf.c:125:71: error: unused parameter 'main_algo' [-Werror,-Wunused-parameter] static void usage(const char *progname, uint32_t width_bits, uint32_t main_algo,
                                                                      ^
external/optee_test/host/xtest/asym_perf.c:126:14: error: unused parameter 'mode' [-Werror,-Wunused-parameter]
                  uint32_t mode, uint32_t salt_len, uint32_t size,
                           ^
external/optee_test/host/xtest/asym_perf.c:127:14: error: unused parameter 'crypto_algo' [-Werror,-Wunused-parameter]
                  uint32_t crypto_algo, int warmup, uint32_t l, uint32_t n)
                           ^
external/optee_test/host/xtest/asym_perf.c:668:76: error: unused parameter 'size' [-Werror,-Wunused-parameter] static int check_rsa_hash_params(uint32_t crypto_algo, int width_bits, int size,
                                                                           ^
4 errors generated.
13:15:41 ninja failed with: exit status 1
```

Adding -Wno-unused-parameter to the build flags seems a reasonable fix since this is a test executable.

Add it to fix the build error.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
