### PR TITLE
ci: update container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   QEMUv8_check:
     name: make check (QEMUv8)
     runs-on: ubuntu-latest
-    container: jforissier/optee_os_ci:qemuv8_check2
+    container: jforissier/optee_os_ci:qemu_check
     steps:
       - name: Remove /__t/*
         run: rm -rf /__t/*
@@ -29,7 +29,7 @@ jobs:
           WD=$(pwd)
           cd ..
           TOP=$(pwd)/optee_repo_qemu_v8
-          /root/get_optee_qemuv8.sh ${TOP}
+          /root/get_optee.sh qemu_v8 ${TOP}
           mv ${TOP}/optee_test ${TOP}/optee_test_old
           ln -s ${WD} ${TOP}/optee_test
           cd ${TOP}/build


### PR DESCRIPTION
Update the CI container to jforissier/optee_os_ci:qemu_check [1] which is the latest one, usable for both 32-bit and 64-bit ARM, and which is used by the optee_os CI [2]. This one should be able to build QEMU 9.2.0 without any issue contrary to the current one which causes:

 *** Ouch! ***

 found no usable tomli, please install it

Link: https://github.com/jforissier/docker_optee_os_ci/tree/qemu_check [1]
Link: https://github.com/OP-TEE/optee_os/blob/4.4.0/.github/workflows/ci.yml#L319 [2]

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
