### PR TITLE
xtest: add digest final short-buffer regression test

### DIFF
--- a/host/xtest/regression_4000.c
+++ b/host/xtest/regression_4000.c
@@ -1502,6 +1502,15 @@ static void xtest_tee_test_4001(ADBG_Case_t *c)
 			ta_crypt_cmd_copy_operation(c, &session, op2, op1)))
 			goto out;
 
+		if (hash_cases[n].algo != TEE_ALG_SHAKE128 &&
+		    hash_cases[n].algo != TEE_ALG_SHAKE256) {
+			out_size = 1;
+			if (!ADBG_EXPECT_TEEC_RESULT(c, TEEC_ERROR_SHORT_BUFFER,
+				ta_crypt_cmd_digest_do_final(c, &session, op1,
+							     NULL, 0, out, &out_size)))
+				goto out;
+		}
+
 		out_size = hash_cases[n].out_len - hash_cases[n].in_incr;
 		if (!ADBG_EXPECT_TEEC_SUCCESS(c,
 			ta_crypt_cmd_digest_do_final(c, &session, op1,


### PR DESCRIPTION
Add coverage for TEE_DigestDoFinal() after TEE_DigestExtract() with an insufficient output buffer on non-XOF algorithms.

Verify that it returns TEE_ERROR_SHORT_BUFFER and leaves the operation usable for a subsequent finalization, as required by GP TEE Internal Core API v1.3.1 §6.3.2.
