### PR TITLE
gp: change from xalan to xsltproc

### DIFF
--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -74,8 +74,8 @@ if (WITH_GP_TESTS)
 	macro(__GEN_GP_FILE outfile xmldir name basedir)
 		add_custom_command(
 			OUTPUT	${outfile}
-			COMMAND	xalan -in ${basedir}/${name}.xml
-				      -xsl gp/${name}.xsl -out ${outfile}
+			COMMAND	xsltproc -o ${outfile} gp/${name}.xsl
+							${basedir}/${name}.xml
 			DEPENDS ${basedir}/${name}.xml gp/${name}.xsl
 		)
 	endmacro(__GEN_GP_FILE)


### PR DESCRIPTION
We have been using an outdated version of xalan, which is what is installed using apt in Ubuntu. If you run Fedora, you will receive the latest version. The executable name has changed from "xalan" to "Xalan" and the supported command line arguments are also different. Therefore supporting different versions of xalan across distros can be challenging.

One alternative is xsltproc. It looks like it works on both Ubuntu and Fedora, so let's swap out xalan for xsltproc.


Tested-by: Joakim Bech <joakim.bech@linaro.org> (Fedora 41)
Tested-by: Joakim Bech <joakim.bech@linaro.org> (Ubuntu 22.04)

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
