### PR TITLE
regression_1041: increase ftpm timeout to 20 seconds

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -3372,6 +3372,7 @@ static void xtest_tee_test_1041(ADBG_Case_t *c)
 	uint32_t ret_orig = 0;
 	struct stat sb = { };
 	bool found = false;
+	int max_wait = 20;
 	int i = 0;
 
 	res = xtest_teec_open_session(&sess, &(const TEEC_UUID)TA_FTPM_UUID,
@@ -3388,11 +3389,12 @@ static void xtest_tee_test_1041(ADBG_Case_t *c)
 	 * (5 seconds) otherwise the test may fail if run immediately after
 	 * boot.
 	 */
-	for (i = 0; i < 5; i++) {
+	for (i = 0; i < max_wait; i++) {
 		if (stat(fname, &sb) == 0) {
 			found = true;
 			break;
 		}
+		Do_ADBG_Log("Waiting for TPM device %d / %d", i, max_wait);
 		sleep(1);
 	}
 	if (!ADBG_EXPECT_TRUE(c, found)) {


### PR DESCRIPTION
The timeout for /dev/tpm0 to appear was previously 5 seconds, but that's not always enough so increase it to 20 seconds to have a larger margin.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
