### PR TITLE
xtest: remove CFG_SECSTOR_TA_MGMT_PTA dependency

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -53,6 +53,7 @@ srcs +=	adbg/src/adbg_case.c \
 	regression_8000.c \
 	regression_8100.c \
 	hash_perf.c \
+	install_ta.c \
 	stats.c \
 	symm_cipher_perf.c \
 	xtest_helpers.c \
@@ -62,10 +63,6 @@ srcs +=	adbg/src/adbg_case.c \
 
 ifeq ($(CFG_SECURE_PARTITION)-$(CFG_SPMC_TESTS),y-y)
 srcs += ffa_spmc_1000.c
-endif
-
-ifeq ($(CFG_SECSTOR_TA_MGMT_PTA),y)
-srcs += install_ta.c
 endif
 
 ifeq ($(CFG_SECURE_DATA_PATH),y)

--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -57,6 +57,7 @@ set (SRC
 	regression_8000.c
 	regression_8100.c
 	hash_perf.c
+	install_ta.c
 	stats.c
 	symm_cipher_perf.c
 	xtest_helpers.c
@@ -99,10 +100,6 @@ if (CFG_GP_SOCKETS)
 		sock_server.c
 		rand_stream.c
 	)
-endif()
-
-if (CFG_SECSTOR_TA_MGMT_PTA)
-	list (APPEND SRC install_ta.c)
 endif()
 
 if (CFG_SECURE_DATA_PATH)

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -72,6 +72,7 @@ srcs +=	adbg/src/adbg_case.c \
 	regression_8000.c \
 	regression_8100.c \
 	hash_perf.c \
+	install_ta.c \
 	stats.c \
 	symm_cipher_perf.c \
 	xtest_helpers.c \
@@ -81,10 +82,6 @@ srcs +=	adbg/src/adbg_case.c \
 
 ifeq ($(CFG_SECURE_PARTITION)-$(CFG_SPMC_TESTS),y-y)
 srcs += ffa_spmc_1000.c
-endif
-
-ifeq ($(CFG_SECSTOR_TA_MGMT_PTA),y)
-srcs += install_ta.c
 endif
 
 ifeq ($(CFG_SECURE_DATA_PATH),y)

--- a/host/xtest/install_ta.c
+++ b/host/xtest/install_ta.c
@@ -126,6 +126,8 @@ int install_ta_runner_cmd_parser(int argc, char *argv[])
 
 	res = TEEC_OpenSession(&ctx, &sess, &uuid, TEEC_LOGIN_PUBLIC, NULL,
 			       NULL, &err_origin);
+	if (res == TEEC_ERROR_ITEM_NOT_FOUND && err_origin == TEEC_ORIGIN_TEE)
+		errx(1, "TA install is not supported by OP-TEE");
 	if (res)
 		errx(1, "TEEC_OpenSession: res %#" PRIx32 " err_orig %#" PRIx32,
 			res, err_origin);

--- a/host/xtest/xtest_main.c
+++ b/host/xtest/xtest_main.c
@@ -104,10 +104,8 @@ void usage(char *program)
 	printf("\t--hash-perf [opts] Hash performance testing tool (-h for usage)\n");
 	printf("\t--aes-perf [opts]  AES performance testing tool (-h for usage)\n");
 	printf("\t--asym-perf [opts]  Asym performance testing tool (-h for usage)\n");
-#ifdef CFG_SECSTOR_TA_MGMT_PTA
 	printf("\t--install-ta [directory or list of TAs]\n");
 	printf("\t                   Install TAs\n");
-#endif
 #ifdef CFG_SECURE_DATA_PATH
 	printf("\t--sdp-basic [opts] Basic Secure Data Path test setup ('-h' for usage)\n");
 #endif
@@ -172,10 +170,8 @@ int main(int argc, char *argv[])
 		return aes_perf_runner_cmd_parser(argc-1, &argv[1]);
 	else if (argc > 1 && !strcmp(argv[1], "--asym-perf"))
 		return asym_perf_runner_cmd_parser(argc-1, &argv[1]);
-#ifdef CFG_SECSTOR_TA_MGMT_PTA
 	else if (argc > 1 && !strcmp(argv[1], "--install-ta"))
 		return install_ta_runner_cmd_parser(argc - 1, argv + 1);
-#endif
 #ifdef CFG_SECURE_DATA_PATH
 	else if (argc > 1 && !strcmp(argv[1], "--sdp-basic"))
 		return sdp_basic_runner_cmd_parser(argc-1, &argv[1]);


### PR DESCRIPTION
Makes xtest tool more flexible regarding OP-TEE configuration of `CFG_SECSTOR_TA_MGMT_PTA`.

Embed TA install interface in xtest even if devkit configuration says the secure storage TA management PTA service is not available. If the service is not found (secstor TA management PTA) print an explicit error message instead.

This change does not change xtest regression suite behavior and will still fails if one uses `--install-ta` option when the effective embedded TEE does not provide this service. This change adds an explicit error message when so.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
