### PR TITLE
ta: crypto_perf: clear crypto_op after free

### DIFF
--- a/ta/crypto_perf/ta_crypto_perf.c
+++ b/ta/crypto_perf/ta_crypto_perf.c
@@ -1001,10 +1001,12 @@ void cmd_clean_obj(void)
 
 void cmd_clean_res(void)
 {
-	if (crypto_op)
+	if (crypto_op) {
 		TEE_FreeOperation(crypto_op);
+		crypto_op = TEE_HANDLE_NULL;
+	}
 	if (crypto_op_enc_sign) {
 		TEE_FreeOperation(crypto_op_enc_sign);
-		crypto_op_enc_sign = NULL;
+		crypto_op_enc_sign = TEE_HANDLE_NULL;
 	}
 }


### PR DESCRIPTION
Fix: #785

Clearing crypto_op after freeing it,
allowing the TA to be called again without crashing.

Signed-off-by: Wenxing Hou <houwenxing@xiaomi.com>
Reviewed-by: Jens Wiklander <jens.wiklander@linaro.org>
