### PR TITLE
xtest: add test entry for transfer list

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -303,18 +303,31 @@ static void xtest_tee_test_1001(ADBG_Case_t *c)
 
 	Do_ADBG_BeginSubCase(c, "Core self tests");
 
-	(void)ADBG_EXPECT_TEEC_SUCCESS(c, TEEC_InvokeCommand(
-		&session, PTA_INVOKE_TESTS_CMD_SELF_TESTS, NULL, &ret_orig));
+	res = TEEC_InvokeCommand(&session, PTA_INVOKE_TESTS_CMD_SELF_TESTS,
+				 NULL, &ret_orig);
+	ADBG_EXPECT_TEEC_SUCCESS(c, res);
 
 	Do_ADBG_EndSubCase(c, "Core self tests");
 
 	Do_ADBG_BeginSubCase(c, "Core dt_driver self tests");
 
-	(void)ADBG_EXPECT_TEEC_SUCCESS(c, TEEC_InvokeCommand(
-		&session, PTA_INVOKE_TESTS_CMD_DT_DRIVER_TESTS, NULL,
-		&ret_orig));
+	res = TEEC_InvokeCommand(&session, PTA_INVOKE_TESTS_CMD_DT_DRIVER_TESTS,
+				 NULL, &ret_orig);
+	ADBG_EXPECT_TEEC_SUCCESS(c, res);
 
 	Do_ADBG_EndSubCase(c, "Core dt_driver self tests");
+
+	Do_ADBG_BeginSubCase(c, "Core transfer list self tests");
+
+	res = TEEC_InvokeCommand(&session,
+				 PTA_INVOKE_TESTS_CMD_TRANSFER_LIST_TESTS, NULL,
+				 &ret_orig);
+	if (res == TEE_ERROR_NOT_SUPPORTED)
+		Do_ADBG_Log("Transfer List tests not supported, skipping");
+	else
+		ADBG_EXPECT_TEEC_SUCCESS(c, res);
+
+	Do_ADBG_EndSubCase(c, "Core transfer list self tests");
 
 	TEEC_CloseSession(&session);
 }


### PR DESCRIPTION
Add test entry for transfer list in xtest 1001.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
