### PR TITLE
xtest: regression_6010: test GetNext after failed start

### DIFF
--- a/host/xtest/regression_6000.c
+++ b/host/xtest/regression_6000.c
@@ -1522,6 +1522,8 @@ seek_write_read_out:
 		fs_next_enum(&sess, e, NULL, 0, out, sizeof(out)));
 	ADBG_EXPECT_TEEC_RESULT(c, TEE_ERROR_ITEM_NOT_FOUND,
 		fs_start_enum(&sess, e, storage_id));
+	ADBG_EXPECT_TEEC_RESULT(c, TEE_ERROR_ITEM_NOT_FOUND,
+		fs_next_enum(&sess, e, NULL, 0, out, sizeof(out)));
 	ADBG_EXPECT_TEEC_SUCCESS(c, fs_free_enum(&sess, e));
 	Do_ADBG_EndSubCase(c, "StartPersistentObjectEnumerator ItemNotFound");
 


### PR DESCRIPTION
Verify that GetNext returns ITEM_NOT_FOUND after Start fails because the storage directory does not exist.

Add coverage for calling `TEE_GetNextPersistentObject()` after
`TEE_StartPersistentObjectEnumerator()` returns `TEE_ERROR_ITEM_NOT_FOUND`.

The expected result is `TEE_ERROR_ITEM_NOT_FOUND`, without a Secure Core abort.

Depends on: [optee_os PR URL](https://github.com/OP-TEE/optee_os/pull/7975)

Tested with:

    make -j2 CHECK_TESTS=xtest XTEST_ARGS=6010 check