### PR TITLE
pkcs11_1007: close session before trying new ones

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -1757,6 +1757,7 @@ static void xtest_pkcs11_test_1007(ADBG_Case_t *c)
 	CK_RV rv = CKR_GENERAL_ERROR;
 	CK_SLOT_ID slot = 0;
 	CK_SESSION_HANDLE sessions[128];
+	CK_SESSION_HANDLE session_saved = 0;
 	size_t n = 0;
 
 	for (n = 0; n < ARRAY_SIZE(sessions); n++)
@@ -1787,15 +1788,8 @@ static void xtest_pkcs11_test_1007(ADBG_Case_t *c)
 
 	Do_ADBG_Log("    created sessions count: %zu", n);
 
-	/* Closing session with out bound and invalid IDs (or negative ID) */
-	rv = C_CloseSession(sessions[n - 1] + 1024);
-	ADBG_EXPECT_CK_RESULT(c, CKR_SESSION_HANDLE_INVALID, rv);
-	rv = C_CloseSession(CK_INVALID_HANDLE);
-	ADBG_EXPECT_CK_RESULT(c, CKR_SESSION_HANDLE_INVALID, rv);
-	rv = C_CloseSession(~0);
-	ADBG_EXPECT_CK_RESULT(c, CKR_SESSION_HANDLE_INVALID, rv);
-
 	/* Closing each session: all related resources shall be free */
+	session_saved = sessions[n - 1];
 	for (n = 0; n < ARRAY_SIZE(sessions); n++) {
 		if (sessions[n] == CK_INVALID_HANDLE)
 			continue;
@@ -1804,6 +1798,14 @@ static void xtest_pkcs11_test_1007(ADBG_Case_t *c)
 		ADBG_EXPECT_CK_OK(c, rv);
 		sessions[n] = CK_INVALID_HANDLE;
 	}
+
+	/* Closing session with out bound and invalid IDs (or negative ID) */
+	rv = C_CloseSession(session_saved);
+	ADBG_EXPECT_CK_RESULT(c, CKR_SESSION_HANDLE_INVALID, rv);
+	rv = C_CloseSession(CK_INVALID_HANDLE);
+	ADBG_EXPECT_CK_RESULT(c, CKR_SESSION_HANDLE_INVALID, rv);
+	rv = C_CloseSession(~0);
+	ADBG_EXPECT_CK_RESULT(c, CKR_SESSION_HANDLE_INVALID, rv);
 
 	/* Open and close another session */
 	rv = open_cipher_session(c, slot, &sessions[0],


### PR DESCRIPTION
Close opened session after secure service memory is exhausted before testing closure on invalid session. This change attempts to fix a non systematic issue found as described in [1].

A test case is slightly changed: where a likely invalid session ID (valid ID + 1024) was tried to be closed, this change now tries to close a session that has been already closed.

Link: https://github.com/OP-TEE/optee_os/issues/6952 [1]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
