### PR TITLE
xtest: pkcs11: fix test_find_objects() when wrong count

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -2622,23 +2622,25 @@ static CK_RV test_find_objects(ADBG_Case_t *c, CK_SESSION_HANDLE session,
 			       CK_ULONG expected_cnt)
 {
 	CK_RV rv = CKR_GENERAL_ERROR;
+	CK_RV rv2 = CKR_GENERAL_ERROR;
 	CK_ULONG hdl_count = 0;
 
 	rv = C_FindObjectsInit(session, find_template, attr_count);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		return rv;
 
-	rv = C_FindObjects(session, obj_found, obj_count, &hdl_count);
-	if (!ADBG_EXPECT_CK_OK(c, rv))
-		return rv;
-	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, hdl_count, ==, expected_cnt))
-		return CKR_GENERAL_ERROR;
+	rv2 = C_FindObjects(session, obj_found, obj_count, &hdl_count);
+	if (ADBG_EXPECT_CK_OK(c, rv2)) {
+		if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, hdl_count, ==,
+						  expected_cnt))
+			rv2 = CKR_GENERAL_ERROR;
+	}
 
 	rv = C_FindObjectsFinal(session);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		return rv;
 
-	return rv;
+	return rv2;
 }
 
 static void destroy_persistent_objects(ADBG_Case_t *c, CK_SLOT_ID slot)


### PR DESCRIPTION
Fix test_find_objects() so that C_FindObjectsFinal() is properly called even if we don't find the expected number of objects.

Fixes: afe2b54fb68b ("xtest: pkcs11: add find object tests")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
