### PR TITLE
xtest: pkcs11: Update test_digest for test 1019 to use SHA-512

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -5767,8 +5767,8 @@ static int test_ec_operations(ADBG_Case_t *c, CK_SESSION_HANDLE session,
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;
 
-	rv = C_Sign(session, (void *)digest_test_pattern_sha256,
-		    sizeof(digest_test_pattern_sha256), (void *)signature,
+	rv = C_Sign(session, (void *)digest_test_pattern_sha512,
+		    sizeof(digest_test_pattern_sha512), (void *)signature,
 		    &signature_len);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;
@@ -5777,8 +5777,8 @@ static int test_ec_operations(ADBG_Case_t *c, CK_SESSION_HANDLE session,
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;
 
-	rv = C_Verify(session, (void *)digest_test_pattern_sha256,
-		    sizeof(digest_test_pattern_sha256), (void *)signature,
+	rv = C_Verify(session, (void *)digest_test_pattern_sha512,
+		    sizeof(digest_test_pattern_sha512), (void *)signature,
 		    signature_len);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;


### PR DESCRIPTION
Modified test 1019 to use digest_test_pattern_sha512 instead of digest_test_pattern_sha256.

Addressed [comment](https://github.com/OP-TEE/optee_test/issues/721#issuecomment-1952822410) in the issue#721.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
