### PR TITLE
license: Add copyright notice line to BSD license text

### DIFF
--- a/LICENSE-BSD
+++ b/LICENSE-BSD
@@ -1,3 +1,5 @@
+Copyright (c) 2015, Linaro Limited
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
The copyright notice is part of the license text (see https://opensource.org/license/bsd-2-clause). I mistakenly removed this when applying review feedback for #749 - sorry about that. This adds the line back.