### PR TITLE
xtest: fix build with GP_PACKAGE and GCC 14

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -122,7 +122,7 @@ LOCAL_CFLAGS += -I $(TA_DEV_KIT_DIR)/host_include -include conf.h
 LOCAL_CFLAGS += -pthread
 LOCAL_CFLAGS += -g3
 LOCAL_CFLAGS += -Wno-missing-field-initializers -Wno-format-zero-length
-LOCAL_CFLAGS += -Wno-unused-parameter
+LOCAL_CFLAGS += -Wno-unused-parameter -Wno-alloc-size
 
 ifneq ($(TA_DIR),)
 LOCAL_CFLAGS += -DTA_DIR=\"$(TA_DIR)\"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ add_compile_options (
 	-Wswitch-default -Wunsafe-loop-optimizations
 	-Wwrite-strings -Werror -fPIC
  	-Wno-missing-field-initializers
-	-Wno-unused-parameter
+	-Wno-unused-parameter -Wno-alloc-size
 )
 
 find_program(CCACHE_FOUND ccache)

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -148,7 +148,8 @@ CFLAGS += -Wall -Wcast-align -Werror \
 	  -Wshadow -Wstrict-prototypes -Wswitch-default \
 	  -Wwrite-strings -Wno-unused-parameter \
 	  -Wno-declaration-after-statement \
-	  -Wno-missing-field-initializers -Wno-format-zero-length
+	  -Wno-missing-field-initializers -Wno-format-zero-length \
+	  -Wno-alloc-size
 
 CFLAGS += -g3
 


### PR DESCRIPTION
Fix the following build error (QEMU build in this instance):

$ export GP=TEE_Initial_Configuration-Test_Suite_v2_0_0_2-2017_06_09.7z $ make -j$(nproc) GDBSERVER=y \
    GP_PACKAGE=/home/builder/optee/$GP
[...]
/home/builder/optee/out-br/build/optee_test_ext-1.0/host/xtest/gp_10000.c: In function 'gp_test_teec_10086': /home/builder/optee/out-br/build/optee_test_ext-1.0/host/xtest/gp/include/xml_client_api.h:162:18: error: allocation of insufficient size '0' for type 'uint8_t' {aka 'unsigned char'} with size '1' [-Werror=alloc-size]
  162 |         temp_mem = malloc(size)
      |                  ^
/home/builder/optee/out-br/build/optee_test_ext-1.0/host/xtest/gp_10000.c:1757:5: note: in expansion of macro 'AllocateTempMemory'
 1757 |     AllocateTempMemory(TEMP_MEM01, ZERO);
      |     ^~~~~~~~~~~~~~~~~~

The root cause is, when GDBSERVER=y the cross compiler is built by Buildroot and is GCC 14, while the default one is GCC 11.3. GCC 14 reports the additional wrning/error which therefore needs to be disabled explicitly (we don't want to change the GP test).

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
