### PR TITLE
xtest: pkcs11_1021: skip CKM_RSA_PKCS test is not supported

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -6758,6 +6758,10 @@ static int test_rsa_pkcs_operations(ADBG_Case_t *c,
 	signature_len = sizeof(signature);
 
 	rv = C_SignInit(session, &sign_mechanism, private_key);
+	if (rv == CKR_MECHANISM_INVALID) {
+		Do_ADBG_Log("CKM_RSA_PKCS is not supported (CFG_CRYPTO_RSASSA_NA1 maybe disabled), skip test");
+		goto non_prehashed_rsa_tests;
+	}
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;
 
@@ -6776,6 +6780,8 @@ static int test_rsa_pkcs_operations(ADBG_Case_t *c,
 		      signature_len);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;
+
+non_prehashed_rsa_tests:
 
 	for (i = 0; i < ARRAY_SIZE(rsa_pkcs_sign_tests); i++) {
 		/*


### PR DESCRIPTION
Skip CKM_RSA_PKCS test in pkcs11_1021 is the mechanism is not supported. This is likely to append when OP-TEE core is built with CFG_CRYPTO_RSASSA_NA1 disabled as when built with MbedTLS as core crypto library.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
