### PR TITLE
regression_4018: remove unused IV variable

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -7098,7 +7098,6 @@ static void xtest_tee_test_4018(ADBG_Case_t *c)
 		.content.ref.buffer = key_data,
 		.content.ref.length = sizeof(key_data)
 	};
-	uint8_t iv[16] = { 0 };
 
 	if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 		xtest_teec_open_session(&s, &crypt_user_ta_uuid, NULL,


### PR DESCRIPTION
Remove unused IV local variable in xtest_tee_test_4018(). Prevents a build warning/error such as the one reported below:

.../out-br/build/optee_test_ext-1.0/host/xtest/regression_4000.c: In function ‘xtest_tee_test_4018’: .../out-br/build/optee_test_ext-1.0/host/xtest/regression_4000.c:7101:17: warning: unused variable ‘iv’ [-Wunused-variable]
 7101 |         uint8_t iv[16] = { 0 };
      |                 ^~

Fixes: 992cf5da9d55 ("Add regression_4018: TEE_SetOperationKey() panic")

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
