### PR TITLE
pkcs11: fix undefined behavior in attribute initialization (compound literals)

### DIFF
--- a/host/xtest/pkcs11_1000.c
+++ b/host/xtest/pkcs11_1000.c
@@ -1201,14 +1201,18 @@ static CK_ATTRIBUTE cktest_token_object[] = {
 	{ CKA_VALUE,	(void *)cktest_aes128_key, sizeof(cktest_aes128_key) },
 };
 
+static const CK_BBOOL ck_true = CK_TRUE;
+static const CK_BBOOL ck_false = CK_FALSE;
+static const CK_OBJECT_CLASS secret_key_class = CKO_SECRET_KEY;
+static const CK_KEY_TYPE aes_key_type = CKK_AES;
+
 static CK_ATTRIBUTE cktest_session_object[] = {
-	{ CKA_DECRYPT,	&(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
-	{ CKA_TOKEN,	&(CK_BBOOL){CK_FALSE}, sizeof(CK_BBOOL) },
-	{ CKA_MODIFIABLE, &(CK_BBOOL){CK_TRUE}, sizeof(CK_BBOOL) },
-	{ CKA_KEY_TYPE,	&(CK_KEY_TYPE){CKK_AES}, sizeof(CK_KEY_TYPE) },
-	{ CKA_CLASS,	&(CK_OBJECT_CLASS){CKO_SECRET_KEY},
-						sizeof(CK_OBJECT_CLASS) },
-	{ CKA_VALUE,	(void *)cktest_aes128_key, sizeof(cktest_aes128_key) },
+	{ CKA_DECRYPT,	  (void *)&ck_true,         sizeof(CK_BBOOL) },
+	{ CKA_TOKEN,	  (void *)&ck_false,        sizeof(CK_BBOOL) },
+	{ CKA_MODIFIABLE, (void *)&ck_true,         sizeof(CK_BBOOL) },
+	{ CKA_KEY_TYPE,	  (void *)&aes_key_type,    sizeof(CK_KEY_TYPE) },
+	{ CKA_CLASS,	  (void *)&secret_key_class, sizeof(CK_OBJECT_CLASS) },
+	{ CKA_VALUE,	  (void *)cktest_aes128_key, sizeof(cktest_aes128_key) },
 };
 
 /* Create session object and token object from a session */


### PR DESCRIPTION
**Problem:**
Incorrect attribute values are observed in test_create_destroy_session_objects,
CKA_TOKEN = 0xe0 (expected CK_FALSE / 0)
The issue appears with default toolchain optimizations, even though no explicit -O2 is set. It disappears when forcing -O0, indicating optimization-dependent undefined behavior.

**Root cause**
Attributes are initialized using compound literals, e.g.:
C&(CK_BBOOL){CK_FALSE}
These create temporary objects whose addresses are stored and reused.
Their lifetime and storage are not guaranteed, and under optimization the compiler may reuse or overlap them, leading to invalid values.

**Why not fix via -O0**
Disabling optimization is not a valid solution:

Hides undefined behavior instead of fixing it
Not portable across compilers/toolchains
Impacts performance in security-sensitive code

**Fix**
Replace compound literals with static variables having stable storage:
e.g. static const CK_BBOOL ck_false = CK_FALSE;

