### PR TITLE
xtest: Fix typo from 'Concurent' to 'Concurrent'

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -3348,7 +3348,7 @@ static void xtest_tee_test_1040(ADBG_Case_t *c)
 	size_t nt = NUM_THREADS;
 	size_t n = 0;
 
-	Do_ADBG_BeginSubCase(c, "Concurent invoke with panic in TA");
+	Do_ADBG_BeginSubCase(c, "Concurrent invoke with panic in TA");
 	for (n = 0; n < nt; n++) {
 		if (!ADBG_EXPECT(c, 0, pthread_create(&arg[n].thr, NULL,
 						      test_1040_thread,
@@ -3359,7 +3359,7 @@ static void xtest_tee_test_1040(ADBG_Case_t *c)
 		ADBG_EXPECT(c, 0, pthread_join(arg[n].thr, NULL));
 		ADBG_EXPECT_TEEC_SUCCESS(c, arg[n].res);
 	}
-	Do_ADBG_EndSubCase(c, "Concurent invoke with panic in TA");
+	Do_ADBG_EndSubCase(c, "Concurrent invoke with panic in TA");
 }
 ADBG_CASE_DEFINE(regression, 1040, xtest_tee_test_1040,
 		 "Test panic in concurrent open/invoke/close session");

--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -1805,7 +1805,7 @@ out:
 		TEEC_CloseSession(&arg[i].session);
 }
 
-/* concurency */
+/* concurrency */
 static void xtest_tee_test_6016_single(ADBG_Case_t *c, uint32_t storage_id)
 {
 	int i = 0;
@@ -1816,7 +1816,7 @@ static void xtest_tee_test_6016_single(ADBG_Case_t *c, uint32_t storage_id)
 		xtest_tee_test_6016_loop(c, storage_id);
 }
 DEFINE_TEST_MULTIPLE_STORAGE_IDS(xtest_tee_test_6016)
-ADBG_CASE_DEFINE(regression, 6016, xtest_tee_test_6016, "Storage concurency");
+ADBG_CASE_DEFINE(regression, 6016, xtest_tee_test_6016, "Storage concurrency");
 
 static void xtest_tee_test_6017_single(ADBG_Case_t *c, uint32_t storage_id)
 {

--- a/ta/concurrent/include/ta_concurrent.h
+++ b/ta/concurrent/include/ta_concurrent.h
@@ -18,12 +18,12 @@ struct ta_concurrent_shm {
 
 /*
  * Busy loops and updates max concurrency.  params[0].memref should contain
- * a struct ta_concurent_shm which can be used to tell how many instances
+ * a struct ta_concurrent_shm which can be used to tell how many instances
  * of this function is running in parallel.
  *
  * in/out	params[0].memref
  * in/out	params[1].value.a	(input) number times to calcule the hash
- * in/out	params[1].value.b	(output) max concurency
+ * in/out	params[1].value.b	(output) max concurrency
  */
 
 #define TA_CONCURRENT_CMD_BUSY_LOOP	0
@@ -31,12 +31,12 @@ struct ta_concurrent_shm {
 /*
  * Calculates a sha-256 hash over param[2].memref and stores the result in
  * params[3].memref. params[0].memref should contain a struct
- * ta_concurent_shm which can be used to tell how many instances of this
+ * ta_concurrent_shm which can be used to tell how many instances of this
  * function is running in parallel.
  *
  * in/out	params[0].memref
  * in/out	params[1].value.a	(input) number times to calcule the hash
- * in/out	params[1].value.b	(output) max concurency
+ * in/out	params[1].value.b	(output) max concurrency
  * in		params[2].memref
  * out		params[3].memref
  */


### PR DESCRIPTION
'Concurent' and 'concurency' are typo. They should be 'Concurrent' and 'concurrency' instead.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
