### PR TITLE
 xtest: pkcs11: Add all attributes for RSA AES Key Wrap/Unwrap

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -8302,6 +8302,12 @@ ADBG_CASE_DEFINE(pkcs11, 1025, xtest_pkcs11_test_1025,
 		.prime1_len	= ARRAY_SIZE(vect ## _prime1), \
 		.prime2		= vect ## _prime2, \
 		.prime2_len	= ARRAY_SIZE(vect ## _prime2), \
+		.exp1		= vect ## _exp1, \
+		.exp1_len	= ARRAY_SIZE(vect ## _exp1), \
+		.exp2		= vect ## _exp2, \
+		.exp2_len	= ARRAY_SIZE(vect ## _exp2), \
+		.coeff		= vect ## _coeff, \
+		.coeff_len	= ARRAY_SIZE(vect ## _coeff), \
 	}
 
 #define RSA_AES_WRAP_RSA(vect) \
@@ -8326,6 +8332,14 @@ static struct rsa_aes_wrap_test {
 			size_t prime1_len;
 			const uint8_t *prime2;
 			size_t prime2_len;
+
+			const uint8_t *exp1;
+			size_t exp1_len;
+			const uint8_t *exp2;
+			size_t exp2_len;
+
+			const uint8_t *coeff;
+			size_t coeff_len;
 		} rsa;
 		struct {
 			CK_ULONG size;
@@ -8346,6 +8360,14 @@ static struct rsa_aes_wrap_test {
 		size_t prime1_len;
 		const uint8_t *prime2;
 		size_t prime2_len;
+
+		const uint8_t *exp1;
+		size_t exp1_len;
+		const uint8_t *exp2;
+		size_t exp2_len;
+
+		const uint8_t *coeff;
+		size_t coeff_len;
 	} key;
 } rsa_aes_wrap_tests[] = {
 	{ CKK_AES, RSA_AES_WRAP_AES(128), RSA_AES_WRAP_KEY(ac_rsassa_vect2) },
@@ -8392,6 +8414,12 @@ static CK_RV test_rsa_aes_wrap(ADBG_Case_t *c, CK_SESSION_HANDLE session,
 		  t->key.modulus_len },
 		{ CKA_PUBLIC_EXPONENT, (CK_VOID_PTR)t->key.pub_exp,
 		  t->key.pub_exp_len },
+		{ CKA_EXPONENT_1, (CK_VOID_PTR)t->key.exp1,
+		  t->key.prime2_len },
+		{ CKA_EXPONENT_2, (CK_VOID_PTR)t->key.exp2,
+		  t->key.prime2_len },
+		{ CKA_COEFFICIENT, (CK_VOID_PTR)t->key.coeff,
+		  t->key.coeff_len },
 	};
 
 	CK_ATTRIBUTE unwrapping_key_template[] = {
@@ -8415,6 +8443,12 @@ static CK_RV test_rsa_aes_wrap(ADBG_Case_t *c, CK_SESSION_HANDLE session,
 		  t->key.prime1_len },
 		{ CKA_PRIME_2, (CK_VOID_PTR)t->key.prime2,
 		  t->key.prime2_len },
+		{ CKA_EXPONENT_1, (CK_VOID_PTR)t->key.exp1,
+		  t->key.prime2_len },
+		{ CKA_EXPONENT_2, (CK_VOID_PTR)t->key.exp2,
+		  t->key.prime2_len },
+		{ CKA_COEFFICIENT, (CK_VOID_PTR)t->key.coeff,
+		  t->key.coeff_len },
 	};
 
 	CK_ATTRIBUTE aes_key_template[] = {
@@ -8444,6 +8478,12 @@ static CK_RV test_rsa_aes_wrap(ADBG_Case_t *c, CK_SESSION_HANDLE session,
 		  t->target.rsa.prime1_len },
 		{ CKA_PRIME_2, (CK_VOID_PTR)t->target.rsa.prime2,
 		  t->target.rsa.prime2_len },
+		{ CKA_EXPONENT_1, (CK_VOID_PTR)t->key.exp1,
+		  t->key.prime2_len },
+		{ CKA_EXPONENT_2, (CK_VOID_PTR)t->key.exp2,
+		  t->key.prime2_len },
+		{ CKA_COEFFICIENT, (CK_VOID_PTR)t->key.coeff,
+		  t->key.coeff_len },
 	};
 
 	CK_ATTRIBUTE unwrapped_aes_key_template[] = {

--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -5767,8 +5767,8 @@ static int test_ec_operations(ADBG_Case_t *c, CK_SESSION_HANDLE session,
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;
 
-	rv = C_Sign(session, (void *)digest_test_pattern_sha256,
-		    sizeof(digest_test_pattern_sha256), (void *)signature,
+	rv = C_Sign(session, (void *)digest_test_pattern_sha512,
+		    sizeof(digest_test_pattern_sha512), (void *)signature,
 		    &signature_len);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;
@@ -5777,8 +5777,8 @@ static int test_ec_operations(ADBG_Case_t *c, CK_SESSION_HANDLE session,
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;
 
-	rv = C_Verify(session, (void *)digest_test_pattern_sha256,
-		    sizeof(digest_test_pattern_sha256), (void *)signature,
+	rv = C_Verify(session, (void *)digest_test_pattern_sha512,
+		    sizeof(digest_test_pattern_sha512), (void *)signature,
 		    signature_len);
 	if (!ADBG_EXPECT_CK_OK(c, rv))
 		goto err_destr_obj;


### PR DESCRIPTION
This change adds all the attributes for RSA AES Keypair Generation.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
