### PR TITLE
xtest: stats: report heap fragmentation metric

### DIFF
--- a/host/xtest/stats.c
+++ b/host/xtest/stats.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <fnmatch.h>
 #include <inttypes.h>
+#include <math.h>
 #include <pta_stats.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -154,6 +155,15 @@ static int stat_alloc(int argc, char *argv[])
 		       stats[n].desc);
 		printf("Bytes allocated:                       %"PRId32"\n",
 		       stats[n].allocated);
+		if (stats[n].free2_sum && stats[n].size != stats[n].allocated) {
+			double free2_sum = stats[n].free2_sum;
+			double free_sum = stats[n].size - stats[n].allocated;
+			double free_quote = sqrt(free2_sum) / free_sum;
+			double fragmentation = 1.0 - free_quote * free_quote;
+
+			printf("Fragmentation:			       %u %%\n",
+				(unsigned int)(fragmentation * 100.0));
+		}
 		printf("Max bytes allocated:                   %"PRId32"\n",
 		       stats[n].max_allocated);
 		printf("Size of pool:                          %"PRId32"\n",


### PR DESCRIPTION
A new field is added to struct pta_stats_alloc, free2_sum, the sum of size^2 of each free chunk. This can be used to calculate a fragmentation metric for the heap [1]. Some examples with xtest --stats --alloc:

When booted:
Pool:                Heap
Bytes allocated:                       21376
Fragmentation:			       3 %
Max bytes allocated:                   21488
Size of pool:                          202608

At some point during xtest:
Pool:                Heap
Bytes allocated:                       31616
Fragmentation:			       54 %
Max bytes allocated:                   101312
Size of pool:                          202608

When xtest has completed:
Pool:                Heap
Bytes allocated:                       25824
Fragmentation:			       33 %
Max bytes allocated:                   101312
Size of pool:                          202608

Link: [1] https://asawicki.info/news_1757_a_metric_for_memory_fragmentation

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
