### PR TITLE
xtest: asymm signature with a too small buffer (regression 4006/4016 + pkcs11 1025)

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -6431,7 +6431,7 @@ static void xtest_tee_test_4016_ed25519(ADBG_Case_t *c)
 	size_t num_key_attrs = 0;
 	TEE_Attribute attrs[2] = { };
 	size_t num_attrs = 0;
-	uint8_t out[64] = { };
+	uint8_t out[128] = { };
 	size_t out_size = sizeof(out);
 	size_t n = 0;
 	uint32_t ret_orig = 0;
@@ -6496,6 +6496,23 @@ static void xtest_tee_test_4016_ed25519(ADBG_Case_t *c)
 						 &session, op, key_handle)))
 				goto out;
 
+			out_size = 0;
+			if (!ADBG_EXPECT_TEEC_RESULT(c, TEEC_ERROR_SHORT_BUFFER,
+					ta_crypt_cmd_asymmetric_sign(c,
+						&session, op,
+						attrs, num_attrs, tv->ptx,
+						tv->ptx_len, out, &out_size)))
+				goto out;
+
+			out_size = 63;
+			if (!ADBG_EXPECT_TEEC_RESULT(c, TEEC_ERROR_SHORT_BUFFER,
+					ta_crypt_cmd_asymmetric_sign(c,
+						&session, op,
+						attrs, num_attrs, tv->ptx,
+						tv->ptx_len, out, &out_size)))
+				goto out;
+
+			out_size = sizeof(out);
 			if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 					ta_crypt_cmd_asymmetric_sign(c,
 						&session, op,

--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -4601,6 +4601,21 @@ static void xtest_tee_test_4006(ADBG_Case_t *c)
 
 			priv_key_handle = TEE_HANDLE_NULL;
 
+			out_size = 0;
+			if (!ADBG_EXPECT_TEEC_RESULT(c, TEEC_ERROR_SHORT_BUFFER,
+				ta_crypt_cmd_asymmetric_sign(c, &session, op,
+					algo_params, num_algo_params, ptx_hash,
+					ptx_hash_size, out, &out_size)))
+				goto out;
+
+			out_size = 1;
+			if (!ADBG_EXPECT_TEEC_RESULT(c, TEEC_ERROR_SHORT_BUFFER,
+				ta_crypt_cmd_asymmetric_sign(c, &session, op,
+					algo_params, num_algo_params, ptx_hash,
+					ptx_hash_size, out, &out_size)))
+				goto out;
+
+			out_size = sizeof(out);
 			if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 				ta_crypt_cmd_asymmetric_sign(c, &session, op,
 					algo_params, num_algo_params, ptx_hash,


### PR DESCRIPTION
Following the issue reported and fixed by https://github.com/OP-TEE/optee_os/pull/7162, I add some tests to request asymmetric signature providing a too small signature output buffer.
Tested with both CFG_CRYPTOLIB_NAME={tomcrypt|mbedtls}`.

Changes in **regression_4006** covers the RSA/ECC cases, already handled in OP-TEE even before tag 4.4.0.
Changes in **regresison_4016** and **pkcs11_1025** covers the ED25519 cases and require https://github.com/OP-TEE/optee_os/pull/7162 (recently merged) to succeed.