### PR TITLE
ta: os_test: fix TA time wrap test

### DIFF
--- a/ta/os_test/os_test.c
+++ b/ta/os_test/os_test.c
@@ -600,7 +600,7 @@ static TEE_Result test_time(void)
 	 * TEE_GetTAPersistentTime() should be much less than 1 second, in fact
 	 * it's not even a millisecond.
 	 */
-	if (t.seconds > 1 || t.millis >= 1000) {
+	if (t.seconds > 60 || t.millis >= 1000) {
 		EMSG("Unexpected stored TA time %"PRIu32".%03"PRIu32, t.seconds,
 		     t.millis);
 		return TEE_ERROR_BAD_STATE;
@@ -623,7 +623,7 @@ static TEE_Result test_time(void)
 	}
 	MSG("TA time %"PRIu32".%03"PRIu32, t.seconds, t.millis);
 
-	if (t.seconds > 1) {
+	if (t.seconds > 60) {
 		EMSG("Unexpected wrapped time %"PRIu32".%03"PRIu32, t.seconds,
 		     t.millis);
 		return TEE_ERROR_BAD_STATE;


### PR DESCRIPTION
In the test for wrapped TA time in test_time() we check that the time has wrapped and that not too much time has passed. The limit for this is currently 2 seconds of which 1 second is passed in TEE_Wait(). This is currently not enough time with the recent introduction of fTPM being probed in parallel with the test. So in order to avoid occasional false negatives increase the limit to 60 seconds.

Fixes: a2c1ce3a8c31 ("ta: os_test: fix TA time wrap test")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
