### PR TITLE
regression_1000: Re-order the include of <sys/stat.h> header

### DIFF
--- a/host/xtest/regression_1000.c
+++ b/host/xtest/regression_1000.c
@@ -20,11 +20,11 @@
 #ifdef CFG_SECURE_DATA_PATH
 #include <sdp_basic.h>
 #endif
+#include <sys/stat.h>
 #include <signed_hdr.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <ta_arm_bti.h>
 #include <ta_concurrent.h>


### PR DESCRIPTION
With musl, the compilation of optee-test would fail:

|   GEN     optee-test/4.6.0/optee-test-4.6.0/xtest/regression_8100_ca_crt.h
| python3 ../../scripts/file_to_c.py --inf ../../cert/ca.crt --out optee-test/4.6.0/optee-test-4.6.0/xtest/regression_8100_ca_crt.h --name regression_8100_ca_crt
| In file included from optee-test/4.6.0/recipe-sysroot/usr/include/sys/stat.h:30,
|                  from optee-test/host/xtest/regression_1000.c:24:
| optee-test/4.6.0/recipe-sysroot/usr/include/bits/stat.h:17:26: error: expected identifier or '(' before '[' token
|    17 |         unsigned __unused[2];
|       |                          ^

The defintion of OP-TEE macro __unused conflicts with the musl implementation and its use of variables named __unused.

Re-ordering and including <sys/stat.h> before the macro gets defined is enough to work around the issue.

