### PR TITLE
Suppress new gcc-15 -Wunterminated-string-initialization

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -1292,6 +1292,9 @@ static const uint8_t hash_data_shake256_out2[] = {
  * https://tools.ietf.org/html/draft-sca-cfrg-sm3-02
  * Appendix A.1
  */
+#if __has_attribute(nonstring)
+__attribute__((nonstring))
+#endif
 static const uint8_t hash_data_sm3_a1_in[3] = "abc";
 
 static const uint8_t hash_data_sm3_a1_out[] = {

--- a/host/xtest/regression_4000_data.h
+++ b/host/xtest/regression_4000_data.h
@@ -7914,6 +7914,9 @@ static struct derive_key_ecdh_t {
 };
 
 /* G/MT 0003 (SM2) Part 5 Annex C.2 - encryption/decryption */
+#if __has_attribute(nonstring)
+__attribute__((nonstring))
+#endif
 static const uint8_t gmt_0003_part5_c2_sm2_testvector_ptx[19] =
 /* M */
 	"encryption standard";
@@ -8383,6 +8386,9 @@ static const uint8_t mac_data_sha3_512_out1[] = {
  * GM/T 0042-2015
  * Section D.3 Test vector 1
  */
+#if __has_attribute(nonstring)
+__attribute__((nonstring))
+#endif
 static const uint8_t mac_data_sm3_d31_in[112] =
 	"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomn"
 	"opnopqabcdbcdecdefdefgefghfghighijhijkijkljklmklmn"


### PR DESCRIPTION
GCC 15 now warns when character arrays are being initialized by strings
and terminating NUL character doesn't fit. GCC 15.1 also allows marking
such arrays with nonstring attribute to suppress the warning. W/o such
attribute, the warning becomes error due to the global -Werror. Add the
attribute accordingly.
